### PR TITLE
Add SmuProbe, a hardware verification harness for the AMD SMU path

### DIFF
--- a/tools/SmuProbe/Counterfactual.cs
+++ b/tools/SmuProbe/Counterfactual.cs
@@ -1,0 +1,69 @@
+using OmenCore.Hardware;
+
+namespace OmenCore.Tools.SmuProbe;
+
+/// <summary>
+/// Confirms a message-id diagnosis instead of assuming it: sends the same Curve Optimizer
+/// offset through the id OmenCore used before the transport fix (PSMU 0x5D) and through the one
+/// RyzenAdj specifies for Strix Point (MP1 0x4C), and prints both SMU status codes.
+///
+/// Result on board 8D87 / Ryzen AI 9 HX 375: BOTH return Ok. That falsified the theory that the
+/// message id was why Curve Optimizer did not work, and is why <see cref="Outcome"/> exists -
+/// a status code says nothing about effect.
+///
+/// Writes CO offsets, and resets to 0 before returning.
+/// </summary>
+internal static class Counterfactual
+{
+    internal static int Run()
+    {
+        Console.WriteLine("=== Curve Optimizer message-id counterfactual ===\n");
+
+        RyzenControl.Init();
+        using var smu = new RyzenSmu();
+        if (!smu.Initialize())
+        {
+            Console.WriteLine($"FAIL: {smu.UnavailableReason}");
+            return 1;
+        }
+
+        RyzenControl.ConfigureSmuAddresses(smu);
+        Console.WriteLine($"CPU family : {RyzenControl.Family}\n");
+
+        const int co = -10;
+        uint encoded = Encode(co);
+        Console.WriteLine($"All-Core CO {co} encodes to 0x{encoded:X}\n");
+
+        Console.WriteLine("Pre-fix path:");
+        Console.WriteLine($"  PSMU 0x5D -> {SendPsmu(smu, 0x5D, encoded)}");
+        Console.WriteLine($"  MP1  0x5D -> {SendMp1(smu, 0x5D, encoded)}   (the old fallback)");
+
+        Console.WriteLine("\nPost-fix path:");
+        Console.WriteLine($"  MP1  0x4C -> {SendMp1(smu, 0x4C, encoded)}");
+
+        Console.WriteLine("\nResetting All-Core CO to 0 ...");
+        Console.WriteLine($"  MP1  0x4C -> {SendMp1(smu, 0x4C, 0)}");
+
+        Console.WriteLine("\nIf more than one id returns Ok, the id is not discriminating -");
+        Console.WriteLine("measure the effect with --outcome before concluding anything.");
+        return 0;
+    }
+
+    /// <summary>Matches AmdUndervoltProvider's signed-offset encoding.</summary>
+    internal static uint Encode(int co) =>
+        co < 0 ? (uint)(0x100000 - (uint)(-co)) : (uint)co;
+
+    private static RyzenSmu.SmuStatus SendMp1(RyzenSmu smu, uint message, uint arg0)
+    {
+        uint[] args = new uint[6];
+        args[0] = arg0;
+        return smu.SendMp1(message, ref args);
+    }
+
+    private static RyzenSmu.SmuStatus SendPsmu(RyzenSmu smu, uint message, uint arg0)
+    {
+        uint[] args = new uint[6];
+        args[0] = arg0;
+        return smu.SendPsmu(message, ref args);
+    }
+}

--- a/tools/SmuProbe/Outcome.cs
+++ b/tools/SmuProbe/Outcome.cs
@@ -1,0 +1,247 @@
+// Verifies the Curve Optimizer by OUTCOME, not by SMU status code.
+//
+// The counterfactual showed the SMU answers Ok to several message ids, so "Ok" proves nothing
+// about whether voltage actually moved. A real All-Core CO undervolt reduces core voltage at a
+// given frequency; under an all-core power-limited load the boost algorithm spends the freed
+// power budget on clock. So the observable is: same load, same power limit, HIGHER effective
+// clock after the offset is applied.
+//
+// Guards against the two false-positive shapes this project has hit before:
+//   - the load must still be running in both phases (core power must not collapse)
+//   - both phases are measured after a settle delay, so STAPM decay is not read as an effect
+//
+// Writes CO offsets, and resets to 0 in a finally.
+
+using System.Diagnostics;
+using OmenCore.Hardware;
+
+namespace OmenCore.Tools.SmuProbe;
+
+internal static class Outcome
+{
+    /// <summary>Time under load before the first pair, so STAPM decay has already happened.</summary>
+    private const int WarmupMs = 45000;
+
+    /// <summary>Settle time after each CO write before sampling.</summary>
+    private const int SettleMs = 6000;
+
+    private const int SampleMs = 5000;
+
+    /// <summary>Number of alternating baseline/offset pairs.</summary>
+    private const int Cycles = 3;
+
+    /// <summary>
+    /// Noise floor. A sham control (CO 0 in both phases) from a warmed steady state reproduces
+    /// 0.0%, so anything at or above this with a consistent sign across every pair is an effect
+    /// rather than drift.
+    /// </summary>
+    private const double MinMeaningfulPct = 1.0;
+
+    internal static int Run(string[] args)
+    {
+        int offset = -25;
+        int idx = Array.IndexOf(args, "--offset");
+        if (idx >= 0 && idx + 1 < args.Length && int.TryParse(args[idx + 1], out int parsed))
+            offset = parsed;
+
+        // Which mailbox/message to test. Defaults to the post-fix MP1 0x4C; --psmu5d selects
+        // the pre-fix path so its *effect* can be compared, not just its status code.
+        bool usePreFixPath = args.Contains("--psmu5d");
+
+        Console.WriteLine("=== Curve Optimizer outcome verification ===");
+        Console.WriteLine($"Comparing All-Core CO 0 against CO {offset} under a sustained all-core load.\n");
+
+        RyzenControl.Init();
+        using var smu = new RyzenSmu();
+        if (!smu.Initialize())
+        {
+            Console.WriteLine($"FAIL: {smu.UnavailableReason}");
+            return 1;
+        }
+        RyzenControl.ConfigureSmuAddresses(smu);
+
+        uint message = usePreFixPath ? 0x5Du : 0x4Cu;
+        Console.WriteLine($"Path under test : {(usePreFixPath ? "PSMU" : "MP1")} 0x{message:X2}" +
+                          $"{(usePreFixPath ? "  (pre-fix)" : "  (post-fix)")}\n");
+
+        using var load = new CpuLoad();
+        try
+        {
+            Console.WriteLine($"Starting all-core load on {Environment.ProcessorCount} threads ...");
+            load.Start();
+
+            // A single A-then-B comparison is not sound here. A first attempt at this measured
+            // +4.8% on one run and -5.3% on another for the SAME offset, because the machine's
+            // thermal/boost state at the start of a run dominates the difference: a run started
+            // hot decays downward across both phases, a run started cool climbs. A sham control
+            // (CO 0 in both phases) from a cool start reproduces 0.0%, which shows the sampling
+            // itself is precise and the confound is purely the drift between phases.
+            //
+            // So alternate 0 / offset several times and pair each offset phase against the
+            // baseline phase immediately before it. Monotonic drift then affects both members of
+            // every pair almost equally and cancels in the mean, and the spread across pairs is
+            // an honest error bar instead of an assumption.
+            Console.WriteLine($"Warming up {WarmupMs / 1000}s to reach a steady thermal state ...");
+            SetCo(smu, 0, message, usePreFixPath);
+            Thread.Sleep(WarmupMs);
+
+            var deltas = new List<double>();
+            var baselines = new List<Reading>();
+            var offsets = new List<Reading>();
+
+            for (int cycle = 1; cycle <= Cycles; cycle++)
+            {
+                SetCo(smu, 0, message, usePreFixPath);
+                Thread.Sleep(SettleMs);
+                var a = Sample(SampleMs);
+
+                SetCo(smu, offset, message, usePreFixPath);
+                Thread.Sleep(SettleMs);
+                var b = Sample(SampleMs);
+
+                if (b.CoreWatts < a.CoreWatts * 0.5)
+                {
+                    Console.WriteLine("INVALID: core power collapsed - the load did not stay up.");
+                    return 1;
+                }
+
+                double pct = a.EffectiveMhz > 0
+                    ? (b.EffectiveMhz - a.EffectiveMhz) / a.EffectiveMhz * 100.0
+                    : 0;
+
+                baselines.Add(a);
+                offsets.Add(b);
+                deltas.Add(pct);
+
+                Console.WriteLine($"  cycle {cycle}: CO 0 {a}  ->  CO {offset} {b}   ({pct:+0.0;-0.0;0.0}%)");
+            }
+
+            double mean = deltas.Average();
+            double min = deltas.Min();
+            double max = deltas.Max();
+            bool consistentSign = deltas.All(d => d > 0) || deltas.All(d => d < 0);
+
+            Console.WriteLine();
+            Console.WriteLine($"Paired clock delta : mean {mean:+0.0;-0.0;0.0}%  (min {min:+0.0;-0.0;0.0}%, max {max:+0.0;-0.0;0.0}%, n={deltas.Count})");
+            Console.WriteLine($"Mean core power    : CO 0 {baselines.Average(r => r.CoreWatts):F2} W" +
+                              $"  ->  CO {offset} {offsets.Average(r => r.CoreWatts):F2} W");
+
+            // Require BOTH a mean above the noise floor the sham control established AND the
+            // same sign in every pair. One large pair cannot carry the result on its own.
+            if (!consistentSign)
+            {
+                Console.WriteLine("\nNOT CONFIRMED: the sign is not consistent across pairs, so this is drift, not an effect.");
+                return 2;
+            }
+
+            if (mean >= MinMeaningfulPct)
+            {
+                Console.WriteLine($"\nCONFIRMED: All-Core CO {offset} raised sustained clock in every pair.");
+                Console.WriteLine("           The offset is reaching the silicon.");
+                return 0;
+            }
+
+            if (mean <= -MinMeaningfulPct)
+            {
+                Console.WriteLine("\nUNEXPECTED: clock fell consistently. Something was written, but this is not");
+                Console.WriteLine("            a working undervolt. Do not ship on this evidence.");
+                return 1;
+            }
+
+            Console.WriteLine("\nNOT CONFIRMED: no effect above the noise floor.");
+            Console.WriteLine("  The SMU accepted the command but nothing measurable changed, so this does");
+            Console.WriteLine("  NOT establish that Curve Optimizer reaches the silicon on this part.");
+            return 2;
+        }
+        finally
+        {
+            Console.WriteLine("\nResetting All-Core CO to 0 ...");
+            SetCo(smu, 0, message, usePreFixPath);
+            load.Stop();
+        }
+    }
+
+    private static void SetCo(RyzenSmu smu, int co, uint message, bool usePsmu)
+    {
+        uint[] args = new uint[6];
+        args[0] = Counterfactual.Encode(co);
+        var status = usePsmu
+            ? smu.SendPsmu(message, ref args)
+            : smu.SendMp1(message, ref args);
+        Console.WriteLine($"  SetCo({co}) -> 0x{message:X2} = {status}");
+    }
+
+    private readonly record struct Reading(double EffectiveMhz, double CoreWatts)
+    {
+        public override string ToString() => $"{EffectiveMhz:F0} MHz, core {CoreWatts:F2} W";
+    }
+
+    private static Reading Sample(int durationMs)
+    {
+        // "% Processor Performance" is relative to nominal; scaled by the nominal clock it gives
+        // an effective-frequency estimate that tracks boost behaviour.
+        using var perf = new PerformanceCounter("Processor Information", "% Processor Performance", "_Total");
+        using var corePower = TryCounter("Energy Meter", "Power", "CPU Power");
+
+        perf.NextValue();
+        corePower?.NextValue();
+        Thread.Sleep(1000);
+
+        double nominalMhz = NominalMhz();
+        var perfSamples = new List<double>();
+        var powerSamples = new List<double>();
+        var sw = Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < durationMs)
+        {
+            perfSamples.Add(perf.NextValue() / 100.0 * nominalMhz);
+            if (corePower != null) powerSamples.Add(corePower.NextValue() / 1000.0);
+            Thread.Sleep(500);
+        }
+
+        return new Reading(
+            perfSamples.Count > 0 ? perfSamples.Average() : 0,
+            powerSamples.Count > 0 ? powerSamples.Average() : 0);
+    }
+
+    private static PerformanceCounter? TryCounter(string category, string counter, string instance)
+    {
+        try { return new PerformanceCounter(category, counter, instance); }
+        catch { return null; }
+    }
+
+    private static double NominalMhz()
+    {
+        try
+        {
+            using var searcher = new System.Management.ManagementObjectSearcher(
+                "select MaxClockSpeed from Win32_Processor");
+            foreach (System.Management.ManagementObject o in searcher.Get())
+                return Convert.ToDouble(o["MaxClockSpeed"]);
+        }
+        catch { }
+        return 2000;
+    }
+
+    private sealed class CpuLoad : IDisposable
+    {
+        private readonly CancellationTokenSource _cts = new();
+        private readonly List<Thread> _threads = new();
+
+        public void Start()
+        {
+            for (int i = 0; i < Environment.ProcessorCount; i++)
+            {
+                var t = new Thread(() =>
+                {
+                    double x = 1.0000001;
+                    while (!_cts.IsCancellationRequested) { x = x * x; if (x > 1e300) x = 1.0000001; }
+                }) { IsBackground = true, Priority = ThreadPriority.Normal };
+                t.Start();
+                _threads.Add(t);
+            }
+        }
+
+        public void Stop() => _cts.Cancel();
+        public void Dispose() { _cts.Cancel(); _cts.Dispose(); }
+    }
+}

--- a/tools/SmuProbe/Program.cs
+++ b/tools/SmuProbe/Program.cs
@@ -1,0 +1,26 @@
+// SmuProbe - hardware verification harness for OmenCore's AMD SMU path.
+//
+// Drives the shipping OmenCore.Hardware types directly, so what is verified is what ships.
+// Requires administrator rights and the PawnIO driver.
+//
+//   SmuProbe.exe                    transport only: driver, module, mailbox liveness  [read-only]
+//   SmuProbe.exe --co <offset>      apply an All-Core Curve Optimizer offset           [WRITES]
+//   SmuProbe.exe --counterfactual   compare SMU status across candidate message ids    [WRITES]
+//   SmuProbe.exe --outcome [opts]   measure whether an offset actually changes clock   [WRITES]
+//
+// Options for --outcome:
+//   --offset <n>   offset to test (default -25)
+//   --psmu5d       use the pre-fix PSMU 0x5D path instead of MP1 0x4C
+//
+// Why a measured mode exists at all: the SMU returns Ok for message ids that change nothing, so
+// a status code is not evidence of an effect. See docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md 5.2.1.
+
+using OmenCore.Tools.SmuProbe;
+
+if (args.Contains("--counterfactual"))
+    return Counterfactual.Run();
+
+if (args.Contains("--outcome"))
+    return Outcome.Run(args);
+
+return Transport.Run(args);

--- a/tools/SmuProbe/SmuProbe.csproj
+++ b/tools/SmuProbe/SmuProbe.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <RootNamespace>OmenCore.Tools.SmuProbe</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OmenCoreApp\OmenCoreApp.csproj" />
+  </ItemGroup>
+
+  <!--
+    PawnIOLib and the RyzenSMU module are declared as None items in OmenCoreApp.csproj, which
+    does not flow across a ProjectReference. Copy the two this probe needs so it can run from
+    its own output directory instead of the app's.
+  -->
+  <ItemGroup>
+    <None Include="..\..\src\OmenCoreApp\drivers\PawnIOLib.dll"
+          Condition="Exists('..\..\src\OmenCoreApp\drivers\PawnIOLib.dll')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>drivers\PawnIOLib.dll</Link>
+    </None>
+    <None Include="..\..\src\OmenCoreApp\drivers\RyzenSMU.bin"
+          Condition="Exists('..\..\src\OmenCoreApp\drivers\RyzenSMU.bin')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>drivers\RyzenSMU.bin</Link>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tools/SmuProbe/Transport.cs
+++ b/tools/SmuProbe/Transport.cs
@@ -1,0 +1,83 @@
+using System.Threading;
+using OmenCore.Hardware;
+
+namespace OmenCore.Tools.SmuProbe;
+
+/// <summary>
+/// Verifies the AMD SMU transport through OmenCore's own <see cref="RyzenSmu"/> and
+/// <see cref="RyzenControl"/>, and optionally applies a Curve Optimizer offset via
+/// <see cref="AmdUndervoltProvider"/>.
+///
+/// Read-only unless <c>--co</c> is passed.
+/// </summary>
+internal static class Transport
+{
+    internal static int Run(string[] args)
+    {
+        Console.WriteLine("=== OmenCore AMD SMU transport probe ===\n");
+
+        RyzenControl.Init();
+        Console.WriteLine($"CPU               : {RyzenControl.CpuName.Trim()}");
+        Console.WriteLine($"Caption           : {RyzenControl.CpuModel}");
+        Console.WriteLine($"Detected family   : {RyzenControl.Family}");
+        Console.WriteLine($"SupportsUndervolt : {RyzenControl.SupportsUndervolt()}");
+        Console.WriteLine($"AI 9 guard trips  : {RyzenControl.IsRyzenAi9CurveOptimizerUnsupported()}");
+
+        using var smu = new RyzenSmu();
+        Console.WriteLine();
+        Console.WriteLine($"Initialize()            : {smu.Initialize()}");
+        Console.WriteLine($"IsAvailable             : {smu.IsAvailable}");
+        Console.WriteLine($"Cross-process PCI lock  : {RyzenSmu.HasCrossProcessPciLock}");
+
+        if (!smu.IsAvailable)
+        {
+            Console.WriteLine($"UnavailableReason       : {smu.UnavailableReason}");
+            Console.WriteLine("\nFAIL: transport unavailable.");
+            return 1;
+        }
+
+        // A successful version read means the mailbox handshake completed end to end: the
+        // module drove the PCI-config register pair, the SMU answered, and the response
+        // register cleared. It is liveness evidence, not a capability claim.
+        Console.WriteLine(smu.TryGetSmuVersion(out uint version)
+            ? $"SMU version             : 0x{version:X8}"
+            : "SMU version             : not readable");
+
+        RyzenControl.ConfigureSmuAddresses(smu);
+        Console.WriteLine($"MP1  mailbox            : msg=0x{smu.Mp1AddrMsg:X} rsp=0x{smu.Mp1AddrRsp:X} arg=0x{smu.Mp1AddrArg:X}");
+        Console.WriteLine($"PSMU mailbox            : msg=0x{smu.PsmuAddrMsg:X} rsp=0x{smu.PsmuAddrRsp:X} arg=0x{smu.PsmuAddrArg:X}");
+
+        int coIndex = Array.IndexOf(args, "--co");
+        if (coIndex < 0 || coIndex + 1 >= args.Length)
+        {
+            Console.WriteLine("\nRead-only probe complete. Nothing was written.");
+            Console.WriteLine("Pass --co <offset> to apply an All-Core CO offset, or --outcome to measure one.");
+            return 0;
+        }
+
+        if (!int.TryParse(args[coIndex + 1], out int co))
+        {
+            Console.WriteLine("\nFAIL: --co requires an integer offset.");
+            return 1;
+        }
+
+        Console.WriteLine($"\n--- Applying All-Core Curve Optimizer offset {co} ---");
+        using var provider = new AmdUndervoltProvider();
+        Console.WriteLine($"ActiveBackend : {provider.ActiveBackend}");
+        Console.WriteLine($"IsSupported   : {provider.IsSupported}");
+
+        try
+        {
+            provider.ApplyRyzenOffsetAsync(co, 0, CancellationToken.None).GetAwaiter().GetResult();
+            Console.WriteLine($"\nRESULT: the SMU accepted All-Core CO = {co}.");
+            Console.WriteLine("        An accepted command is NOT proof of a voltage change - the SMU");
+            Console.WriteLine("        answers Ok to ids that do nothing. Use --outcome to measure it.");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"\nRESULT: rejected - {ex.Message}");
+            return 1;
+        }
+    }
+}


### PR DESCRIPTION
## Where this sits

Four PRs, split so each carries its own evidence. Only 1 → 2 is a stack.

| | PR | Branch | Base | Scope |
|---|---|---|---|---|
| **→ 1** | **Add SmuProbe (this PR)** | `tooling/smu-probe` | `main` | Verification harness. No shipping code touched. |
| 2 | Fix the AMD SMU transport (#161) | `fix/amd-smu-transport` | `main`, stacked on this | Makes a dead AMD backend live. Affects all AMD boards. |
| 3 | Capability profile and telemetry corrections (#162) | `8d87/profile-and-telemetry` | `main` | Independent of 1 and 2 — no file overlap. |
| 4 | Power-adapter performance control | `8d87/power-adapter-gate` | `main` | **Not yet opened** — gated, see below. |

**Why this one is first:** PRs 2 and 3 both make claims about hardware behaviour, and PR 2's central claim ("Curve Optimizer now reaches the silicon") is not checkable from a return code. This is the instrument that produced that evidence, so it is reviewable on its own before anything depends on it.

It also earns its place by having caught a false positive I had already written down — see the `--outcome` section below.

**PR 4 is listed so the series reads as a whole, not because it is ready.** On a non-330 W adapter the EC clamps this GPU from 175 W to 35 W. The mechanism is fully traced — EC `PROH` at `0x90`, `_Q73`, `Notify (PEGP, 0xD1..0xD5)` — and three things gate the implementation:

- **Write-side EC evidence.** Port↔MMIO aliasing at `0xFE700600` is established for **reads only**, on one adapter state. Nothing may write EC RAM on that basis.
- **A shared-code change.** A hold loop needs a path that takes the `Global\Access_EC` mutex once and omits `PawnIOEcAccess.WriteByte`'s per-call `Thread.Sleep(1)` — that touches every board, so it lands as its own reviewable commit.
- **Safety gating.** Forcing 175 W on a 200 W supply is out-of-spec by design, and a forced unlock was observed leaving the GPU degraded until reboot. Needs explicit opt-in and a proportional cap sized from #162's adapter-wattage read.

It will likely split further: the EC hold path, the Stage-2 unlock as a resident re-applier, then the proportional cap. Tracked in `docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md` §5.

Also not in this series: the four AMD SMU power limits that lift this board's 25 W APU clamp to ~51 W. #161 gives them a working transport; they are not implemented yet.

## What

A standalone console tool at `tools/SmuProbe` that verifies OmenCore's AMD SMU path against real hardware. No changes to any shipping code path.

## Why

The AMD SMU returns `Ok` for message IDs that change no hardware state. That makes "did the write land" unanswerable from inside the app, and it is how the existing SMU code came to look correct while doing nothing (see the follow-up PR).

SmuProbe drives the shipping `OmenCore.Hardware` types directly — `RyzenControl`, `RyzenSmu`, `AmdUndervoltProvider` — via `ProjectReference`, so what it verifies is what ships rather than a reimplementation.

## Modes

| Command | Writes? | What it answers |
|---|---|---|
| `SmuProbe.exe` | **no** | Does the driver open, does the module load, does the mailbox round-trip |
| `--counterfactual` | yes | Sends the same offset through candidate message IDs and prints each status, so an ID theory can be *refuted* |
| `--outcome` | yes | Measures whether an offset changes anything observable |

Both writing modes reset Curve Optimizer to 0 on the way out.

## Why `--outcome` is built the way it is

An early version compared one baseline phase against one offset phase. It reported **+4.8% and −5.3% for the same offset** on consecutive runs — it was measuring how hot the machine started, not the offset.

It now alternates baseline/offset three times and pairs each offset phase against the baseline immediately before it, so monotonic thermal drift cancels. Two guards on top:

- A **sham control** (offset 0 in both phases) establishes the noise floor empirically — it reproduces ±0.1% — rather than assuming one.
- It refuses to confirm on a mean alone; every pair must share the sign, so one large pair cannot carry a result.
- It voids the run if core power collapses between phases, which is what a load that self-terminated looks like.

## Notes for review

- **Not added to `OmenCore.sln`**, matching `tools/ViewProbe`. CI never builds it, so it cannot break the pipeline.
- Requires administrator rights and PawnIO. Only the default mode is read-only.
- Copies `PawnIOLib.dll` and `RyzenSMU.bin` from `OmenCoreApp/drivers` into its own output, because `None` items do not flow across a `ProjectReference`.

## Testing

Builds clean. Full suite unaffected (935/935 passing on the stacked branch).
