### PR TITLE
Document OMEN 15-dc0xxx (84DB) fan boost via EC 0xEC

### DIFF
--- a/docs/LINUX_INSTALL_GUIDE.md
+++ b/docs/LINUX_INSTALL_GUIDE.md
@@ -642,6 +642,7 @@ OmenCore automatically selects the best fan control method available for your ha
    - Path: `/sys/kernel/debug/ec/ec0/io`
    - Direct reads/writes to EC registers
    - Based on [omen-fan](https://github.com/alou-S/omen-fan) register documentation
+   - **OMEN 15-dc0xxx (board 84DB):** fan boost at offset `0xEC` — write `1` for max, `0` for auto. Stock `hp-wmi` `pwm1_enable=0` fails with EINVAL; RPM readback via `fan1_input`/`fan2_input` works. See [hp-omen-fan-linux](https://github.com/murilopontes/hp-omen-fan-linux).
 
 ### Safety Protections
 
@@ -669,6 +670,7 @@ OmenCore automatically selects the best fan control method available for your ha
 
 | Model | Kernel | Method | Notes |
 |-------|--------|--------|-------|
+| OMEN 15 2018-19 (dc0xxx, 84DB) | 5.15+ | ec_sys + hp-wmi RPM | Fan max via EC `0xEC=1`; `pwm1_enable=0` returns EINVAL on stock kernel |
 | OMEN 15 2020 | 5.15+ | ec_sys | Full EC access |
 | OMEN 16 2022 | 5.19+ | ec_sys | Full EC access |
 | OMEN 16 2023 (wf0xxx) | 6.5+ | hp-wmi | Partial fan control |


### PR DESCRIPTION
## Summary

Community test results for **OMEN by HP Laptop 15-dc0xxx** (board `84DB`, BIOS F.19, kernel `7.0.0-27-generic`).

Adds to `LINUX_INSTALL_GUIDE.md`:
- Known working model row for OMEN 15 2018-19 (`84DB`)
- Note under ec_sys method: fan max at EC `0xEC=1`, stock `pwm1_enable=0` fails with EINVAL

## Measured RPM (84DB)

| Mode | fan1 | fan2 |
|------|------|------|
| Auto (hot idle) | ~3600 | ~3400 |
| EC boost (`0xEC=1`) | ~4600 | ~5300 |

## References

https://github.com/murilopontes/hp-omen-fan-linux