### PR TITLE
Board 8D87 (OMEN MAX 16, 2025 AMD): capability profile and telemetry corrections

### DIFF
--- a/docs/8D87-EVIDENCE.md
+++ b/docs/8D87-EVIDENCE.md
@@ -1,0 +1,373 @@
+# Board `8D87` — evidence behind the claims in this repo
+
+Several field layouts asserted in OmenCore's source — `ShippingAdapterPowerRating`, the six-value
+`SmartAdapterStatus` enum, `IsTwoBytePL4Support`, the `Default 0x22` GPS-temperature byte — cannot be
+checked by reading OmenCore. They came from **static decompilation of HP's own OMEN Gaming Hub
+binaries**, and from **live measurement** on one machine.
+
+This document is the citation for those claims, so a reviewer can locate the original without a link
+to a private tree. It is a summary of provenance, not a copy of HP's code: it names the assembly and
+line where each field is read, and states what was measured, in what units, with what control.
+
+**Scope.** Everything here is board `8D87`, one physical machine — HP OMEN MAX 16-ak0098nr, BIOS
+**F.07**, EC **40.38**, Ryzen AI 9 HX 375 (Strix Point, family `1Ah` / model `24h`), RTX 5080 Laptop
+(PCI `0x2C19`, subsystem `103C`). Nothing here should be assumed to generalise to another OMEN board
+without re-measurement. Several findings *are* corrections to other projects' register maps that were
+correct on their own hardware.
+
+---
+
+## 1. Two evidence classes, and what each is good for
+
+| Class | Method | Good for | Not evidence for |
+|---|---|---|---|
+| **Static** | Decompilation of HP's shipping assemblies. 309 assemblies, **not obfuscated** — namespaces, method names and enum members intact. | Field layout, arity, control flow, HP's own naming and thresholds. | Runtime behaviour. A field HP reads may be gated by something never reached on a given SKU. |
+| **Measured** | Live instrumentation on the machine: WMI replies, EC reads, `nvidia-smi enforced.power.limit`, Windows `\Energy Meter(*)\Power` counters. | What the hardware actually does. | Layout of anything not exercised. |
+
+Where the two disagree, static wins on **layout and naming**; measurement wins on **behaviour**. One
+such disagreement is recorded in §2.1 and resolved in favour of static.
+
+The epicentre of the static work is `HP.Omen.Core.Common` (54,462 lines decompiled) and
+`HP.Omen.Background.PerformanceControl`. Line numbers below are into those decompilations; they locate
+a claim, they are not stable identifiers across HP releases.
+
+---
+
+## 2. Static: field layouts taken from HP's own accessors
+
+### 2.1 `Default 0x28` `byte[0..1]` is the SKU's adapter wattage
+
+`HP.Omen.Core.Common.cs:34384` — HP's own accessor:
+
+- reads exactly `systemDesignData[0] | (systemDesignData[1] << 8)`
+- is named **`ShippingAdapterPowerRating`**
+- is compared against the literals **200** and **280** (`:34409`, `:34482`) — BIOS performance-mode
+  support, and TGP/PPAB enable
+
+This machine reads `0x014A` = **330**, on a laptop whose shipping adapter is 330 W.
+
+A bitwise reading of the same field as a 16-bit status-flag struct circulates and renders those
+thresholds as `>= 0x00C8` and `>= 0x0118`. Those are the decimal wattages 200 and 280. **The field is
+watts.**
+
+Consequence for this repo: with `Legacy 0x0F` (§2.2) giving the *connected* rating, OmenCore can read
+**both halves** of the comparison HP's adapter gate makes — required vs connected — rather than
+accepting a binary verdict.
+
+### 2.2 `Legacy 0x0F` is fully decoded
+
+Four-byte reply. HP's accessors, `HP.Omen.Core.Model.Device.cs:9460-9481`:
+
+| Byte | HP's accessor | Meaning |
+|---|---|---|
+| `[0]` | `GetSmartAdapterStatus` | the enum in §2.3 |
+| `[1]` bit 7 | `GetSupportBarrel` | `(data[1] & 0x80) > 0` — barrel jack supported |
+| `[2]` | `GetUsbcDesignRating` | `data[2] * 5` — USB-C **design** rating, W |
+| `[3]` | `GetPowerRating` | `data[3] * 5` — **connected adapter rating, W** |
+
+**`0xFF` on `byte[3]` is a sentinel meaning *unknown*, decoding to 0** — check it before treating a
+`0` rating as "no adapter".
+
+Measured across three physical adapters, exact each time:
+
+| Adapter | Reply | `byte[3]` × 5 |
+|---|---|---|
+| 330 W barrel | `01 C2 00 42` | **330** |
+| 280 W barrel | `02 C2 00 38` | **280** |
+| 200 W barrel | `02 C2 00 28` | **200** |
+
+### 2.3 `SmartAdapterStatus` has six values, not five
+
+`HP.Omen.Core.Common.cs:36545`:
+
+| Value | Name |
+|---|---|
+| `-1` / `0xFF` | `Error` |
+| `0` | `NotSupported` |
+| `1` | `MeetsRequirement` |
+| `2` | `BelowRequirement` |
+| `3` | `BatteryPower` |
+| `4` | `NotFunctioning` |
+| **`5`** | **`ConnectedTypeC`** |
+
+Value `5` is the one most third-party sources omit. It is **not** a fault state — it is USB-C PD
+connected, and HP gives it its own comparison logic in `IsLowWattage`
+(`HP.Omen.Core.Model.Device.cs:9484-9493`): the connected rating is compared against the USB-C
+*design* rating, instead of the binary meets/below test used for the barrel path. There is also a
+special case where barrel support is present and the USB-C design rating is 0.
+
+So `ConnectedTypeC` must not be folded into "anything that is not `MeetsRequirement`".
+
+### 2.4 `Default 0x22` byte 3 is a GPS temperature threshold
+
+`HP.Omen.Background.PerformanceControl.cs:5970` builds the payload as
+`[cTGP, ppab, dState, gps]`, and every caller passes a temperature into the fourth byte
+(`:1720`, `:1661`).
+
+OmenCore's existing `peakTemperature` naming was therefore **right**, and a "spare" reading is wrong.
+
+The value is the output of HP's `IRHandler`, a closed loop driven by the chassis **infra-red skin
+sensor**, bounded by two `PlatformSettings` values: `GpsMaxTemperature = 87` (un-throttled) and
+`GpsMinTemperature = 75` (IR-overheat response only).
+
+**Why this repo still sends 0.** A replacement with no IR loop is permanently in the un-throttled
+state. Sending the un-throttled bound `87` would assert to the firmware that the chassis is cool — a
+claim we have no sensor to justify — and byte 3 is **not** in the `0x21` readback, so the write cannot
+be verified by outcome. The decode is recorded at `HpWmiBios.HpGpsTemperatureThresholdC` and the byte
+is deliberately left at 0. See `docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md` §2.
+
+### 2.5 `Default 0x28` full decode
+
+Reply is 128 bytes, 11 non-zero here: `4A 01 3A 01 03 00 01 07 3C 00 03 00`.
+
+| Byte | Mask | HP's name | Here | Meaning |
+|---|---|---|---|---|
+| `[0..1]` | 16-bit LE | `ShippingAdapterPowerRating` | `0x014A` | **330 W** (§2.1) |
+| `[3]` | whole | `GetThermalPolicyVersion` | `0x01` | **V1** |
+| `[4]` | `0x01` | `IsSwFanControlSupport` | `0x03` | true |
+| `[4]` | `0x02` | `IsExtremeModeSupport` | | **true** |
+| `[4]` | `0x04` | `IsExtremeModeUnlock` | | **false** |
+| `[4]` | `0x08` | `IsDTBiosControl` | | false |
+| `[4]` | `0x10` | **`IsTwoBytePL4Support`** | | **false** |
+| `[5]` | whole | `PL4DefaultValue` | `0x00` | 0 |
+| `[6]` | `0x01` | `IsBiosDefinedOcSupport` | `0x01` | true |
+| `[7]` | whole | `GpuModeSwitch` | `0x07` | capability bitmask, **not** current mode |
+| `[8]` | whole | `DefaultCpuPowerLimitWithGpu` | `0x3C` | **60 W** concurrent CPU budget |
+| `[9]` | `0x0F`/`0xF0` | `LoadLineSupportLevels` / `DefaultLoadLine` | `0x00` | 0 / 0 |
+| `[10]` | `0x01`,`0x02`/`0x04`/`0x08` | `ChangeIrSensorToBoard` / `IsPchOverheatSupport` / `IsVrSensorSupport` | `0x03` | false / false / false |
+
+**`IsTwoBytePL4Support` is the entry that matters beyond this board** — it changes the wire format of
+`Default 0x29 SetPL4`. Getting it wrong is a silent write-corruption class of bug on any board where
+the bit is set.
+
+**The reply is static.** Byte-identical on the 330 W and 200 W adapters, and byte-identical in Hybrid
+and Discrete GPU modes. It describes the SKU — not the connected supply, and not the current graphics
+mode. Read the connected adapter from `Legacy 0x0F` and the GPU mode from `Legacy 0x52`.
+
+`byte[0..1] = 4A 01` also establishes the board strap **`BYID = 0`** on this machine, because the
+firmware writes those bytes only on the `BYID == Zero` branch.
+
+### 2.6 Where HP's capability data actually lives
+
+Two structural findings that bear on this repo's design, both from the static work:
+
+- **There is no EC register map anywhere in OGH.** A grep across all four decompiled roots for the EC
+  MMIO base, `EmbeddedController`, `Ec{Read,Write}`, `{Read,Write}EcRam`, `LpcACPIEC` and raw port I/O
+  returns **zero hits**. HP reaches the EC only through AML `GCxx`, and the AMD SMU through AMD's own
+  driver. A per-board table of EC offsets has no counterpart in HP's software to copy.
+- **No power decision in OGH is keyed on board ID.** The board table gates hotkeys, chassis and
+  lighting only. HP's capability source is the runtime `Default 0x28` query. This repo's per-board
+  capability model is its own invention — legitimate, but it should not be mistaken for HP's.
+
+Consequence, and it is why the board list in `ModelCapabilityDatabase.Vibrance25C1BoardIds` is scoped
+the way it is: use board ID as a **safety scope for raw EC offsets**, and prefer `0x28` for
+**capability**.
+
+### 2.7 A driver that is not a stub, and one that is
+
+- `hpomencustomcapdriver.sys` imports exactly `DbgPrintEx` and `RtlCopyUnicodeString` plus WDF loader
+  stubs — no `MmMapIoSpace`, no port I/O, no `IoCreateDevice`. It **cannot** touch the EC by
+  construction. Do not investigate it as an arming agent.
+- `HpReadHWData.sys` is the one that is not a stub. It exposes a kernel-mode WMI passthrough whose
+  validator checks the literal `SECU` tag and executes via `IoWMIExecuteMethod` on device
+  `ACPI\PNP0C14\0_0`. It also enforces a **caller-identity allowlist of eight named HP binaries** —
+  the only privilege asymmetry located between HP's writes and a third party's.
+
+---
+
+## 3. Measured: the numbers, and the controls that make them trustworthy
+
+### 3.1 Performance modes are two power profiles, not three
+
+`Default 0x1A` writes `NPCF.MODE`, and the firmware consumes **`MODE & 0x0F`**. The named mode bytes
+therefore collapse onto low nibbles. Measured in `nvidia-smi enforced.power.limit`:
+
+| Byte | Name | `& 0x0F` | `enforced` |
+|---|---|---|---|
+| `0x30` | Default | 0 | ~102 W |
+| `0x31` | Performance | 1 | **175.00 W** |
+| `0x50` | Cool | 0 | ~103 W — **same power profile as Default** |
+| `0x34` | *(unnamed)* | 4 | **175.00 W** — reachable, named by no consumer project |
+
+All of these return `RTCD 0`, **including the two that select the same profile** — so acceptance says
+nothing about which profile you got. `Cool` is a fan/thermal policy, not a power tier.
+
+**The control that makes this valid.** `OGHP` decays to 0 within ~2 minutes of OMEN userland being
+killed, and a gate-down machine reads 80.00 W while `MODE 0` reads ~102 W — close enough that a
+dropped gate mid-sweep reads as "this mode selects MODE 0". `Performance` was therefore re-run as a
+positive control between **every pair** of readings, and the run is void unless every control hits
+175 W. The first sweep attempted here produced exactly that false reading, and its `Cool` row was
+discarded.
+
+`"L5P"` is not `MODE 4` or anything else: the string has no byte anywhere in the WMI path. It was
+removed from this board's profile because `SetPerformanceMode("L5P")` fell through to
+`FanMode.Default` — asking for L5P silently gave you Default.
+
+### 3.2 Fan tachometers are `0x70` and `0x5C`
+
+Both 16-bit raw RPM in the EC state window.
+
+`0x7E`/`0x5E` are **commanded setpoints, not tachometers**, gated by the level byte `0x5B`. The
+discriminating measurement, against a full OGH "Full fan speed" ramp: `0x70`/`0x5C` climbed 0 → 4980
+rpm in step with the audible spin-up, while `0x7E`/`0x5E` read 2000/2200 throughout and then **fell to
+0/0 while the fans were still turning at 4980**. A tachometer cannot be invariant while its fan
+changes speed.
+
+This was asserted the wrong way round in an earlier draft of this work and corrected before any PR
+opened.
+
+### 3.3 `MaxFanLevel` is 60, not 100
+
+This board reports thermal policy **V1** and refuses the V2 fan commands outright — `0x37` returns
+`RTCD 6` and `0x38` returns `RTCD 4`, at every input and output buffer size tried. Fan levels
+therefore arrive through the V1 `0x2D` path in krpm/100, **not percent**.
+
+With `MaxFanLevel = 100`, `MapFanPercentToWmiLevel` became an identity: a request for 50% wrote raw
+level 50 ≈ 5000 rpm — near maximum, not half.
+
+Sampled against the EC tachometers and OGH's own readout at four points — `0`/0, `22`/2220, `47`/4680,
+`60`/6000 rpm — linear within ~1%, ceiling **60**.
+
+### 3.4 The AMD Curve Optimizer reaches the silicon
+
+Verified by outcome, not by SMU status. Three alternating pairs under sustained all-core load
+(`tools/SmuProbe --outcome`):
+
+| | Effective clock | Core power |
+|---|---|---|
+| CO 0 | 3148 MHz | 21.40 W |
+| CO −25 | 3301 MHz | 20.10 W |
+| **paired delta** | **+4.9% mean** (range +4.8…+4.9%, consistent sign in all 3 pairs) | −1.3 W |
+| sham control (CO 0 both phases) | **−0.1%** | — |
+
+More clock at less core power is the signature of a real undervolt, and the baseline returns to
+~3148 MHz every time the offset is removed.
+
+**Why it is paired.** A single before/after comparison measures thermal drift as readily as an effect:
+an earlier version of this harness reported **+4.8% and −5.3% for the same offset** on consecutive
+runs, depending only on how hot the machine started. Alternating and pairing each offset phase against
+the baseline immediately before it makes monotonic drift cancel. The sham control establishes the
+noise floor rather than assuming one.
+
+Note also that the SMU returns `Ok` for **both** MP1 `0x4C` and PSMU `0x5D` on this part, and both
+measurably work — so the message id was never the reason Curve Optimizer did nothing. The transport
+was.
+
+### 3.5 Legacy EC offsets do not port to this board, and one of them lies
+
+`0x95`, `0xBA`, `0xCE`, `0xCF` are the pre-2024 OMEN layout. This board's EC is memory-mapped at
+`0xFE700600`.
+
+The instructive one is a third-party map placing single-byte krpm fan RPM at `0x34`/`0x35`. On this
+board those two bytes are the ASCII characters `A` and `0` from the serial number `6LJCA0HTZLC9G0`,
+and a `<= 80` plausibility test passes them — yielding a confident **6500 / 4800 rpm** from string
+data.
+
+**A wrong offset that returns a believable number is worse than one that returns `0xFF`.** This is why
+raw EC offsets in this repo are board-scoped rather than shared.
+
+### 3.6 There is a mux; it is not Advanced Optimus
+
+Two different claims, and this board splits them.
+
+- **The mux is real.** In Discrete the internal panel is driven by the RTX 5080, and `Legacy 0x52`
+  reads `01`. Measured across a reboot in each direction: Hybrid → `00`, Discrete → `01`, back to
+  Hybrid → `00`. So `HasMuxSwitch = true`.
+- **Advanced Optimus is off.** That is the *dynamic* mux, moving under live ACPI control with no
+  reboot. The firmware block stays disabled through a **successful** mode switch — Smart Mux Support,
+  Acpi Control, MDM Support and Display Panel Multiplexer all read `0` in Hybrid, Discrete *and* after
+  returning to Hybrid. Routing is decided at boot. So `SupportsAdvancedOptimus = false`.
+
+`Default 0x28` byte 7 = `0x07` does **not** settle either claim: it is byte-identical in all three
+modes, so it describes the SKU family, not the current state.
+
+### 3.7 An idle dGPU is not iGPU-only mode
+
+A dGPU in D3 reports `Win32_VideoController` `Availability: 8` (Off Line) with no resolution, refresh
+rate or bit depth — indistinguishable, to an adapter-activity check, from a machine with the dGPU
+switched off in firmware. On this board that made Hybrid render as "Integrated GPU Only" with a
+healthy RTX 5080 enumerated.
+
+Read the mode from `Legacy 0x52`. The only way to make an adapter-activity check agree is to wake the
+dGPU, which spends real power to answer a question the firmware already answers.
+
+Related instrument trap: `nvidia-smi` reports `P0`/25 W at idle **because the query itself wakes the
+GPU**, then holds D0 for 120–150 s. Polling to observe D3 re-entry is what prevents it. Read
+`DEVPKEY_Device_PowerData`, which does not wake the device.
+
+---
+
+## 4. Closed questions — do not re-derive these
+
+Each was established and is closed. Recorded because the natural next step for anyone picking this up
+is to rediscover a dead end and mistake it for a lead.
+
+| Claim | Status |
+|---|---|
+| `Default 0x10` is the `OGHP` arming command | **RETRACTED.** `GC01`/`GC10`/`GC28`/`GC2B` are all 0-arg read-only methods. If a capture shows OGH sending `0x10`, that is a read. |
+| `DSTA` via `Default 0x22` is a usable lever | **NO.** `GC22`'s own tail calls `_Q73`, which overwrites `DSTA` from `PROH`. Writes snap back within a second on *either* adapter. |
+| `OGHP` has an AML writer | **NO.** Across all four decompiled tables it appears only as an `External`, a field declaration, and two `== Zero` reads. The EC owns it. |
+| `OGHP` survives a reboot | **NO.** And **the bit is not a valid readout** — it read `1` on a boot where the grants had been revoked. Test with `Default 0x21` or delivered watts. |
+| The mailbox block at `0xF5`–`0xF8` is a power lever | **NO.** It is the EC *publishing* a decision; forcing it to the 330 W values changed nothing. The SMU never reads it back. |
+| `PROH`/`DSTA` values 3/4/5 are intermediate power tiers | **NO.** They are `SmartAdapterStatus` (§2.3). There is no middle tier. |
+| A matched fan-level readback proves the fan changed speed | **NO.** It proves the firmware accepted the command. `0x38` is refused on this board, so no physical tachometer reached the old verification path at all — which made "level matched" the only evidence checked, and incapable of failing. Measured: level 28 echoed back while five consecutive samples read 0 rpm. |
+| A mode sweep can be run sequentially | **NO.** See the `OGHP` decay control in §3.1. |
+| `ZenStates-Core` can read this SMU | **NO.** No map for family `1Ah`/model `24h`. Use RyzenAdj ≥ 0.19.0, which recognises Strix Point. |
+| `GetSystemFirmwareTable(ACPI,'SSDT')` enumerates the loaded SSDTs | **NO.** It returns only the first table per signature — an enumeration loop yields 41 copies of one table. Read `HKLM:\HARDWARE\ACPI` instead: 37 distinct tables. |
+
+---
+
+## 5. Method rules these came from
+
+Four separate false positives in this work had the same shape. They are recorded as rules because the
+same shapes recur in this repo's own history.
+
+1. **Check the outcome, not the request.** A WMI command returning `RTCD 0` means the firmware
+   accepted it, not that the hardware did anything. Verify fan claims in RPM and power claims in
+   watts. On this platform `RTCD 0` is especially weak: the ACPI returns `0` on its own timeout path,
+   so an all-zero buffer at `RTCD 0` is indistinguishable from no answer. **Non-zero is the
+   trustworthy direction.**
+2. **Compare against the requested value, not the previous sample.** A write the EC has already undone
+   looks stable if you only diff consecutive polls.
+3. **Adjacency in a high-rate capture is not causation.** The `Default 0x10` claim was published and
+   retracted on exactly this error, and one grep of the static tables refuted it. **When a capture and
+   a decompiled table disagree, the table wins.**
+4. **Two agreeing snapshots are not a reproducibility filter.** One adapter-keyed byte passed that bar
+   and was still wrong. Vary the input across more than two states.
+5. **`RTCD 5` means the output buffer was the wrong size**, not "unsupported". A genuine refusal
+   persists across every buffer size tried.
+6. **Reads can be corrupted by OMEN Gaming Hub.** The EC command mailbox is a single shared buffer with
+   no locking between OS agents, and OGH polls it continuously. Repeated identical reads returned OGH's
+   replies to *its* questions until OGH was stopped. Distrust a value that changes between
+   back-to-back identical reads.
+7. **Check the instrument against a known value before believing it.** PowerShell's `-shl` preserves
+   the left operand's type, so `[byte]0x0A -shl 8` is `0`. A 16-bit EC field assembled that way
+   silently returns only its low byte — one tool reported a fan at 200 rpm while the raw window held
+   `C8 0A` = 2760. Nothing in the output looked wrong on its own.
+
+---
+
+## 6. Provenance
+
+The full lab notebooks are outside this repository — they are long (one is over 2,500 lines), they
+record method and measurement rather than conclusions, and they contain their own retractions. This
+document is the distilled citation; the source tree separates `reference/` (current truth) from
+`investigation/` (how it was established), and its notebook filenames are:
+
+| Document | Covers |
+|---|---|
+| `01-bios-f07-static.md` | static firmware analysis |
+| `02-power-gate-measurements.md` | live power measurement |
+| `03-nvpcf-tgp-mechanism.md` | the NVPCF/TGP mechanism, ACPI-decompiled |
+| `04-ogh-binaries.md` | static decompilation of HP's OMEN Gaming Hub |
+| `05-keyboard-lighting.md` | lighting topology |
+| `06-hpreadhwdata-driver.md` | `HpReadHWData.sys` |
+| `08-ec-port-aliasing.md` | ACPI EC port ↔ MMIO aliasing |
+| `09-capability-verification.md` | per-field capability verification |
+
+Two things to carry from them if this is ever reopened:
+
+- **Several findings there were corrected more than once before settling.** Prefer a distilled
+  statement over a raw section, and treat anything marked untested as untested.
+- **The port↔MMIO aliasing is established for *reads only*, on one adapter state.** Nothing may write
+  EC RAM on that basis. See `docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md` §5.1.

--- a/docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md
+++ b/docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md
@@ -1,6 +1,6 @@
 # Board `8D87` — OMEN MAX 16 (2025, AMD) Support Plan
 
-**Status:** planning. Nothing in this document has been implemented.
+**Status:** Tier 1 is largely **implemented** — see §8 for what has landed and what has not. Tier 2 (the AMD SMU transport) is fixed; Tier 3 (the adapter gate) is not started and is gated on evidence stated in §5.1.
 **Target board:** `8D87` — HP OMEN MAX 16-ak0098nr, Ryzen AI 9 HX 375 (family `1Ah`/model `24h`, Strix Point) + RTX 5080 Laptop (`10DE:2C19`), BIOS F.07, EC 40.38.
 **Sibling boards on the same HP platform (`Vibrance25C1`):** `8D88`, `8DD5`, `8DD6`.
 **Related existing DB entry:** `AK0003NR` (`ModelNamePattern = "max 16 ak0"`), same family, different SKU.
@@ -9,34 +9,30 @@
 
 ## 0. Where this comes from, and how much to trust it
 
-Two external investigations, both outside this repo:
+Two evidence classes, from an investigation conducted outside this repo on one physical machine:
 
-| Source | Method | Evidence class |
-|---|---|---|
-| `D:\src\omen-max-16\investigation\03-nvpcf-tgp-mechanism.md` | ACPI decompilation + **live measurement** on the physical machine | Strongest available. Firmware-derived and instrumented. |
-| `D:\src\omen-max-16\investigation\04-ogh-binaries.md` | Static decompilation of HP's own OMEN Gaming Hub binaries (309 assemblies, not obfuscated) | Strong for **arity, field layout, HP's own naming**. No evidence at all for runtime behaviour. |
+| Class | Method | Good for | Not evidence for |
+|---|---|---|---|
+| **Measured** | ACPI decompilation plus **live instrumentation** — WMI replies, EC reads, `nvidia-smi enforced.power.limit`, Windows Energy Meter counters. | What the hardware actually does. | Layout of anything not exercised. |
+| **Static** | Decompilation of HP's own OMEN Gaming Hub binaries — 309 assemblies, **not obfuscated**. | Field layout, arity, control flow, HP's own naming and thresholds. | Runtime behaviour. |
 
-Supporting documents in the same series: `01-bios-f07-static.md` (static firmware), `02-power-gate-measurements.md` (measurement), `07-setup-variable-map.md`.
+Where they conflict, **static wins on layout and naming; measurement wins on behaviour.** One such
+conflict is load-bearing here: the `Default 0x28` `byte[0..1]` field was read behaviourally as a
+status-flag struct and is, per HP's own accessor, watts.
 
 > [!IMPORTANT]
-> **Do not read either source document to answer a question of fact.** They are lab notebooks: they
-> record method and measurement — how a thing was established, on what instrument, with what numbers —
-> and they are long. `03-nvpcf-tgp-mechanism.md` alone is over 2500 lines.
+> **The distilled evidence for every claim in this document lives in
+> [`8D87-EVIDENCE.md`](8D87-EVIDENCE.md), in this repository.** It cites HP's assembly and line for
+> each static claim, and the control that makes each measurement trustworthy.
 >
-> The distilled current truth is in **`D:\src\omen-max-16\reference\`** — five short documents:
-> ``power-model.md``, ``ec-map.md``,
-> ``wmi-commands.md``,
-> ``board-8d87.md`` and
-> ``settled-negatives.md``, plus
-> ``capabilities-8d87.json`` for this plan's §3.6 database entry.
-> Cite the notebook for provenance; take facts from `reference/`.
+> The original lab notebooks are outside this repo and are deliberately not linked: they are long (one
+> is over 2,500 lines), they record method rather than conclusions, and they contain their own
+> retractions. Notebook filenames are listed in `8D87-EVIDENCE.md` §6 for provenance.
 
 **Two things to keep in mind while reading:**
 
-1. **The two sources disagree in places, and 04-ogh-binaries.md is usually the correction.** The mechanism doc's §7h concluded `0x28` bytes 0–1 were a status-flag field; 04-ogh-binaries.md §1a shows HP's own source names it `ShippingAdapterPowerRating` and compares it against 200 and 280. Where they conflict, the binary analysis wins on *layout and naming*, the mechanism doc wins on *runtime behaviour*. Both resolutions are already applied in `reference/`.
-2. **Five plausible findings on this board turned out to be false, and four failed the same way.** `PROH` at `0x8F`, `Default 0x10` as the arming command, `HPBA` as adapter-keyed, `P3TV` as a working lever, and "the exploit is a durable one-shot" were each established and then disproved — four of them because the *request* was checked instead of the *outcome*. A command that returns success is not a watt. That failure mode is directly relevant to how we implement this: see §5.2, and ``settled-negatives.md`` for the current statement of each.
-
-**This board's `UserVerified` status stays `false` for now.** The evidence above is excellent, but it comes from one machine and one investigator, not from this project's normal field-report channel. Individual items below carry their own evidence assessment.
+1. **Five plausible findings on this board turned out to be false, and four failed the same way.** `PROH` at `0x8F`, `Default 0x10` as the arming command, `HPBA` as adapter-keyed, `P3TV` as a working lever, and "the exploit is a durable one-shot" were each established and then disproved — four of them because the *request* was checked instead of the *outcome*. A command that returns success is not a watt. That failure mode is directly relevant to how we implement this: see §5.2, and [`8D87-EVIDENCE.md`](8D87-EVIDENCE.md) §4 for the current statement of each closed question.
+2. **This is one machine and one investigator**, not this project's normal field-report channel. `UserVerified` on this board's entry is now `true` because every board-specific field in it was measured on the hardware — see [`8D87-VERIFICATION-CHECKLIST.md`](8D87-VERIFICATION-CHECKLIST.md) for which claim rests on what, and what the flag does not cover. Individual items below carry their own evidence assessment.
 
 ---
 
@@ -243,8 +239,8 @@ OmenCore cannot do that:
 > [!IMPORTANT]
 > **T3.1 has now been run. The ports alias the MMIO window for reads, and the latency objection
 > below did not survive measurement.** Full method and limits:
-> ``../investigation/08-ec-port-aliasing.md``; distilled in
-> ``../reference/settled-negatives.md``.
+> the `08-ec-port-aliasing.md` notebook; distilled for this repo in
+> [`8D87-EVIDENCE.md`](8D87-EVIDENCE.md).
 
 - **T3.1 — DONE (2026-08-04).** Three runs sandwiching a PawnIO/`LpcACPIEC` port sweep between two MMIO captures, so that only bytes which held still across the whole window got a vote. **100 % / 100 % / 99.6 % agreement on judged bytes; 8 of 8 entropy-carrying anchors matched**, including both fan tachometers at 3000 rpm under deliberate CPU load and `PROH` itself. Correlation falls from 99.6 % at shift 0 to ~33 % at ±1 byte, which is what rules out coincidental resemblance rather than mere agreement. The one diverging byte was a temperature sensor that ticked mid-sweep — tracked across all three runs and explained, not waved away.
   - The warning not to accept partial agreement was honoured: §7h's withdrawn `CPUT`/`0x57` argument rested on a single static byte, and that argument is **not** what re-established this.
@@ -309,7 +305,7 @@ Every offset here (`0x59`, `0x90`, `0xE6`, `0xF6`/`0xF7`) came from *this* DSDT.
 ## 6. Explicitly do not
 
 **The full list of settled dead ends lives in one place:
-``../reference/settled-negatives.md``.** Read it before proposing
+[`8D87-EVIDENCE.md`](8D87-EVIDENCE.md) §4.** Read it before proposing
 any experiment on this board — it also records two claims that were retracted and then
 *un*-retracted, which is the layer most likely to be read wrong.
 
@@ -317,7 +313,7 @@ Specific to this repo, on top of that list:
 
 - **Do not** add EC power offsets `0xC0`–`0xC5` for this board. `SupportsEcPowerLimits` stays `false`.
 - **Do not** look for an EC register map in OGH's binaries. There is none — a grep across all four decompiled roots for `0xFE7006*`, `EmbeddedController`, `Ec{Read,Write}`, `LpcACPIEC` and raw port I/O returns zero hits. HP reaches the EC only through AML `GCxx` and the SMU only through AMD's own driver.
-- **Do not** investigate `hpomencustomcapdriver.sys`. It imports exactly `DbgPrintEx` and `RtlCopyUnicodeString` plus WDF loader stubs — no `MmMapIoSpace`, no port I/O, no `IoCreateDevice`. It is a stub and cannot touch the EC by construction. (`HpReadHWData.sys` is the one that is *not* a stub — see ``../investigation/06-hpreadhwdata-driver.md``.)
+- **Do not** investigate `hpomencustomcapdriver.sys`. It imports exactly `DbgPrintEx` and `RtlCopyUnicodeString` plus WDF loader stubs — no `MmMapIoSpace`, no port I/O, no `IoCreateDevice`. It is a stub and cannot touch the EC by construction. (`HpReadHWData.sys` is the one that is *not* a stub — see [`8D87-EVIDENCE.md`](8D87-EVIDENCE.md) §2.7.)
 - **Do not** raise TDC/EDC.
 - **Do not** reintroduce WinRing0 or inpoutx64. Note the upstream investigation's own `tools/lever/` scripts use `inpoutx64` for MMIO — **that does not port here**, and this repo removed it deliberately over Defender detections.
 
@@ -325,7 +321,7 @@ Three from the shared list are worth repeating because they are easy to re-deriv
 
 - **Do not** try to write `DSTA` directly via `GC22`. It sets `DSTA` and then calls `_Q73`, which overwrites it from `PROH`. Measured on both adapters.
 - **Do not** treat `EWDS` (mailbox `0x0E`) as a size field. Declared once, referenced by no AML, reads 0 in 1666/1666 captured events.
-- **Do not** treat `Default 0x28` as *connected* adapter state — it is byte-identical on 330 W and 200 W, and describes the SKU. But it is **not** contentless: `byte[0..1]` is `ShippingAdapterPowerRating` in watts (330 here), and `Legacy 0x0F` `byte[3] × 5` gives the connected rating. See ``../reference/wmi-commands.md``.
+- **Do not** treat `Default 0x28` as *connected* adapter state — it is byte-identical on 330 W and 200 W, and describes the SKU. But it is **not** contentless: `byte[0..1]` is `ShippingAdapterPowerRating` in watts (330 here), and `Legacy 0x0F` `byte[3] × 5` gives the connected rating. See [`8D87-EVIDENCE.md`](8D87-EVIDENCE.md) §2.1 and §2.5.
 
 ---
 
@@ -335,7 +331,7 @@ Carried forward from both documents, with our own added.
 
 **Blocking for us:**
 
-1. **Do ports `0x62`/`0x66` alias the MMIO window for *writes*, and on a second adapter state?** They do alias for **reads** — measured, three sandwiched runs; see §5.1 and ``../investigation/08-ec-port-aliasing.md``. The write direction is unproven, and nothing may write EC RAM through the ports until it is closed.
+1. **Do ports `0x62`/`0x66` alias the MMIO window for *writes*, and on a second adapter state?** They do alias for **reads** — measured, three sandwiched runs; see §5.1 and [`8D87-EVIDENCE.md`](8D87-EVIDENCE.md) §6. The write direction is unproven, and nothing may write EC RAM through the ports until it is closed.
 2. **Does the PawnIO release driver load third-party modules?** Decides Option B. **Now much less urgent** — Option A succeeded, so Option B is no longer on the critical path for either stage.
 3. **Does the `OGHP` race actually win over ports?** Feasible on the latency numbers; unproven in fact. Requires the dedicated hold path described in §5.1.
 
@@ -356,9 +352,24 @@ Carried forward from both documents, with our own added.
 
 **Phase 0 — decide the transport. ✅ DONE (2026-08-04).** T3.1 came back positive: the ports alias for reads and the transport is fast enough for *both* levers, not just `PROH`. Tier 3 exists. Two things moved as a result — Option B (custom PawnIO module) leaves the critical path, and the `OGHP` blocker is now a wrapper fix (`Thread.Sleep(1)` + per-call mutex in `PawnIOEcAccess.WriteByte`) rather than a transport dead end. The remaining gate before any EC write is confirming the aliasing holds **for writes** and on a **second adapter state**.
 
-**Phase 1 — Tier 1.** T1.4 → T1.5 → T1.6 first: adapter awareness is the highest value-per-risk item in the whole plan, it is read-only, and it makes every subsequent field report better. Then T1.8/T1.9/T1.10 (payload correctness), T1.11/T1.12 (`0x28`), T1.15/T1.16 (model DB). T1.1/T1.2/T1.3 (`MODE`) last in this phase, since they are the first real behaviour change.
+**Phase 1 — Tier 1. ✅ LARGELY DONE.** Landed: adapter awareness (`Legacy 0x0F`), the full `0x28`
+decode, the `0x22` payload correction, the model-DB entry with `UserVerified = true`, real fan
+tachometers at `0x70`/`0x5C`, a V2-capability *probe* replacing the model-name force-switch (which
+closes open question 11), the GPU mode read from `Legacy 0x52`, and the performance-mode measurement
+that removed `"L5P"`.
 
-**Phase 2 — Tier 2.** T2.1 (verify, then fix `pawnio_load`) → T2.2/T2.3 → T2.6 (verification harness) → T2.5. This is the biggest measured user-facing win (25 → 51 W CPU) and it needs no EC writes and no races.
+Not landed from Tier 1: `MODE 4` as a user-facing control (T1.2), and `OTPP` (§7.7) which remains
+untested.
+
+**Phase 2 — Tier 2. ⚠️ TRANSPORT DONE, LIMITS NOT.** T2.1 turned out to be three faults, not one: no
+`pawnio_load` call, ioctl names no bundled module exports, and a stale bundled module that rejected
+this CPU outright. All three are fixed and the transport is verified end to end — Curve Optimizer
+measures **+4.9% sustained clock at CO −25** against a ±0.1% sham control
+([`8D87-EVIDENCE.md`](8D87-EVIDENCE.md) §3.4).
+
+Still open in Tier 2: **T2.2/T2.3 — the four SMU power limits** (`stapm`, `fast`, `slow`, `apu-slow`)
+that lift the 25 W APU clamp to ~51 W. The transport they need now works; the limits themselves are
+not implemented. T2.4 stands: **do not raise TDC/EDC.**
 
 **Phase 3 — Tier 3.** Phase 0 succeeded, so this is live. T3.2 → T3.3 (Stage 2) → T3.5 (proportional). **T3.4 (Stage 1) is no longer conditional on transport speed** — 0.325 ms per transaction clears the 2 ms window — but it does depend on the dedicated hold path in §5.1, and it stays behind the safety gating in §5.2.3 regardless.
 

--- a/docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md
+++ b/docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md
@@ -1,0 +1,365 @@
+# Board `8D87` — OMEN MAX 16 (2025, AMD) Support Plan
+
+**Status:** planning. Nothing in this document has been implemented.
+**Target board:** `8D87` — HP OMEN MAX 16-ak0098nr, Ryzen AI 9 HX 375 (family `1Ah`/model `24h`, Strix Point) + RTX 5080 Laptop (`10DE:2C19`), BIOS F.07, EC 40.38.
+**Sibling boards on the same HP platform (`Vibrance25C1`):** `8D88`, `8DD5`, `8DD6`.
+**Related existing DB entry:** `AK0003NR` (`ModelNamePattern = "max 16 ak0"`), same family, different SKU.
+
+---
+
+## 0. Where this comes from, and how much to trust it
+
+Two external investigations, both outside this repo:
+
+| Source | Method | Evidence class |
+|---|---|---|
+| `D:\src\omen-max-16\investigation\03-nvpcf-tgp-mechanism.md` | ACPI decompilation + **live measurement** on the physical machine | Strongest available. Firmware-derived and instrumented. |
+| `D:\src\omen-max-16\investigation\04-ogh-binaries.md` | Static decompilation of HP's own OMEN Gaming Hub binaries (309 assemblies, not obfuscated) | Strong for **arity, field layout, HP's own naming**. No evidence at all for runtime behaviour. |
+
+Supporting documents in the same series: `01-bios-f07-static.md` (static firmware), `02-power-gate-measurements.md` (measurement), `07-setup-variable-map.md`.
+
+> [!IMPORTANT]
+> **Do not read either source document to answer a question of fact.** They are lab notebooks: they
+> record method and measurement — how a thing was established, on what instrument, with what numbers —
+> and they are long. `03-nvpcf-tgp-mechanism.md` alone is over 2500 lines.
+>
+> The distilled current truth is in **`D:\src\omen-max-16\reference\`** — five short documents:
+> ``power-model.md``, ``ec-map.md``,
+> ``wmi-commands.md``,
+> ``board-8d87.md`` and
+> ``settled-negatives.md``, plus
+> ``capabilities-8d87.json`` for this plan's §3.6 database entry.
+> Cite the notebook for provenance; take facts from `reference/`.
+
+**Two things to keep in mind while reading:**
+
+1. **The two sources disagree in places, and 04-ogh-binaries.md is usually the correction.** The mechanism doc's §7h concluded `0x28` bytes 0–1 were a status-flag field; 04-ogh-binaries.md §1a shows HP's own source names it `ShippingAdapterPowerRating` and compares it against 200 and 280. Where they conflict, the binary analysis wins on *layout and naming*, the mechanism doc wins on *runtime behaviour*. Both resolutions are already applied in `reference/`.
+2. **Five plausible findings on this board turned out to be false, and four failed the same way.** `PROH` at `0x8F`, `Default 0x10` as the arming command, `HPBA` as adapter-keyed, `P3TV` as a working lever, and "the exploit is a durable one-shot" were each established and then disproved — four of them because the *request* was checked instead of the *outcome*. A command that returns success is not a watt. That failure mode is directly relevant to how we implement this: see §5.2, and ``settled-negatives.md`` for the current statement of each.
+
+**This board's `UserVerified` status stays `false` for now.** The evidence above is excellent, but it comes from one machine and one investigator, not from this project's normal field-report channel. Individual items below carry their own evidence assessment.
+
+---
+
+## 1. The mechanism, compressed
+
+Three independent clamps. Understanding that they are independent is the whole point — earlier work in this repo and upstream conflated them.
+
+```
+Stage 1  GPU 105 W -> 175 W     OGHP  (EC 0x59 bit 1)     "OMEN Gaming Hub Present"
+Stage 2  GPU 175 W ->  35 W     PROH  (EC 0x90)           adapter verdict, on non-330 W supplies
+Stage 3  CPU  73 W ->  25 W     AMD SMU limits            adapter-keyed, entirely outside NVPCF
+```
+
+**Stage 1 — `OGHP`.** `NVPCF._DSM`'s whole body is gated on `OGHP == 1`. At boot, `_REG` sees `OGHP == 0` (no OMEN software) and zeroes `NPCF.CTGP`/`NPCF.DTGP`, revoking the configurable-TGP adder. Result: 105 W base TGP instead of 175 W (105 + `ACBT` 560/8 = 70 W adder = 175). Repaired at runtime by holding `OGHP` from a ~2 ms loop while firing `GC22` (`Default 0x22`) so the driver's `_DSM` re-read lands inside the window. The resulting `Notify` is never retracted, so the hold can be dropped immediately after. **Measured, with zero OMEN processes running.**
+
+**Stage 2 — `PROH`.** The EC classifies the adapter into `ADID` (3-bit class) and writes its verdict to `PROH` at EC `0x90`. `_Q73` copies `PROH` into `DSTA` and issues `Notify (PEGP, 0xD1..0xD5)`; the NVIDIA driver maps `0xD1` → 175 W and `0xD2` → 35 W. Holding `PROH = 1` from a ~2 ms loop and triggering `_Q73` via `GC22` took the 200 W adapter from **35 W to 175 W**. The EC reasserts `PROH` on a ~100 ms cycle, but the notify survives.
+
+**Stage 3 — the CPU.** Not reachable through `PROH`, `ADID`, `RPWR`, or anything in NVPCF. It is three ordinary AMD SMU limits (`STAPM`, `PPT FAST`, `PPT SLOW`) pinned at exactly 25.000 W, plus `PPT APU` at 45. Writing all four with RyzenAdj took the APU from **25.02 W to ~51 W sustained**, with OGH not running and **no hold thread needed** — the EC does not fight back here.
+
+**None of the three survives a reboot.** A replacement for OGH is a resident agent, not a one-shot script.
+
+---
+
+## 2. What this repo currently believes, and where it is wrong
+
+Repo-wide grep for `OGHP`, `PROH`, `NVPCF`, `CTGP`, `DTGP`, `0xFE7006`, `_Q73`, `P3TV` returns **zero hits**. None of this mechanism is known to OmenCore today.
+
+| Location | Current state | Reality on `8D87` |
+|---|---|---|
+| `ModelCapabilityDatabase.cs:928-954` | `8D87` entry, `UserVerified = false`, notes say "inferred from adjacent MAX ak/ah generation" | Now substantially characterised. See §3.5. |
+| `PowerLimitController.cs:17-25` | EC power offsets `0xC0`–`0xC5`, self-described "EXAMPLE - varies by model!" | Meaningless on this board. `SupportsEcPowerLimits` must stay `false`. |
+| `PawnIOEcAccess.cs:27-28` | EC via ACPI ports `0x62`/`0x66`, offset allowlist `0x2C`…`0xF4` | The ports **are** declared (`EC0._CRS`), and AML also reaches the EC through an MMIO alias at `0xFE700600`. The two views **are the same 256 bytes for reads** — measured, three sandwiched runs. **Writes through the ports remain unproven**, so nothing may write EC RAM that way yet. See §4 and §5.1. |
+| `HpWmiBios.cs:192` | `BuildGpuPowerPayload` returns `peakTemperature = 0x00` | Byte 3 of `0x22` is a GPS temperature threshold in °C. HP passes 87 — but only as the *most permissive* output of a closed loop it drives from the chassis IR sensor, revising it to 75 on overheat. **Deliberately left at 0**: with no IR loop, sending 87 pins the firmware in the chassis-is-cool state, and byte 3 is not in the `0x21` readback so it cannot be verified by outcome. Decode recorded at `HpGpsTemperatureThresholdC`. |
+| `HpWmiBios.cs:636-642` | `SetFanMode` sends `Default 0x1A` `{0xFF, mode, 0, 0}` — treated as fan-only | This is `GC1A`, which writes `NPCF.MODE` from **byte[1]**. It is the GPU/CPU power-profile selector, not just a fan knob. See §3.1. |
+| `RyzenSmu.cs:68-126` | `Initialize()` opens PawnIO | Never calls `pawnio_load`, so no module backs `ioctl_pci_read_config_dword` / `ioctl_pci_write_config_dword`. Every other PawnIO consumer in the repo — `PawnIOEcAccess`, `LibreHardwareMonitorImpl`, `HardwareWorker` — resolves and calls it; `RyzenSmu` is the sole exception. **The AMD SMU path is dead today**, confirmed by inspection at `RyzenSmu.cs:102-104`. |
+| `AmdUndervoltProvider.cs:300` | `SetStapmLimit` only | Three more limits are required; raising only stapm/fast/slow lands on a hard 46 W ceiling. |
+| Adapter awareness | None. Grep for "adapter" across `src/` returns Linux battery paths and one ADL delegate name. | `Legacy 0x0F` reports the connected adapter's real wattage. See §3.3. |
+| `DiagnoseCommand.cs:298-301` | Board `8D41` note: "Linux GPU TGP may stay capped near base power if hp-wmi does not send the … Dynamic Boost unlock that Windows OGH sends" | Correct symptom, now with a named cause (`OGHP`). The note can be replaced with the actual mechanism. |
+
+---
+
+## 3. Tier 1 — pure WMI. No new driver, no EC writes, no transport decision.
+
+Everything in this tier uses `HpWmiBios.SendBiosCommand` as it exists today.
+
+### 3.1 `MODE` is a power lever, and `Cool` currently costs 70 W of GPU
+
+**Evidence:** firmware (decompiled `wmi_live.dsl` + `nvpcf_live.dsl`), mechanism doc §7a/§7p. Not yet measured on this board for MODE 4.
+
+`GC1A` does `CreateByteField (Local2, One, PWMD); \_SB.NPCF.MODE = PWMD` — byte[1] of the `0x1A` payload. `NPCF` then selects a profile row on `MODE & 0x0F`. For `NVXX = 2` (this GPU):
+
+| `MODE & 0x0F` | `ACBT` → GPU adder | `ATPP` → CPU limit w/ GPU | GPU `enforced` |
+|---|---|---|---|
+| `0` | 0 → **0 W** | `0x0118` → 35 W | 105 W |
+| `1` | `0x0230` → **70 W** | `0x01E0` → 60 W | 175 W |
+| **`4`** | `0x0230` → **70 W** | `0x0320` → **100 W** | 175 W |
+
+Cross-referenced against the current `FanMode` enum (`HpWmiBios.cs:133-142`):
+
+- `Default = 0x30` → low nibble **0**
+- `Performance = 0x31` → low nibble **1**
+- `Cool = 0x50` → low nibble **0**
+
+**Consequence, and it is a live bug:** selecting **Cool** on this board sends `MODE = 0x50`, whose low nibble is 0, which revokes the entire configurable-TGP adder and drops the GPU to 105 W. That is not a fan setting, and users have no way to know.
+
+**Work items:**
+
+- **T1.1** Add a `MODE`-aware layer over the existing `0x1A` path, board-gated. Do not reuse `FanMode` for this — the coupling is the bug. Surface, at minimum, that Cool revokes the GPU adder on `Vibrance25C1` boards.
+- **T1.2** Add `MODE 4` (`0x34`) as an option. Same GPU adder as MODE 1, `ATPP` 60 → 100 W.
+  - **Caveat:** §7p measured the CPU already reaching `ATPP = 60 W` momentarily and settling at 45 W at 86 °C under a combined load. The 60 W ceiling is real and reachable but is *not* what holds the sustained figure down — so MODE 4 may buy nothing until cooling improves. Ship it as a control, not as a promised gain.
+  - Both `MODE` and `OTPP` sit inside `If ((OGHP == One))`, so neither does anything without the Stage-1 arm.
+
+### 3.2 This closes an open evidence gate already tracked in this repo
+
+`docs/ROADMAP_v4.0.0.md:349-350` records that `8D87` and `AK0003NR` are **the only two 2025 MAX boards in the database without `AllowDecoupledWmiThermalPolicyFallback = true`**, that the one-line fix was identified, and that it was deliberately withheld pending field evidence — because nobody knew what the WMI thermal-policy write actually *did* on the AMD path.
+
+We now know exactly what it does: `SetFanPerformanceModeSerialized` → `_fanController.SetPerformanceMode` → `SetFanMode` → `Default 0x1A` → `GC1A` → `NPCF.MODE`. With the flag off, `PerformanceModeService.Apply()` sends nothing at all on this board (EC limits blocked by `SupportsEcPowerLimits = false`, WMI fallback disabled), so `MODE` stays at its `Name (MODE, Zero)` initializer — low nibble 0 — and the GPU adder is never granted.
+
+That is a complete mechanical explanation for the reporter's symptom ("OGH reaches higher wattage, OmenCore doesn't touch it").
+
+- **T1.3** Set `AllowDecoupledWmiThermalPolicyFallback = true` on `8D87` and `AK0003NR`, matching their Intel siblings `8D41`/`8D42`.
+  - **Evidence class:** the mechanism is now firmware-derived rather than inferred-by-symmetry, which is a materially higher bar than the roadmap had when it deferred. It is still a hardware-behaviour change on `UserVerified = false` boards. Recommend shipping it **with** T1.4's verification so the next field report carries before/after wattage automatically, rather than shipping it blind.
+  - **Arithmetic worth checking against the field report:** the roadmap records the reporter seeing 71 W default → 105 W with OGH. MODE 1's `ATPP` is 60 W and MODE 4's is 100 W. If OGH drives MODE 4 rather than MODE 1, that fits. **Hypothesis, not a finding** — it needs one measurement to settle, and it changes which value T1.1 should send for "Performance".
+
+### 3.3 Adapter awareness — `Legacy 0x0F`
+
+**Evidence:** measured on three physical adapters (330/280/200 W), exact both times. Field layout confirmed against HP's own accessors (findings §1d). **Strongest item in this document.**
+
+`BiosCmd.Legacy` (`0x00000001`), command `0x0F`, 4-byte reply:
+
+| Byte | HP's accessor | Meaning |
+|---|---|---|
+| `[0]` | `GetSmartAdapterStatus` | `SmartAdapterStatus` enum — see below |
+| `[1]` bit 7 | `GetSupportBarrel` | barrel jack supported (`0xC2` here ⇒ true) |
+| `[2]` | `GetUsbcDesignRating` | `× 5` = USB-C **design** rating, W |
+| `[3]` | `GetPowerRating` | `× 5` = **connected adapter's rating, W**; `0xFF` means unknown ⇒ 0 |
+
+`SmartAdapterStatus`, from HP's own enum (findings §1c — note this extends OmenMon-Reborn's table, which stops at 4):
+
+`-1` Error · `0` NotSupported · `1` MeetsRequirement · `2` BelowRequirement · `3` BatteryPower · `4` NotFunctioning · **`5` ConnectedTypeC**
+
+Measured: 330 W → `01 C2 00 42` (`0x42` × 5 = 330). 200 W → `02 C2 00 28` (200). 280 W → `02 C2 00 38` (280).
+
+**Work items:**
+
+- **T1.4** Add `GetAdapter()` to `HpWmiBios` — the concrete class, **not** `IHpWmiBios`. Every consumer holds the concrete type, and a defaulted interface member would make "silently return null" the default for a future implementer, which renders as the affirmative claim *this board does not report an adapter*. Read-only, works on any board that answers the `Legacy` class. Note that this repo had **never issued the `Legacy` class for anything but `0x52`** — handle unsupported returns cleanly.
+- **T1.5** Surface it: adapter wattage + status in Diagnostics, and a clear explanation when status is `BelowRequirement`. Today a user on a 200 W adapter sees "GPU stuck at 35 W" with no explanation available anywhere in the app.
+- **T1.6** Feed it into the diagnostics export. Every future field report from a MAX-series board should carry the adapter verdict.
+- **T1.7** Handle `ConnectedTypeC` (5) separately — HP's `IsLowWattage` uses different comparison logic for it (findings §1c): `powerRating > 0 && powerRating < usbcDesignRating`, plus a barrel-support special case. Do not fold it into "not MeetsRequirement".
+
+### 3.4 `0x22` payload and arity
+
+**Evidence:** HP's own source (findings §1b), `PerformanceControl.cs:5970` and callers.
+
+- **T1.8** Byte 3 of the `0x22` payload is a **GPS temperature threshold**, not a spare. HP's `SetTgpPpabAsync` hardcodes 87 (°C). `BuildGpuPowerPayload` currently returns 0. Fix, and name it correctly.
+  - Credit where due: OmenCore's existing `peakTemperature` naming was *right* and the firmware doc's "spare" was wrong — findings §1b says so explicitly. Only the value is wrong.
+- **T1.9** `0x22` has a **second 1-byte arity** (`SetTGPAsync`, `new byte[1] { enable }`). Nothing should assume it is always 4 bytes.
+- **T1.10** `dState` is hardcoded `0x01`, which matches HP — but per §7c/§7i, `GC22` sets `DSTA` and then calls `_Q73`, which immediately overwrites it from `PROH`. `DSTA` is **not independently settable on either adapter.** Document this at the call site so nobody re-derives it.
+
+### 3.5 `0x28 SystemDesignData` is badly under-decoded
+
+**Evidence:** HP's own bitwise accessors (findings §3c). Applies to **every** board, not just this one.
+
+`QuerySystemData` reads 128 bytes and parses one (ThermalPolicy). HP's map, applied to this machine's reply `4A 01 3A 01 03 00 01 07 3C 00 03 00`:
+
+| Byte | Mask | HP's name | Here |
+|---|---|---|---|
+| `[0..1]` | 16-bit LE | `ShippingAdapterPowerRating` | **330 W** |
+| `[3]` | whole | `GetThermalPolicyVersion` | V1 |
+| `[4]` | `0x01` | `IsSwFanControlSupport` | true |
+| `[4]` | `0x02` | `IsExtremeModeSupport` | **true** |
+| `[4]` | `0x04` | `IsExtremeModeUnlock` | **false** |
+| `[4]` | `0x08` | `IsDTBiosControl` | false |
+| `[4]` | `0x10` | **`IsTwoBytePL4Support`** | **false** |
+| `[5]` | whole | `PL4DefaultValue` | 0 |
+| `[6]` | `0x01` | `IsBiosDefinedOcSupport` | true |
+| `[7]` | — | `GpuModeSwitch` | `0x07` |
+| `[8]` | whole | `DefaultCpuPowerLimitWithGpu` | **60 W** |
+| `[9]` | `0x0F`/`0xF0` | `LoadLineSupportLevels` / `DefaultLoadLine` | 0 / 0 |
+| `[10]` | `0x01`,`0x02`/`0x04`/`0x08` | `ChangeIrSensorToBoard` / `IsPchOverheatSupport` / `IsVrSensorSupport` | false / false / false |
+| `[11]` | `0x01`/`0x02` | `IsHotkeySupportFnP` / `IsHotkeySupportFnF1` | false / false (but true by board table) |
+
+**Work items:**
+
+- **T1.11** Decode the full block into a typed struct. **`IsTwoBytePL4Support` is the one that matters beyond this board** — it changes the wire format of `Default 0x29 SetPL4`. Getting it wrong is a silent write-corruption class of bug on any board where the bit is set.
+- **T1.12** Expose `ShippingAdapterPowerRating` alongside T1.4's connected wattage. Together they give the app both halves of the comparison the firmware is making — required wattage vs actual — which is what lets a replacement size a TGP against the real ratio instead of accepting HP's binary verdict.
+- **T1.13** Note `IsExtremeModeSupport = true` with `IsExtremeModeUnlock = false`. Unexplained; findings §3c calls tracing `IsExtremeModeUnlock`'s consumers the most promising unexplored lead in that section. Record, don't act.
+- **T1.14** HP caches this block at `HKCU\Software\HP\OMEN Ally\Settings\SystemDesignData` and **never invalidates it** — not even on a BIOS update (findings §0a). If we ever read that key as a convenience, treat it as a convenience only; prefer the live `0x28`.
+
+### 3.6 Model database entry
+
+- **T1.15** Update the `8D87` entry with what is now known:
+  - Thermal policy **V1** (measured — `0x28` byte 3 = `0x01`). Cross-check against `HpWmiBios`'s `Contains("MAX") && Contains("OMEN")` V2 force-switch, which `ROADMAP_v4.0.0.md:256` already flags as a broad name-substring match rather than a per-ProductId decision. **These may currently disagree on this board.**
+  - Fan tachometers at EC `0x70` (`FASP`) and `0x5C`, both 16-bit raw rpm, corroborated against
+    `Default 0x2D` at four operating points. **Not `0x7E`** — that is a commanded setpoint, a strict
+    function of the level byte at `0x5B`, and it reads 0 whenever nothing has been commanded even
+    while the fans turn. Same for `0x5E` (fan 2's setpoint, always `0x7E` + 200); there is no third
+    fan. Measured across all 28 EC captures in the research tree.
+  - **`0x9F` is `BRC0`, battery remaining capacity in mAh** — not a GPU tachometer. OmenMon-Reborn has this wrong on `8D87` and is showing its users battery charge in the GPU RPM field. Worth reporting upstream; OmenCore has not inherited the error, so this is a note, not a fix.
+  - `SupportsEcPowerLimits` stays **false**. `SupportsUndervolt` stays **false** (AMD, no Intel MSR path).
+  - `MaxModeDropChecksBeforeReapply = 1` is already present and is independently corroborated by the observed `MODE` decay.
+- **T1.16** Add the sibling board IDs `8D88`, `8DD5`, `8DD6` (HP platform `Vibrance25C1`, findings §3a) as the **safety scope** for anything in Tier 3.
+  - **But note the deeper point:** findings §3a establishes that **no power decision in OGH is keyed on board ID.** HP gates power on the runtime `0x28` capability query; the board table gates only hotkeys, chassis and lighting. This repo's per-board capability model has no counterpart in HP's own software. Use the board list to scope *raw offsets*, and prefer `0x28` for *capability*.
+
+---
+
+## 4. Tier 2 — the CPU 25 W clamp. Mostly built, plumbing is dead.
+
+**Evidence:** measured end-to-end with RyzenAdj v0.19.0 on the physical machine (§7m). 25.02 W → 45.73 W → ~51 W sustained / 60.7 W peak.
+
+The strongest single piece of evidence in the entire investigation is here and worth restating: raising `stapm` + `fast` + `slow` but **not** `apu-slow` produced a hard ceiling at ~46 W, which is exactly the untouched `PPT LIMIT APU = 45`. A cap landing precisely on the one limit left unraised is a much better check that these are the real controls than any single before/after number.
+
+**And the EC does not fight back here.** Unlike `PROH` and `OGHP`, the SMU limits were still set a minute later, and the EC's own mailbox block went on reading 25/25 while the SMU ran at 100/125 — they demonstrably disagree, and the SMU wins. No hold thread, no race.
+
+**Work items:**
+
+- **T2.1 (blocker)** Fix `RyzenSmu.Initialize()`. It opens a PawnIO handle but never calls `pawnio_load`, so `ioctl_pci_read_config_dword` / `ioctl_pci_write_config_dword` have no module behind them. Compare `PawnIOEcAccess.LoadEcModule()`, which does load `LpcACPIEC`. **This is a confirmed defect, not a hypothesis** — `RyzenSmu.cs:102-104` resolves only `pawnio_open`/`pawnio_execute`/`pawnio_close`, and it is the only PawnIO consumer in the repo that skips `pawnio_load`. Gate the fix so it does not enable an untested path for every AMD board.
+- **T2.2** Add `fast-limit`, `slow-limit`, `apu-slow-limit` alongside the existing `SetStapmLimit`. Message IDs must come from RyzenAdj's Strix Point table — **do not guess them**, and do not infer them from the existing `0x14`/`0x31` stapm pair.
+- **T2.3** Raise `SetStapmLimit`'s clamp. It currently caps at 54,000 mW (`AmdUndervoltProvider.cs:302`); the measured target is 100 W with a 125 W fast limit. Pick the new ceiling deliberately and document why.
+- **T2.4** **Do not raise TDC/EDC.** With the four power limits raised the part becomes current-bound at 53.977 A against a 54.000 A limit. §7m's argument for leaving it alone is sound and should be preserved verbatim in the code comment: a power limit is self-limiting (throttle or brownout, both fixed by a reboot); a current limit governs how hard the VRM is driven, and sustained overcurrent is not self-correcting. Every write in that investigation used a value the firmware writes itself; we don't know what TDC/EDC read on the 330 W adapter.
+- **T2.5** Re-assert after power-source changes, sleep/resume, and adapter swaps — the EC recomputes everything on those transitions. Steady-state operation needs nothing.
+- **T2.6** Verify by measured APU package power, not by SMU return code. Windows exposes `\Energy Meter(Apu Power)\Power` in milliwatts (also `CPU Power`, `GPU Power`, `NPU Power`). The separate `Power Meter` counter set reads all-zero on this machine — do not use it.
+- **T2.7** Do not attempt to reproduce HP's mechanism. How the EC gets 25 W into the SMU is still unknown and is excluded from AML, AMD PMF, NVPCF/Dynamic Boost, Windows PPM, HP's userland, and the EC mailbox block — leaving SMM as the surviving hypothesis. It is a curiosity, not a blocker.
+
+---
+
+## 5. Tier 3 — the adapter gate. Transport decided; write path still gated.
+
+This is "ungating the power adapter issue", and the mechanism is fully solved and demonstrated. **As of 2026-08-04 the transport question is also settled** (§5.1): the ports alias for reads and are fast enough for both levers. What remains gated is narrower — confirming the aliasing holds for *writes* and on a second adapter state, and building a hold path that does not inherit `PawnIOEcAccess.WriteByte`'s per-call sleep.
+
+### 5.1 The transport problem
+
+`PROH` (`0x90`) and `OGHP` (`0x59` bit 1) live in the EC's **memory-mapped** window at `0xFE700600`. The investigation wrote them with `inpoutx64` + `Marshal.WriteByte`.
+
+OmenCore cannot do that:
+
+- WinRing0/inpoutx64 were **deliberately removed** from this project over Defender's `VulnerableDriver:WinNT/Winring0` detections (`CHANGELOG.md:34, 840, 879`). Reintroducing them reverses a decision made for good reasons and would re-break every user who upgraded to escape those alerts.
+- The bundled PawnIO module is `LpcACPIEC`, which whitelists exactly ports `0x62`/`0x66` and cannot touch physical memory.
+
+**Three options, in order of preference:**
+
+**Option A — test the aliasing first. Read-only, cheap, and it decides everything.**
+
+> [!IMPORTANT]
+> **T3.1 has now been run. The ports alias the MMIO window for reads, and the latency objection
+> below did not survive measurement.** Full method and limits:
+> ``../investigation/08-ec-port-aliasing.md``; distilled in
+> ``../reference/settled-negatives.md``.
+
+- **T3.1 — DONE (2026-08-04).** Three runs sandwiching a PawnIO/`LpcACPIEC` port sweep between two MMIO captures, so that only bytes which held still across the whole window got a vote. **100 % / 100 % / 99.6 % agreement on judged bytes; 8 of 8 entropy-carrying anchors matched**, including both fan tachometers at 3000 rpm under deliberate CPU load and `PROH` itself. Correlation falls from 99.6 % at shift 0 to ~33 % at ±1 byte, which is what rules out coincidental resemblance rather than mere agreement. The one diverging byte was a temperature sensor that ticked mid-sweep — tracked across all three runs and explained, not waved away.
+  - The warning not to accept partial agreement was honoured: §7h's withdrawn `CPUT`/`0x57` argument rested on a single static byte, and that argument is **not** what re-established this.
+  - The port path here is byte-for-byte the one `PawnIOEcAccess.ReadByte` uses, so this is a result about the shipping code path.
+  - **Reads only, one adapter state (330 W).** Writes through the ports remain unproven, and the anchors should be re-checked on the 200 W supply — where `PROH` → 2 and `P3TV` → 185 — before this is more than provisional. Two agreeing states is the `HPBA` error.
+
+`PROH` and `OGHP` are therefore addressable through the module OmenCore **already ships**, and Stage 2 costs an allowlist entry plus a hold thread.
+
+**The caveat that was expected to be decisive, and what measurement did to it.** The plan predicted the port protocol would be far slower than an MMIO store, making `OGHP` unreachable. Measured over 200 samples: PawnIO's bare ioctl round trip is **~6 µs**, and a full EC read transaction is **0.325 ms median** (p95 1.86 ms, max 4.03 ms).
+
+| Target | Reassert cadence | Predicted | **Measured** |
+|---|---|---|---|
+| `PROH` | ~100 ms | Plausible | **~300 transactions per cycle.** Comfortable. |
+| `OGHP` | EC clears it on 98 % of 2 ms cycles | Very unlikely | **~6 transactions per window.** Feasible. |
+
+**So the transport is not the barrier — `PawnIOEcAccess` is.** `WriteByte` (`PawnIOEcAccess.cs:530-533`) ends every write with `Thread.Sleep(1)` and acquires the `Global\Access_EC` mutex per call. `Thread.Sleep(1)` yields the rest of a scheduler quantum — commonly 1–15 ms — which alone can exceed the entire `OGHP` hold window. A hold loop needs a dedicated path that takes the mutex once for its duration and omits the per-write sleep. **That is an application-layer fix, not a transport limitation**, and it is the single most consequential thing this test changed.
+
+Two operational notes for any hold loop: port reads time out on 1–3 % of offsets at randomly varying addresses, so retry rather than single-shot; and the `OGHP` p95 of 1.86 ms means a minority of iterations overrun 2 ms — tolerable, since the MMIO race already loses ~98 % of cycles and is won by repetition, but it means the loop is measured by `enforced ≥ 170 W` and never by iteration count.
+
+**Option B — a custom PawnIO module** exposing that one physical page, allowlisted to the two offsets. Technically the right answer. Friction is module signing: official PawnIO modules are signed by the project author. **Needs verifying** whether the release driver loads third-party modules, or whether upstreaming an `HpOmenEcMmio` module is the realistic path.
+
+**Option C — accept Stage 1 as out of scope in-app**, and keep `OGHP` arming as a documented external step (the investigation's `Invoke-OmenArm.ps1`). Least satisfying, but honest, and it still leaves Stage 2 and Tier 2 fully in-app if Option A succeeds.
+
+### 5.2 Design rules that apply regardless of transport
+
+These come from the investigation's own retractions. They invert how parts of this codebase currently work.
+
+**5.2.1 — Verify by outcome, never by readback of what we wrote.**
+`GC22` returns `RTCD = 0` whether or not the driver was listening. §7o records the exact failure: a textbook-clean `GC22` with `CTGP = 1`, `DTGP = 1`, `RTCD = 0` — and `enforced` still at 80 W, because the driver's `_DSM` re-read landed on one of the EC's zeros. The tool reported that as `GRANTS RESTORED`. It now requires `enforced ≥ 170 W`.
+
+That was the **fourth** wrong-reference false positive in that investigation, after `P3TV`, the `STABLE` bug, and the retracted `Default 0x10` arming command. The recurring error is checking the request instead of the outcome.
+
+`HpWmiBios.VerifyGpuPowerReadback` (`HpWmiBios.cs:986-1006`) is precisely this pattern. It is fine for what it currently does, but **must not** be the verification for anything in this tier. Verification means delivered watts, via NVAPI (`NvapiService` already exists) or `nvidia-smi`.
+
+**5.2.2 — This is a resident agent, not a one-shot.**
+- No stage survives a reboot. `_REG` zeroes the grants ~2 s into boot, before any userland exists.
+- Stage 2's 175 W **reverts spontaneously while idle** — `_Q73` re-runs on EC events and power-state transitions, re-deriving the limit from whatever `PROH` then reads. An earlier revision of the doc concluded from a single 20 s observation that the unlock was durable; that was retracted.
+- Stage 3 survives steady state but not a power-source change.
+
+So: a supervised re-applier with hooks on adapter change, resume, and a slow watchdog. Not a button.
+
+**5.2.3 — Safety gating is not optional here.**
+Forcing 175 W on a 200 W supply is out-of-spec by design. §7j observed the GPU entering a degraded state after a forced unlock — `nvidia-smi` at 23–27 s per call, FurMark unable to render — which **persisted after the manipulation stopped** and cleared only on reboot, on a machine with a history of `nvlddmkm` power-IRP BSODs. The GPU-under-load comparison at forced `PROH = 1` is therefore **unmeasured**, not merely unfavourable.
+
+Requirements: explicit opt-in with the risk stated plainly; adapter wattage from T1.4 so the feature can offer a **proportional** cap against the real supply rather than all-or-nothing 175 W; and a rollback path.
+
+**5.2.4 — Board scoping.**
+Every offset here (`0x59`, `0x90`, `0xE6`, `0xF6`/`0xF7`) came from *this* DSDT. Gate on `8D87` + `8D88`/`8DD5`/`8DD6`, never generally. This is the same class of error as `PowerLimitController`'s `0xC0`–`0xC5` and OmenMon-Reborn's `0x9F`.
+
+**5.2.5 — EC access discipline.**
+`PawnIOEcAccess` already has the `Global\Access_EC` mutex. OmenMon-Reborn additionally uses a graduated spin → yield → sleep backoff (added after relentless polling was implicated in ACPI-timeout BIOS panic shutdowns, their issue #88) and a torn-read guard requiring two consecutive identical 16-bit reads (their issue #86). A hold loop running at tens of Hz makes both of those relevant to us for the first time.
+
+### 5.3 Work items (conditional on T3.1)
+
+- **T3.2** MMIO or port-based access to the two offsets, single-purpose and allowlisted. Follow the investigation's pattern: `Write-EcProh.ps1` writes `0x90` **only** — the offset is not a parameter. Fan control (`MFAN` at `0x4A`), thermal trip points and battery charge parameters share the same 256-byte window.
+- **T3.3** Stage-2 unlock: hold `PROH = 1`, fire `GC22` to run `_Q73`, release. Verify against delivered watts. Re-apply on revert.
+- **T3.4** Stage-1 arm, **only if** a fast enough transport exists: hold `OGHP` (mask `0x02`, preserving `DBST` at bit 4 — it is a read-modify-write, unlike `PROH`) from a ≤2 ms loop, fire `GC22` inside the window, release. Measured minimums: 2 ms hold, 5000 ms settle before re-read. 5 ms hold fails; 1200 ms settle fails.
+- **T3.5** Proportional TGP mode: read the connected wattage (T1.4), pick a cap the supply can plausibly sustain, apply it driver-side rather than requesting the full 175 W. This is the *responsible* version of the feature and it is only possible because `Legacy 0x0F` exposes a real number.
+
+---
+
+## 6. Explicitly do not
+
+**The full list of settled dead ends lives in one place:
+``../reference/settled-negatives.md``.** Read it before proposing
+any experiment on this board — it also records two claims that were retracted and then
+*un*-retracted, which is the layer most likely to be read wrong.
+
+Specific to this repo, on top of that list:
+
+- **Do not** add EC power offsets `0xC0`–`0xC5` for this board. `SupportsEcPowerLimits` stays `false`.
+- **Do not** look for an EC register map in OGH's binaries. There is none — a grep across all four decompiled roots for `0xFE7006*`, `EmbeddedController`, `Ec{Read,Write}`, `LpcACPIEC` and raw port I/O returns zero hits. HP reaches the EC only through AML `GCxx` and the SMU only through AMD's own driver.
+- **Do not** investigate `hpomencustomcapdriver.sys`. It imports exactly `DbgPrintEx` and `RtlCopyUnicodeString` plus WDF loader stubs — no `MmMapIoSpace`, no port I/O, no `IoCreateDevice`. It is a stub and cannot touch the EC by construction. (`HpReadHWData.sys` is the one that is *not* a stub — see ``../investigation/06-hpreadhwdata-driver.md``.)
+- **Do not** raise TDC/EDC.
+- **Do not** reintroduce WinRing0 or inpoutx64. Note the upstream investigation's own `tools/lever/` scripts use `inpoutx64` for MMIO — **that does not port here**, and this repo removed it deliberately over Defender detections.
+
+Three from the shared list are worth repeating because they are easy to re-derive from the code:
+
+- **Do not** try to write `DSTA` directly via `GC22`. It sets `DSTA` and then calls `_Q73`, which overwrites it from `PROH`. Measured on both adapters.
+- **Do not** treat `EWDS` (mailbox `0x0E`) as a size field. Declared once, referenced by no AML, reads 0 in 1666/1666 captured events.
+- **Do not** treat `Default 0x28` as *connected* adapter state — it is byte-identical on 330 W and 200 W, and describes the SKU. But it is **not** contentless: `byte[0..1]` is `ShippingAdapterPowerRating` in watts (330 here), and `Legacy 0x0F` `byte[3] × 5` gives the connected rating. See ``../reference/wmi-commands.md``.
+
+---
+
+## 7. Open questions
+
+Carried forward from both documents, with our own added.
+
+**Blocking for us:**
+
+1. **Do ports `0x62`/`0x66` alias the MMIO window for *writes*, and on a second adapter state?** They do alias for **reads** — measured, three sandwiched runs; see §5.1 and ``../investigation/08-ec-port-aliasing.md``. The write direction is unproven, and nothing may write EC RAM through the ports until it is closed.
+2. **Does the PawnIO release driver load third-party modules?** Decides Option B. **Now much less urgent** — Option A succeeded, so Option B is no longer on the critical path for either stage.
+3. **Does the `OGHP` race actually win over ports?** Feasible on the latency numbers; unproven in fact. Requires the dedicated hold path described in §5.1.
+
+**Carried from the investigation, unresolved:**
+
+4. **How does OGH set `OGHP` durably?** OGH's arm stays up until the app is killed; ours is cleared on 98% of 2 ms cycles. The EC treats OGH's arm as authoritative and ours as noise. Not a blocker (a momentary hold suffices) but it is the one OGH behaviour that cannot be reproduced, only worked around. Every `GCxx` command OGH has been observed to send is a 0-arg read, so passive mailbox capture is the wrong instrument.
+5. **What transports the EC's 25 W decision into the SMU?** SMM is the surviving hypothesis. Not needed — the SMU limits are directly writable.
+6. **Why does `GC22`-zeroing give 80 W while `_REG`-zeroing gives 105 W?** Both set `CTGP = DTGP = 0`. 105 W is explained (base TGP, adder absent); 80 W is not. Suggests the historical 80 W baseline was never the clean "grants revoked" state it was taken for.
+7. **`OTPP`** — a one-shot arbitrary override of `ATPP`, consumed on use, writable in the same SSDT scope as `MODE`/`CTGP`/`DTGP`. Finest-grained lever found. Untested.
+8. **PPAB values above 1** — OmenCore's `Extended3`/`Extended4` pass `ppab = 2`/`3`, documented as "+25 W or more (RTX 5080+)". Unverified on this board, and there is no headroom to expose them while `enforced` already equals `power.max_limit`.
+9. **Why is NVPCF variant A selected?** Eight `Nvd*` SSDTs ship; something picks one. If it is a setup variable, that is a directly writable lever.
+10. **`STS0` at EC `0xBB`** — the one surviving unexplained adapter-keyed byte, and suspect by association after `HPBA` was retracted.
+11. **The V2 fan-command force-switch.** `HpWmiBios` switches this board to V2 fan commands via a `Contains("MAX") && Contains("OMEN")` name-substring match, but `0x28` byte 3 reports thermal policy **V1**. `ROADMAP_v4.0.0.md:256` already flags the substring match as a problem. Do these disagree on `8D87`?
+
+---
+
+## 8. Suggested sequencing
+
+**Phase 0 — decide the transport. ✅ DONE (2026-08-04).** T3.1 came back positive: the ports alias for reads and the transport is fast enough for *both* levers, not just `PROH`. Tier 3 exists. Two things moved as a result — Option B (custom PawnIO module) leaves the critical path, and the `OGHP` blocker is now a wrapper fix (`Thread.Sleep(1)` + per-call mutex in `PawnIOEcAccess.WriteByte`) rather than a transport dead end. The remaining gate before any EC write is confirming the aliasing holds **for writes** and on a **second adapter state**.
+
+**Phase 1 — Tier 1.** T1.4 → T1.5 → T1.6 first: adapter awareness is the highest value-per-risk item in the whole plan, it is read-only, and it makes every subsequent field report better. Then T1.8/T1.9/T1.10 (payload correctness), T1.11/T1.12 (`0x28`), T1.15/T1.16 (model DB). T1.1/T1.2/T1.3 (`MODE`) last in this phase, since they are the first real behaviour change.
+
+**Phase 2 — Tier 2.** T2.1 (verify, then fix `pawnio_load`) → T2.2/T2.3 → T2.6 (verification harness) → T2.5. This is the biggest measured user-facing win (25 → 51 W CPU) and it needs no EC writes and no races.
+
+**Phase 3 — Tier 3.** Phase 0 succeeded, so this is live. T3.2 → T3.3 (Stage 2) → T3.5 (proportional). **T3.4 (Stage 1) is no longer conditional on transport speed** — 0.325 ms per transaction clears the 2 ms window — but it does depend on the dedicated hold path in §5.1, and it stays behind the safety gating in §5.2.3 regardless.
+
+Phases 1 and 2 are independent and can run in parallel. Phase 3 benefits from T1.4 and is now gated on write-side confirmation rather than on Phase 0.

--- a/docs/8D87-VERIFICATION-CHECKLIST.md
+++ b/docs/8D87-VERIFICATION-CHECKLIST.md
@@ -1,0 +1,128 @@
+# Board 8D87 — what is verified, and what is not
+
+`ModelCapabilities.UserVerified` is a single flag over a profile with ~20 fields. On board `8D87`
+every board-specific claim in the entry has now been confirmed on real hardware, so the flag is
+**true**.
+
+It did not start that way. This document was written while fan curves and performance modes were
+still inherited from the adjacent MAX generation, and it recorded the flag as `false` on the rule
+below that the flag is all-or-nothing. Those rows have since been measured — see
+[Was not verified, now is](#was-not-verified-now-is) — and the flag was flipped in the same commit
+that measured the last of them.
+
+This document says exactly which claim rests on what, so the next person does not have to re-derive
+it, and so that the flag is a decision with a checklist behind it rather than a guess.
+
+## Verified on hardware
+
+Board `8D87`, HP OMEN MAX 16-ak0098nr, BIOS **F.07**, EC **40.38**, by the machine's owner,
+2026-08-01..05. Method was ACPI decompilation plus live measurement, cross-checked against three
+physical power adapters, the EC tachometers and OMEN Gaming Hub's own readout.
+
+| Field | How it was established |
+|---|---|
+| `SupportsEcPowerLimits = false` | The EC mailbox power block at `0xF5`–`0xF8` was forced to its high-power values with no effect on delivered watts — it is a mirror the SMU never reads back. |
+| `SupportsFanControlEc = false` | The EC is memory-mapped at `0xFE700600`, not at the legacy port offsets. The legacy register map does not apply. |
+| `SupportsUndervolt = false` | AMD Ryzen AI part; the Intel MSR undervolt path does not exist here. |
+| `MaxModeDropChecksBeforeReapply = 1` | Corroborated by the observed performance-mode decay on this machine. |
+| `Family`, `ModelYear`, `ProductId` | Firmware identification. |
+| Thermal policy | `Default 0x28` byte 3 reads `0x01` (V1). The app drives this board as V2 via a model-name force-switch; the diagnostics export prints both and flags the disagreement. See the caveat below. |
+| `FanZoneCount = 2` | `Default 0x10` returns 2, and two EC tachometers track independently. |
+| **`MaxFanLevel = 60`** | Measured, was 100. `0x2D` sampled against the EC tachometers and OGH's readout at four points — `0`/0, `22`/2220, `47`/4680, `60`/6000 rpm — linear within ~1 %. |
+| `SupportsRpmReadback = true` | Same four samples; the V1 `0x2D` level tracks the tachometers at every point. |
+| **`HasPerKeyRgb = true`** | Topology probe — class `0x00020008`, command `0x2B`, null input, 4-byte return — returns `0x03` = `RgbPerKey`, stable across repeated reads. |
+| `HasKeyboardBacklight = true` | Same probe: a lighting type is reported and it is neither `None` nor `Normal`. |
+| **`HasFourZoneRgb = false`** | Was defaulted `true`. HP's own `FourZoneHelper.IsSupported` returns false for lighting type 3, so the four-zone path does not drive a per-key keyboard. |
+| `HasMuxSwitch = true` | Inherited, now **measured** by switching modes and rebooting. In Discrete the internal panel is driven by the dGPU. See below. |
+| **`SupportsAdvancedOptimus = false`** | Was inherited `true`. There *is* a mux, but it is routed at boot — the Smart Mux block stays disabled through a working switch. See below. |
+
+### There is a mux; it is not Advanced Optimus
+
+These are two different claims and this board splits them. BIOS setup offers **Hybrid / Discrete /
+UMA**, taking effect on reboot; OMEN Gaming Hub exposes the same selector. Captured in Hybrid, in
+Discrete, and again after returning to Hybrid.
+
+| Reading | Hybrid | Discrete | Restored |
+|---|---|---|---|
+| `Legacy 0x52` | `00 00 00 00` | **`01 00 00 00`** | `00 00 00 00` |
+| `AMD_PBS_SETUP 0x05` Primary Video Adaptor | 1 = IGD | **2 = PEG** | 1 = IGD |
+| Internal panel driven by | Radeon 890M | **RTX 5080** | Radeon 890M |
+| `nvidia-smi display_active` | Disabled | **Enabled** | Disabled |
+| Smart Mux block (`0xB6`/`0xC7`/`0xC8`/`0xCA`) | all 0 | **all 0** | all 0 |
+
+**`HasMuxSwitch = true`** because the internal panel changes which GPU drives it — in Discrete the
+sole display is the built-in `CMN1652` at its native 2560×1600, attached to the RTX 5080, with the
+Radeon reporting no active mode. Reversible: the restored capture matches the baseline on every WMI
+and `AMD_PBS_SETUP` field.
+
+**`SupportsAdvancedOptimus = false`** because Advanced Optimus means the mux moves under **live ACPI
+control, without a reboot**, and the entire Smart Mux block reads zero in all three states. It stays
+off through a switch that demonstrably works, so the routing decision is taken at boot by firmware
+and there is no runtime control surface.
+
+`Default 0x28` byte 7 = `0x07` ("graphics switching supported") is a **capability bitmask, not the
+current mode** — byte-identical in all three states, so it describes the SKU family. Read the mode
+from `Legacy 0x52`.
+
+`Legacy 0x52` is genuine state rather than an ACPI timeout: a field that only ever returns zero
+cannot return `0x01`. The size-gate control agrees — `Default 0x28` returns code `5` at the 4-byte
+output size while `0x52` returns `0`, so the gate is live and `0x52`'s declared reply really is four
+bytes.
+
+No byte in the EC state window at `0xFE700600` tracks the mode; the 25 bytes that differ across the
+three captures are fan and thermal values, and none returns to its Hybrid value.
+
+Fan tachometers are at EC `0x70` (fan 1) and `0x5C` (fan 2). **`0x7E` is not a reliable second
+tachometer** — it reads 0 at every manual fan setting while that fan is spinning, and under auto it
+shadowed fan 1. `0x9F` is battery remaining capacity in mAh, **not** a GPU tachometer — a mistake
+other projects have made on this board. OmenCore has never carried it.
+
+### Caveat: this board is V1 and is driven as V2
+
+`Default 0x28` byte 3 reports thermal policy **V1**, and the firmware **rejects the V2 fan
+commands** — `0x37` returns `RTCD 6` and `0x38` returns `RTCD 4`, at every input and output buffer
+size. Fan levels reach the app only because `GetFanLevel()` falls back to the V1 command `0x2D`.
+
+That fallback is correct and works. But the model-name force-switch to V2 (`HpWmiBios.cs:858-866`)
+also drives `MaxFanLevel = 100` (`:931-935`), which is wrong here because V1 levels are krpm/100.
+This entry now sets `MaxFanLevel = 60` explicitly, and the model override returns from
+`DetectMaxFanLevel` **before** the V2 branch, so the correct value is what takes effect. The
+underlying force-switch logic is untouched and still affects any OMEN MAX board without an entry.
+
+## Was not verified, now is
+
+These three rows were the reason this document originally kept `UserVerified = false`. All three
+have since been measured on the hardware.
+
+| Field | Then | Now |
+|---|---|---|
+| `PerformanceModes` | inherited, included `"L5P"` | Measured in **delivered watts**, not return codes, with the `OGHP` gate armed: `Default 0x30` → ~102 W, `Performance 0x31` → 175.00 W, `Cool 0x50` → ~103 W. `SetFanMode` writes `NPCF.MODE` and the firmware consumes `(MODE & 0x0F)`, so Default and Cool both select nibble 0 and deliver the same power profile — Cool differs as *fan* policy, not as a power tier. All three bytes return `RTCD 0`, including the two that select the same profile, so acceptance was never the evidence. **`"L5P"` removed:** there is no such member in `HpWmiBios.FanMode`, so `SetPerformanceMode("L5P")` fell through to `FanMode.Default` — asking for L5P silently gave you Default. |
+| `SupportsFanCurves = true` | inherited | Verified by RPM readback against the EC tachometers, not by return code. |
+| `SupportsIndependentFanCurves = false` | inherited | Confirmed impossible on this board, so the `false` is now a measurement rather than a default. |
+
+Method note worth keeping: `Performance` was re-run as a **positive control between every pair of
+readings**, because a decayed `OGHP` gate reads 80.00 W and would otherwise masquerade as MODE 0.
+Without that control the Default/Cool result would have been indistinguishable from a gate that had
+simply lapsed mid-measurement.
+
+## Rules for this entry
+
+- **Verify by outcome.** A WMI command returning success does not mean the hardware did anything.
+  For fan claims that means RPM readback; for power claims, watts. On this platform `RTCD == 0` is
+  especially weak evidence — the ACPI returns `0` on its own timeout path.
+- **Reads can be corrupted by OMEN Gaming Hub.** The EC command mailbox is a single shared buffer
+  with no locking between OS agents, and OGH polls it continuously. During this verification,
+  repeated identical reads returned OGH's replies to *its* questions until OGH was stopped. Prefer
+  the EC tachometers (direct MMIO) for fan cross-checks, and distrust a value that changes between
+  back-to-back identical reads.
+- **`RTCD = 5` means the output buffer was the wrong size,** not "unsupported". A genuine rejection
+  persists across every buffer size.
+- **The flag is all-or-nothing.** It was flipped only once every board-specific row was measured. If
+  a future field is added to this entry by inheritance rather than measurement, `UserVerified` goes
+  back to `false` until it is checked. If the flag ever gains per-field granularity, revisit this.
+- **What `UserVerified = true` does not claim.** It covers the board-specific fields in this entry.
+  Fields that are platform-generic and untested here — `SupportsNetworkBoost`, and anything driven by
+  a subsystem this board routes elsewhere — are not evidence-backed by the flag.
+- **Do not widen to sibling boards.** `8D88`, `8DD5` and `8DD6` share this platform's firmware but
+  none of them has been measured. See `ModelCapabilityDatabase.Vibrance25C1BoardIds`, which is a
+  scope list for raw EC offsets and explicitly not a capability claim.

--- a/src/OmenCoreApp.Tests/Hardware/EcFanTachometerTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/EcFanTachometerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -35,6 +36,46 @@ namespace OmenCoreApp.Tests.Hardware
             {
                 ReadAddresses.Add(address);
                 return _bytes.TryGetValue(address, out var b) ? b : (byte)0x00;
+            }
+
+            public void WriteByte(ushort address, byte value) { }
+            public void Dispose() { }
+        }
+
+        /// <summary>
+        /// EC stub driven by a script of per-tick outcomes: a null entry throws the way a busy
+        /// ACPI EC port pair does, a tuple serves that fan pair. The last entry repeats once the
+        /// script runs out, so "fails once then works" and "never works" are both expressible.
+        /// </summary>
+        private sealed class ScriptedEcAccess : IEcAccess
+        {
+            private readonly Queue<(int fan1, int fan2)?> _script;
+            private (int fan1, int fan2)? _current;
+
+            public ScriptedEcAccess(params (int fan1, int fan2)?[] ticks)
+                => _script = new Queue<(int fan1, int fan2)?>(ticks);
+
+            public List<ushort> ReadAddresses { get; } = new();
+            public bool IsAvailable => true;
+            public bool Initialize(string devicePath) => true;
+
+            public byte ReadByte(ushort address)
+            {
+                ReadAddresses.Add(address);
+
+                // A tick begins at the first tachometer's low byte.
+                if (address == 0x70 && _script.Count > 0)
+                {
+                    _current = _script.Dequeue();
+                }
+
+                if (_current is null)
+                {
+                    throw new TimeoutException("EC output buffer not full");
+                }
+
+                var rpm = address is 0x70 or 0x71 ? _current.Value.fan1 : _current.Value.fan2;
+                return address is 0x71 or 0x5D ? (byte)(rpm >> 8) : (byte)(rpm & 0xFF);
             }
 
             public void WriteByte(ushort address, byte value) { }
@@ -200,6 +241,79 @@ namespace OmenCoreApp.Tests.Hardware
 
             ec.ReadAddresses.Should().BeEmpty();
             fans[0].SpeedRpm.Should().Be(2000);
+        }
+
+        [Fact]
+        public void OneFailedTransaction_DoesNotDisableTheTachometerForTheSession()
+        {
+            // Measured on 8D87: the app logged a single "EC output buffer not full" 39 seconds
+            // after start and, because the first failure was treated as permanent, spent the
+            // next eight minutes on the fan-level estimate - including a full verification run,
+            // which then scored six passes on evidence that was the commanded level echoed back.
+            // The port pair is shared with the firmware's own traffic; one refusal is contention.
+            var ec = new ScriptedEcAccess(null, (2760, 2220));
+
+            using var controller = CreateController(ec, new ushort[] { 0x70, 0x5C });
+
+            var duringFailure = Read(controller);
+            duringFailure[0].RpmSource.Should().Be(RpmSource.Estimated, "the tick itself has no reading");
+
+            var afterRecovery = Read(controller);
+            afterRecovery[0].SpeedRpm.Should().Be(2760);
+            afterRecovery[0].RpmSource.Should().Be(RpmSource.EcDirect, "the next tick must try again");
+        }
+
+        [Fact]
+        public void SustainedFailures_StopHammeringTheEc()
+        {
+            // The other half of the trade: retrying every tick forever would amplify exactly the
+            // contention that caused the failure. After a short run of failures it backs off, so
+            // an EC that genuinely will not answer costs almost no traffic.
+            var ec = new ScriptedEcAccess(null, null, null, null, null);
+
+            using var controller = CreateController(ec, new ushort[] { 0x70, 0x5C });
+
+            for (var tick = 0; tick < 8; tick++)
+            {
+                Read(controller);
+            }
+
+            ec.ReadAddresses.Count.Should().BeLessThan(8, "the backoff must actually stop the traffic");
+            ec.ReadAddresses.Should().OnlyContain(a => a == 0x70, "a tick that throws never reaches the second byte");
+        }
+
+        [Fact]
+        public void OneImplausibleReading_IsDiscardedAsATornRead_NotAsWrongOffsets()
+        {
+            // A tachometer is two separate byte transactions, so a single absurd pair can be a
+            // read torn across an EC update. Writing the offsets off on the strength of one is
+            // the same over-reaction as giving up after one timeout.
+            var ec = new ScriptedEcAccess((65535, 65535), (2760, 2220));
+
+            using var controller = CreateController(ec, new ushort[] { 0x70, 0x5C });
+
+            Read(controller)[0].RpmSource.Should().Be(RpmSource.Estimated);
+            Read(controller)[0].SpeedRpm.Should().Be(2760, "one bad pair is not proof the offsets are wrong");
+        }
+
+        [Fact]
+        public void RepeatedImplausibleReadings_WriteOffTheOffsetsForGood()
+        {
+            // A run of them is proof. Offsets pointed at something that is not a tachometer -
+            // 0x34/0x35 on this board's neighbours land in an ASCII serial number - must be
+            // abandoned rather than retried, because they will read "fine" forever.
+            var ec = new ScriptedEcAccess((65535, 65535), (65535, 65535), (65535, 65535), (2760, 2220));
+
+            using var controller = CreateController(ec, new ushort[] { 0x70, 0x5C });
+
+            for (var tick = 0; tick < 3; tick++)
+            {
+                Read(controller);
+            }
+
+            var afterGivingUp = Read(controller);
+            afterGivingUp[0].SpeedRpm.Should().Be(2000, "the offsets are written off; this is the level estimate");
+            afterGivingUp[0].RpmSource.Should().Be(RpmSource.Estimated);
         }
 
         [Fact]

--- a/src/OmenCoreApp.Tests/Hardware/EcFanTachometerTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/EcFanTachometerTests.cs
@@ -1,0 +1,216 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using OmenCore.Hardware;
+using OmenCore.Models;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Hardware
+{
+    /// <summary>
+    /// Board 8D87 reported 0 RPM in the UI while its fans turned at 2760. The V2 command
+    /// GetFanRpmDirect (0x38) is refused there, leaving GetFanLevel x 100 as the only RPM
+    /// source - and that is the *commanded* level echoed back, which reads 0 under BIOS
+    /// automatic control because nothing has been commanded.
+    ///
+    /// These pin the EC tachometer path that fixes it: that it is preferred over the level
+    /// estimate rather than used only as a last resort, that it decodes 16-bit little-endian,
+    /// that a genuine zero survives as a zero, and that a model without configured offsets
+    /// behaves exactly as before.
+    /// </summary>
+    public class EcFanTachometerTests
+    {
+        /// <summary>EC stub serving a fixed byte map; records every address read.</summary>
+        private sealed class MapEcAccess : IEcAccess
+        {
+            private readonly Dictionary<ushort, byte> _bytes;
+
+            public MapEcAccess(Dictionary<ushort, byte> bytes) => _bytes = bytes;
+
+            public List<ushort> ReadAddresses { get; } = new();
+            public bool IsAvailable { get; init; } = true;
+            public bool Initialize(string devicePath) => true;
+
+            public byte ReadByte(ushort address)
+            {
+                ReadAddresses.Add(address);
+                return _bytes.TryGetValue(address, out var b) ? b : (byte)0x00;
+            }
+
+            public void WriteByte(ushort address, byte value) { }
+            public void Dispose() { }
+        }
+
+        /// <summary>
+        /// V1 board: GetFanRpmDirect refused, GetFanLevel answers. Mirrors 8D87, where the
+        /// level is the thing that must NOT win over a tachometer.
+        /// </summary>
+        private sealed class V1FanLevelBios : IHpWmiBios
+        {
+            public (byte fan1, byte fan2)? Level { get; init; } = (20, 22);
+
+            public bool IsAvailable => true;
+            public string Status => "fake V1";
+            public HpWmiBios.ThermalPolicyVersion ThermalPolicy => HpWmiBios.ThermalPolicyVersion.V1;
+            public int FanCount => 2;
+            public int MaxFanLevel => 60;
+
+            // The board this models refuses 0x38 outright - that refusal is the whole reason
+            // the level estimate was ever load-bearing.
+            public (int fan1Rpm, int fan2Rpm)? GetFanRpmDirect() => null;
+            public (byte fan1, byte fan2)? GetFanLevel() => Level;
+
+            public bool SetFanMax(bool enabled) => true;
+            public bool SetFanLevel(byte fan1, byte fan2) => true;
+            public bool SetFanMode(HpWmiBios.FanMode mode) => true;
+
+            public double? GetTemperature() => 50;
+            public double? GetGpuTemperature() => 50;
+            public void ExtendFanCountdown() { }
+
+            public (bool customTgp, bool ppab, int dState)? GetGpuPower() => null;
+            public bool SetGpuPower(HpWmiBios.GpuPowerLevel level) => true;
+            public HpWmiBios.GpuMode? GetGpuMode() => null;
+
+            public void Dispose() { }
+        }
+
+        private static WmiFanController CreateController(
+            IEcAccess? ecAccess,
+            ushort[]? offsets,
+            IHpWmiBios? bios = null)
+            => new(
+                hwMonitor: null,
+                logging: null,
+                injectedWmiBios: bios ?? new V1FanLevelBios(),
+                ecAccess: ecAccess,
+                ecFanTachometerOffsets: offsets);
+
+        private static List<FanTelemetry> Read(WmiFanController controller)
+            => controller.ReadFanSpeeds().ToList();
+
+        [Fact]
+        public void Tachometers_AreReadAs16BitLittleEndian()
+        {
+            // 0x70/0x71 = C8 0A -> 2760; 0x5C/0x5D = AC 08 -> 2220. Taking only the low byte
+            // would give 200 and 172 - the exact failure a sibling probe script hit.
+            var ec = new MapEcAccess(new Dictionary<ushort, byte>
+            {
+                [0x70] = 0xC8, [0x71] = 0x0A,
+                [0x5C] = 0xAC, [0x5D] = 0x08
+            });
+
+            using var controller = CreateController(ec, new ushort[] { 0x70, 0x5C });
+            var fans = Read(controller);
+
+            fans.Should().HaveCount(2);
+            fans[0].SpeedRpm.Should().Be(2760);
+            fans[1].SpeedRpm.Should().Be(2220);
+        }
+
+        [Fact]
+        public void Tachometer_BeatsTheFanLevelEstimate()
+        {
+            // The level says 20 -> 2000 RPM. The tachometer says 2760. Preferring the level
+            // would replace a measurement with an echo of the last command.
+            var ec = new MapEcAccess(new Dictionary<ushort, byte>
+            {
+                [0x70] = 0xC8, [0x71] = 0x0A,
+                [0x5C] = 0xC8, [0x5D] = 0x0A
+            });
+
+            using var controller = CreateController(
+                ec, new ushort[] { 0x70, 0x5C }, new V1FanLevelBios { Level = (20, 20) });
+
+            var fans = Read(controller);
+
+            fans[0].SpeedRpm.Should().Be(2760, "the physical tachometer must win over level x 100");
+            fans[0].SpeedRpm.Should().NotBe(2000, "2000 is the commanded level echoed back, not a measurement");
+            fans[0].RpmSource.Should().Be(RpmSource.EcDirect);
+        }
+
+        [Fact]
+        public void StoppedFans_ReportZero_RatherThanFallingBackToTheLevel()
+        {
+            // The whole point of having a tachometer: when it says the fans are stopped, that
+            // is the answer, even though the firmware still remembers a non-zero level. Falling
+            // through to the level here would resurrect exactly the reading that made a fan
+            // change verifiable against its own request.
+            var ec = new MapEcAccess(new Dictionary<ushort, byte>
+            {
+                [0x70] = 0x00, [0x71] = 0x00,
+                [0x5C] = 0x00, [0x5D] = 0x00
+            });
+
+            using var controller = CreateController(
+                ec, new ushort[] { 0x70, 0x5C }, new V1FanLevelBios { Level = (35, 35) });
+
+            var fans = Read(controller);
+
+            fans[0].SpeedRpm.Should().Be(0);
+            fans[0].RpmSource.Should().Be(RpmSource.EcDirect, "a measured zero is still a measurement");
+            fans[0].SpeedRpm.Should().NotBe(3500, "3500 would be the level estimate leaking back in");
+        }
+
+        [Fact]
+        public void ImplausibleReading_IsRejected_AndFallsBackToWmi()
+        {
+            // A mis-aimed offset usually reads as something absurd rather than as an error.
+            // 0xFFFF is 65535 RPM; publishing it would be worse than falling back.
+            var ec = new MapEcAccess(new Dictionary<ushort, byte>
+            {
+                [0x70] = 0xFF, [0x71] = 0xFF,
+                [0x5C] = 0xFF, [0x5D] = 0xFF
+            });
+
+            using var controller = CreateController(
+                ec, new ushort[] { 0x70, 0x5C }, new V1FanLevelBios { Level = (20, 22) });
+
+            var fans = Read(controller);
+
+            fans[0].SpeedRpm.Should().Be(2000, "rejecting the EC read must fall back to the level estimate");
+            fans[0].RpmSource.Should().Be(RpmSource.Estimated, "and must be labelled as the estimate it is");
+        }
+
+        [Fact]
+        public void ModelWithoutConfiguredOffsets_TouchesTheEcNotAtAll()
+        {
+            // Every board that has not had its tachometers located must behave exactly as
+            // before - no new EC transactions on the monitoring cadence.
+            var ec = new MapEcAccess(new Dictionary<ushort, byte>
+            {
+                [0x70] = 0xC8, [0x71] = 0x0A
+            });
+
+            using var controller = CreateController(ec, offsets: null);
+            var fans = Read(controller);
+
+            ec.ReadAddresses.Should().NotContain(0x70);
+            fans[0].SpeedRpm.Should().Be(2000, "unchanged: the WMI fan-level estimate");
+            fans[0].RpmSource.Should().Be(RpmSource.Estimated);
+        }
+
+        [Fact]
+        public void UnavailableEcAccess_FallsBackWithoutThrowing()
+        {
+            var ec = new MapEcAccess(new Dictionary<ushort, byte>()) { IsAvailable = false };
+
+            using var controller = CreateController(ec, new ushort[] { 0x70, 0x5C });
+            var fans = Read(controller);
+
+            ec.ReadAddresses.Should().BeEmpty();
+            fans[0].SpeedRpm.Should().Be(2000);
+        }
+
+        [Fact]
+        public void TachometerOffsets_AreIndependentOfEcFanControlSupport()
+        {
+            // 8D87 has SupportsFanControlEc = false and readable tachometers. The two must not
+            // be coupled: one gates writes, the other is a read.
+            var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
+
+            caps.SupportsFanControlEc.Should().BeFalse();
+            caps.EcFanTachometerOffsets.Should().Equal(new ushort[] { 0x70, 0x5C });
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Hardware/HpWmiBiosAdapterDecodeTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/HpWmiBiosAdapterDecodeTests.cs
@@ -54,6 +54,27 @@ namespace OmenCoreApp.Tests.Hardware
         }
 
         [Fact]
+        public void DecodeAdapterData_Decodes_UsbC_Dock_Capture()
+        {
+            // Measured: 100 W USB-C PD dock on the same machine. 0x14 * 5 = 100.
+            //
+            // This is the capture the Type-C branch below was written against, and it is the one
+            // that shows why the branch cannot be simplified to the wattage comparison: the design
+            // rating reads 0 with the source live and negotiating 100 W, so the comparison is
+            // 100 < 0 and only the barrel special case reaches the right answer. The EC clamps the
+            // GPU to 35 W on this dock, so "under-rated" is the correct verdict to arrive at.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x05, 0xC2, 0x00, 0x14 });
+
+            decoded.Should().NotBeNull();
+            decoded!.Value.Status.Should().Be(HpWmiBios.SmartAdapterStatus.ConnectedTypeC);
+            decoded.Value.PowerRatingWatts.Should().Be(100);
+            decoded.Value.PowerRatingKnown.Should().BeTrue();
+            decoded.Value.UsbcDesignRatingWatts.Should().Be(0);
+            decoded.Value.SupportsBarrelConnector.Should().BeTrue();
+            decoded.Value.IsLowWattage.Should().BeTrue();
+        }
+
+        [Fact]
         public void DecodeAdapterData_Treats_0xFF_As_Unknown_Not_1275W()
         {
             // 0xFF is HP's "unknown" sentinel. Decoding it arithmetically would report 1275 W and

--- a/src/OmenCoreApp.Tests/Hardware/HpWmiBiosAdapterDecodeTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/HpWmiBiosAdapterDecodeTests.cs
@@ -1,0 +1,181 @@
+using FluentAssertions;
+using OmenCore.Hardware;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Hardware
+{
+    /// <summary>
+    /// Decode tests for the <c>Legacy 0x0F</c> adapter reply.
+    ///
+    /// The three 4-byte payloads used here are real captures from an OMEN MAX 16 (board 8D87,
+    /// BIOS F.07) taken with three physical adapters plugged into the same machine. They are the
+    /// reason this decode can be trusted: the wattage byte was checked against the printed rating on
+    /// three different supplies, not inferred from one.
+    /// </summary>
+    public class HpWmiBiosAdapterDecodeTests
+    {
+        [Fact]
+        public void DecodeAdapterData_Decodes_330W_Adapter_Capture()
+        {
+            // Measured: 330 W supply. 0x42 * 5 = 330.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x01, 0xC2, 0x00, 0x42 });
+
+            decoded.Should().NotBeNull();
+            decoded!.Value.Status.Should().Be(HpWmiBios.SmartAdapterStatus.MeetsRequirement);
+            decoded.Value.PowerRatingWatts.Should().Be(330);
+            decoded.Value.PowerRatingKnown.Should().BeTrue();
+            decoded.Value.UsbcDesignRatingWatts.Should().Be(0);
+            decoded.Value.SupportsBarrelConnector.Should().BeTrue();
+            decoded.Value.IsLowWattage.Should().BeFalse();
+        }
+
+        [Fact]
+        public void DecodeAdapterData_Decodes_280W_Adapter_Capture()
+        {
+            // Measured: 280 W supply. 0x38 * 5 = 280, and the firmware calls it below requirement.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x02, 0xC2, 0x00, 0x38 });
+
+            decoded.Should().NotBeNull();
+            decoded!.Value.Status.Should().Be(HpWmiBios.SmartAdapterStatus.BelowRequirement);
+            decoded.Value.PowerRatingWatts.Should().Be(280);
+            decoded.Value.IsLowWattage.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DecodeAdapterData_Decodes_200W_Adapter_Capture()
+        {
+            // Measured: 200 W supply. 0x28 * 5 = 200.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x02, 0xC2, 0x00, 0x28 });
+
+            decoded.Should().NotBeNull();
+            decoded!.Value.PowerRatingWatts.Should().Be(200);
+            decoded.Value.Status.Should().Be(HpWmiBios.SmartAdapterStatus.BelowRequirement);
+            decoded.Value.IsLowWattage.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DecodeAdapterData_Treats_0xFF_As_Unknown_Not_1275W()
+        {
+            // 0xFF is HP's "unknown" sentinel. Decoding it arithmetically would report 1275 W and
+            // make an unidentified supply look like the best-equipped machine in the field reports.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x01, 0xC2, 0x00, 0xFF });
+
+            decoded.Should().NotBeNull();
+            decoded!.Value.PowerRatingKnown.Should().BeFalse();
+            decoded.Value.PowerRatingWatts.Should().Be(0);
+        }
+
+        [Fact]
+        public void DecodeAdapterData_Reads_BarrelSupport_From_Bit7_Only()
+        {
+            // 0xC2 has bit 7 set; 0x42 is the same byte without it. Nothing else in byte 1 matters.
+            HpWmiBios.DecodeAdapterData(new byte[] { 0x01, 0xC2, 0x00, 0x42 })!
+                .Value.SupportsBarrelConnector.Should().BeTrue();
+
+            HpWmiBios.DecodeAdapterData(new byte[] { 0x01, 0x42, 0x00, 0x42 })!
+                .Value.SupportsBarrelConnector.Should().BeFalse();
+        }
+
+        [Fact]
+        public void DecodeAdapterData_Returns_Null_For_Short_Or_Missing_Payload()
+        {
+            HpWmiBios.DecodeAdapterData(null).Should().BeNull();
+            HpWmiBios.DecodeAdapterData(new byte[] { 0x01, 0xC2, 0x00 }).Should().BeNull();
+        }
+
+        // ── IsLowWattage: HP's own comparison, including the Type-C branch most tables miss ──
+
+        [Fact]
+        public void IsLowWattage_TypeC_Compares_Against_UsbcDesignRating_Not_The_Status()
+        {
+            // 100 W PD supply on a chassis designed for 140 W: under-rated, even though the status
+            // byte is ConnectedTypeC rather than BelowRequirement. Folding value 5 into
+            // "anything that isn't MeetsRequirement" would get the right answer here by accident and
+            // the wrong one in the next test.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x05, 0x00, 0x1C, 0x14 });
+
+            decoded!.Value.Status.Should().Be(HpWmiBios.SmartAdapterStatus.ConnectedTypeC);
+            decoded.Value.UsbcDesignRatingWatts.Should().Be(140);
+            decoded.Value.PowerRatingWatts.Should().Be(100);
+            decoded.Value.IsLowWattage.Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsLowWattage_TypeC_At_Design_Rating_Is_Not_Low_Wattage()
+        {
+            // 140 W PD on a 140 W design: adequate. This is the case a naive
+            // "status != MeetsRequirement" test gets wrong - it would warn the user about a supply
+            // that is exactly what the chassis was designed for.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x05, 0x00, 0x1C, 0x1C });
+
+            decoded!.Value.IsLowWattage.Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsLowWattage_TypeC_With_Barrel_Support_And_Zero_Design_Rating_Is_Low_Wattage()
+        {
+            // HP's special case: a barrel-capable chassis reporting no USB-C design rating is
+            // treated as under-rated on PD regardless of what the supply claims.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x05, 0x80, 0x00, 0x42 });
+
+            decoded!.Value.SupportsBarrelConnector.Should().BeTrue();
+            decoded.Value.UsbcDesignRatingWatts.Should().Be(0);
+            decoded.Value.IsLowWattage.Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsLowWattage_TypeC_Without_Barrel_Support_And_Zero_Design_Rating_Is_Not_Low_Wattage()
+        {
+            // Same zero design rating, no barrel jack: the special case does not apply, and the
+            // primary comparison (0 < 0) is false.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x05, 0x00, 0x00, 0x42 });
+
+            decoded!.Value.IsLowWattage.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(0x02)] // BelowRequirement
+        [InlineData(0x03)] // BatteryPower
+        [InlineData(0x04)] // NotFunctioning
+        public void IsLowWattage_NonTypeC_Is_Anything_Other_Than_MeetsRequirement(byte status)
+        {
+            HpWmiBios.DecodeAdapterData(new byte[] { status, 0xC2, 0x00, 0x42 })!
+                .Value.IsLowWattage.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(0x00)] // NotSupported
+        [InlineData(0xFF)] // Error
+        public void NoVerdict_Statuses_Are_Not_Reported_As_Low_Wattage(byte status)
+        {
+            // HP evaluates its low-wattage rule only after a successful query. Feeding a non-answer
+            // through the "anything that isn't MeetsRequirement" branch turns "no verdict" into "bad
+            // adapter" - and a board that replies with zeroes would then be told, confidently and on
+            // screen, to go and check a power supply that is probably fine.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { status, 0x00, 0x00, 0x00 });
+
+            decoded!.Value.HasVerdict.Should().BeFalse();
+            decoded.Value.IsLowWattage.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Status_0xFF_Decodes_To_Error_Not_255()
+        {
+            // The enum is sbyte-backed for this reason. With the default int backing, a 0xFF wire
+            // byte produced 255, which fell through every switch to render as the literal "255" in
+            // the UI and the diagnostics export.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0xFF, 0xC2, 0x00, 0x42 });
+
+            decoded!.Value.Status.Should().Be(HpWmiBios.SmartAdapterStatus.Error);
+        }
+
+        [Fact]
+        public void SmartAdapterStatus_Includes_ConnectedTypeC()
+        {
+            // Guards the sixth value. Tables sourced from third-party projects commonly stop at 4,
+            // which silently reclassifies a USB-C PD machine as a fault state.
+            ((int)HpWmiBios.SmartAdapterStatus.ConnectedTypeC).Should().Be(5);
+            ((int)HpWmiBios.SmartAdapterStatus.Error).Should().Be(-1);
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Hardware/HpWmiBiosEnumDecodeTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/HpWmiBiosEnumDecodeTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using OmenCore.Hardware;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Hardware
+{
+    /// <summary>
+    /// Decode tests for the two BIOS replies that are cast to an enum: <c>Keyboard 0x01</c> keyboard
+    /// type and <c>Legacy 0x52</c> GPU mode.
+    ///
+    /// These exist because casting a wire byte straight to an enum silently manufactures values the
+    /// enum never declared. The repo has already been bitten by that shape once - SmartAdapterStatus
+    /// was int-backed, so a 0xFF byte decoded to 255 rather than Error and rendered as the literal
+    /// "255" in the UI. The 0xFF keyboard payload below is a real capture from board 8D87.
+    /// </summary>
+    public class HpWmiBiosEnumDecodeTests
+    {
+        // ---- keyboard type -------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(0x00, HpWmiBios.KbdType.Standard)]
+        [InlineData(0x01, HpWmiBios.KbdType.WithNumPad)]
+        [InlineData(0x02, HpWmiBios.KbdType.TenKeyLess)]
+        [InlineData(0x03, HpWmiBios.KbdType.PerKeyRgb)]
+        public void DecodeKeyboardType_Accepts_Every_Declared_Value(byte wire, HpWmiBios.KbdType expected)
+        {
+            HpWmiBios.DecodeKeyboardType(new byte[] { wire, 0, 0, 0 }).Should().Be(expected);
+        }
+
+        [Fact]
+        public void DecodeKeyboardType_Rejects_The_0xFF_Reply_Measured_On_Board_8D87()
+        {
+            // Measured on an OMEN MAX 16 (8D87, BIOS F.07): this board does not answer Keyboard 0x01
+            // and returns 0xFF. Before validation that became (KbdType)255 - not a member, but not a
+            // failure either, so callers had no way to tell it apart from a real answer.
+            HpWmiBios.DecodeKeyboardType(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF })
+                .Should().BeNull("0xFF is not a KbdType and must not be manufactured into one");
+        }
+
+        [Theory]
+        [InlineData(0x04)]
+        [InlineData(0x7F)]
+        [InlineData(0xFE)]
+        public void DecodeKeyboardType_Rejects_Anything_Outside_The_Declared_Range(byte wire)
+        {
+            HpWmiBios.DecodeKeyboardType(new byte[] { wire, 0, 0, 0 }).Should().BeNull();
+        }
+
+        [Fact]
+        public void DecodeKeyboardType_Handles_Missing_And_Empty_Replies()
+        {
+            HpWmiBios.DecodeKeyboardType(null).Should().BeNull();
+            HpWmiBios.DecodeKeyboardType(new byte[0]).Should().BeNull();
+        }
+
+        // ---- GPU mode ------------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(0x00, HpWmiBios.GpuMode.Hybrid)]
+        [InlineData(0x01, HpWmiBios.GpuMode.Discrete)]
+        [InlineData(0x02, HpWmiBios.GpuMode.Optimus)]
+        public void DecodeGpuMode_Accepts_Every_Declared_Value(byte wire, HpWmiBios.GpuMode expected)
+        {
+            HpWmiBios.DecodeGpuMode(new byte[] { wire, 0, 0, 0 }).Should().Be(expected);
+        }
+
+        [Fact]
+        public void DecodeGpuMode_Decodes_The_Hybrid_Reply_Measured_On_Board_8D87()
+        {
+            // Measured: 00 00 00 00 with return code 0. Worth pinning as a decode, but note that on
+            // this transport an all-zero reply is also what an ACPI timeout produces, so the value
+            // being Hybrid is not on its own evidence that a MUX exists to be in hybrid.
+            HpWmiBios.DecodeGpuMode(new byte[] { 0x00, 0x00, 0x00, 0x00 })
+                .Should().Be(HpWmiBios.GpuMode.Hybrid);
+        }
+
+        [Theory]
+        [InlineData(0x03)]
+        [InlineData(0x04)]
+        [InlineData(0xFF)]
+        public void DecodeGpuMode_Rejects_Anything_Outside_The_Declared_Range(byte wire)
+        {
+            HpWmiBios.DecodeGpuMode(new byte[] { wire, 0, 0, 0 })
+                .Should().BeNull("GpuMode declares only 0x00-0x02");
+        }
+
+        [Fact]
+        public void DecodeGpuMode_Handles_Missing_And_Empty_Replies()
+        {
+            HpWmiBios.DecodeGpuMode(null).Should().BeNull();
+            HpWmiBios.DecodeGpuMode(new byte[0]).Should().BeNull();
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Hardware/HpWmiBiosSystemDesignDataTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/HpWmiBiosSystemDesignDataTests.cs
@@ -1,0 +1,156 @@
+using FluentAssertions;
+using OmenCore.Hardware;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Hardware
+{
+    /// <summary>
+    /// Decode tests for HP's <c>SystemDesignData</c> block (<c>Default 0x28</c>).
+    ///
+    /// The reply used throughout is a real capture from board 8D87 (BIOS F.07). The command returns
+    /// 128 bytes and OmenCore historically read exactly one of them.
+    /// </summary>
+    public class HpWmiBiosSystemDesignDataTests
+    {
+        /// <summary>
+        /// Measured 0x28 reply, padded to the 128 bytes the firmware actually returns.
+        /// 4A 01 = 330 W shipping adapter, 3A = unused, 01 = thermal policy V1, 03 = SW fan control
+        /// + extreme mode support, 00 = PL4 default, 01 = BIOS OC support, 07 = GPU mode switch,
+        /// 3C = 60 W CPU budget with GPU, 00 = load lines, 03 00 = sensor/hotkey bits.
+        /// </summary>
+        private static byte[] Board8D87Reply()
+        {
+            var reply = new byte[128];
+            byte[] head = { 0x4A, 0x01, 0x3A, 0x01, 0x03, 0x00, 0x01, 0x07, 0x3C, 0x00, 0x03, 0x00 };
+            head.CopyTo(reply, 0);
+            return reply;
+        }
+
+        [Fact]
+        public void DecodeSystemDesignData_Decodes_Board8D87_Capture()
+        {
+            var decoded = HpWmiBios.DecodeSystemDesignData(Board8D87Reply());
+
+            decoded.Should().NotBeNull();
+            var design = decoded!.Value;
+
+            design.ShippingAdapterPowerRatingWatts.Should().Be(330);
+            design.ThermalPolicyVersion.Should().Be(HpWmiBios.ThermalPolicyVersion.V1);
+            design.IsSwFanControlSupport.Should().BeTrue();
+            design.IsExtremeModeSupport.Should().BeTrue();
+            design.IsExtremeModeUnlock.Should().BeFalse();
+            design.IsDTBiosControl.Should().BeFalse();
+            design.IsTwoBytePL4Support.Should().BeFalse();
+            design.PL4DefaultValue.Should().Be(0);
+            design.IsBiosDefinedOcSupport.Should().BeTrue();
+            design.GpuModeSwitch.Should().Be(0x07);
+            design.DefaultCpuPowerLimitWithGpuWatts.Should().Be(60);
+            design.LoadLineSupportLevels.Should().Be(0);
+            design.DefaultLoadLine.Should().Be(0);
+
+            // Byte 10 is 0x03 and byte 11 is 0x00 on this board. These five were omitted from an
+            // earlier version of this test, which is exactly where a decode bug hid: reading
+            // ChangeIrSensorToBoard as bit 0 alone returned true here, where HP's two-bit rule
+            // (bit 0 clear AND bit 1 set) returns false. Assert them against the unmodified capture.
+            design.ChangeIrSensorToBoard.Should().BeFalse();
+            design.IsPchOverheatSupport.Should().BeFalse();
+            design.IsVrSensorSupport.Should().BeFalse();
+            design.IsHotkeySupportFnP.Should().BeFalse();
+            design.IsHotkeySupportFnF1.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(0x00, false)] // both clear
+        [InlineData(0x01, false)] // bit 0 set   -> excluded by the "bit 0 clear" half
+        [InlineData(0x02, true)]  // bit 1 only  -> the only pattern that qualifies
+        [InlineData(0x03, false)] // both set    -> this board; the case a bit-0-only read gets wrong
+        public void ChangeIrSensorToBoard_RequiresBit0Clear_AndBit1Set(byte byte10, bool expected)
+        {
+            var reply = Board8D87Reply();
+            reply[10] = byte10;
+
+            HpWmiBios.DecodeSystemDesignData(reply)!
+                .Value.ChangeIrSensorToBoard.Should().Be(expected);
+        }
+
+        [Fact]
+        public void ShippingAdapterPowerRating_Is_LittleEndian_Watts_Not_A_Flag_Field()
+        {
+            // 0x014A = 330. This field was once read as a 16-bit flag field whose decimal value
+            // happened to be 330; HP's own accessor compares it numerically against 200 and 280,
+            // which settles it as watts.
+            HpWmiBios.DecodeSystemDesignData(Board8D87Reply())!
+                .Value.ShippingAdapterPowerRatingWatts.Should().Be(330);
+
+            var twoHundredEighty = Board8D87Reply();
+            twoHundredEighty[0] = 0x18;
+            twoHundredEighty[1] = 0x01; // 0x0118 = 280
+            HpWmiBios.DecodeSystemDesignData(twoHundredEighty)!
+                .Value.ShippingAdapterPowerRatingWatts.Should().Be(280);
+        }
+
+        [Fact]
+        public void IsTwoBytePL4Support_Reads_Byte4_Bit4()
+        {
+            // This bit changes the wire format of Default 0x29 SetPL4 from one byte to two. Nothing
+            // issues 0x29 today; the bit is decoded so that whatever does can branch on it rather
+            // than assume a width. It is not board-specific - any board may set it.
+            var reply = Board8D87Reply();
+            reply[4] |= 0x10;
+
+            var design = HpWmiBios.DecodeSystemDesignData(reply)!.Value;
+            design.IsTwoBytePL4Support.Should().BeTrue();
+
+            // and the neighbouring bits in the same byte are unaffected
+            design.IsSwFanControlSupport.Should().BeTrue();
+            design.IsExtremeModeSupport.Should().BeTrue();
+            design.IsExtremeModeUnlock.Should().BeFalse();
+            design.IsDTBiosControl.Should().BeFalse();
+        }
+
+        [Fact]
+        public void LoadLine_Splits_Byte9_Into_Nibbles()
+        {
+            var reply = Board8D87Reply();
+            reply[9] = 0x34; // low nibble = supported levels, high nibble = default
+
+            var design = HpWmiBios.DecodeSystemDesignData(reply)!.Value;
+            design.LoadLineSupportLevels.Should().Be(4);
+            design.DefaultLoadLine.Should().Be(3);
+        }
+
+        [Fact]
+        public void DecodeSystemDesignData_Reads_Sensor_And_Hotkey_Bits()
+        {
+            var reply = Board8D87Reply();
+            reply[10] = 0x0E; // bit 1 IR sensor (bit 0 clear), bit 2 PCH overheat, bit 3 VR sensor
+            reply[11] = 0x03; // bit 0 Fn+P, bit 1 Fn+F1
+
+            var design = HpWmiBios.DecodeSystemDesignData(reply)!.Value;
+            design.ChangeIrSensorToBoard.Should().BeTrue();
+            design.IsPchOverheatSupport.Should().BeTrue();
+            design.IsVrSensorSupport.Should().BeTrue();
+            design.IsHotkeySupportFnP.Should().BeTrue();
+            design.IsHotkeySupportFnF1.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DecodeSystemDesignData_Returns_Null_When_Reply_Is_Too_Short()
+        {
+            // The existing thermal-policy read only needed 9 bytes. Firmware that answers with fewer
+            // than the 12 HP's accessors cover must not be decoded past what it sent.
+            HpWmiBios.DecodeSystemDesignData(null).Should().BeNull();
+            HpWmiBios.DecodeSystemDesignData(new byte[11]).Should().BeNull();
+            HpWmiBios.DecodeSystemDesignData(new byte[12]).Should().NotBeNull();
+        }
+
+        [Fact]
+        public void DecodeSystemDesignData_Keeps_Only_The_First_12_Bytes_Of_Raw_Data()
+        {
+            var design = HpWmiBios.DecodeSystemDesignData(Board8D87Reply())!.Value;
+
+            design.RawData.Should().HaveCount(12);
+            design.RawData.Should().Equal(0x4A, 0x01, 0x3A, 0x01, 0x03, 0x00, 0x01, 0x07, 0x3C, 0x00, 0x03, 0x00);
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Hardware/ModelCapabilityDatabase8D87Tests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/ModelCapabilityDatabase8D87Tests.cs
@@ -16,10 +16,10 @@ namespace OmenCoreApp.Tests.Hardware
             var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
 
             caps.ProductId.Should().Be("8D87");
-            // Not flipped: fan curves and performance modes are still inherited because confirming
-            // them needs writes, and UserVerified is all-or-nothing so it must report the weakest
-            // claim in the entry. See docs/8D87-VERIFICATION-CHECKLIST.md for exactly what remains.
-            caps.UserVerified.Should().BeFalse();
+            // Flipped once the last inherited field - the named performance modes - was measured in
+            // delivered watts rather than return codes. Every board-specific claim in the entry is
+            // now owner-verified on the hardware.
+            caps.UserVerified.Should().BeTrue();
 
             // The EC on this board is memory-mapped and does not follow the legacy offset layout, so
             // neither EC fan control nor EC power-limit writes may be attempted on it. The power-limit
@@ -28,11 +28,43 @@ namespace OmenCoreApp.Tests.Hardware
             caps.SupportsFanControlEc.Should().BeFalse();
             caps.SupportsEcPowerLimits.Should().BeFalse();
 
-            // AMD Ryzen AI part: the Intel MSR undervolt path does not apply.
-            caps.SupportsUndervolt.Should().BeFalse();
+            // True: this part undervolts via AMD Curve Optimizer, owner-confirmed. The field
+            // describes the hardware, not whether OmenCore's SMU backend can drive it today -
+            // ShowUndervolt already ANDs this with UndervoltRuntimeReady, so backend gaps surface
+            // as AmdUndervoltProvider's RuntimeBlockReason rather than as a false capability claim.
+            // RyzenControl's exclusion is (family 0x1A && model >= 0x40); this part is family 0x1A
+            // model 0x24, below that bound, so Curve Optimizer is not ruled out here either.
+            caps.SupportsUndervolt.Should().BeTrue();
+
+            // Intel thermal-control-circuit knob; there is no such register on a Ryzen AI 9 HX 375.
+            caps.SupportsTccOffset.Should().BeFalse();
+
+            // Default 0x28 byte 4 = 0x03: ExtremeMode is SUPPORTED (bit 1) but ExtremeModeUnlock
+            // (bit 2) is CLEAR, so the effective capability is false. Guards against a later reader
+            // seeing "ExtremeMode supported" in the capability block and flipping this.
+            caps.SupportsOverboost.Should().BeFalse();
 
             // Independently corroborated by the observed performance-mode decay on this machine.
             caps.MaxModeDropChecksBeforeReapply.Should().Be(1);
+        }
+
+        [Fact]
+        public void Board8D87_PerformanceModes_Are_The_Three_The_Wmi_Path_Can_Actually_Send()
+        {
+            var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
+
+            // "L5P" was inherited from the adjacent AK0003NR entry and is NOT sendable: there is no
+            // L5P member in HpWmiBios.FanMode at all, so SetPerformanceMode can never produce it.
+            // The name resolves only inside OghServiceProxy.ThermalPolicy, a different transport.
+            caps.PerformanceModes.Should().Equal("Default", "Performance", "Cool");
+            caps.PerformanceModes.Should().NotContain("L5P");
+
+            // Measured in delivered watts on the hardware: SetFanMode writes NPCF.MODE and the
+            // firmware consumes (MODE & 0x0F), so Default (0x30) and Cool (0x50) both select
+            // nibble 0 and delivered ~102 W, while Performance (0x31) selects nibble 1 and pinned
+            // enforced.power.limit at 175 W. All three return RTCD 0, so the return code never
+            // distinguished them - Cool differs as fan policy, not as a power tier.
+            caps.SupportsPerformanceModes.Should().BeTrue();
         }
 
         [Fact]
@@ -68,6 +100,13 @@ namespace OmenCoreApp.Tests.Hardware
             var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
 
             caps.HasPerKeyRgb.Should().BeTrue();
+
+            // The four-zone flag gates the four-zone KEYBOARD path, which HP's own
+            // FourZoneHelper.IsSupported refuses for lighting type 3. The four-zone commands are
+            // not inert on this chassis though - owner-observed, they drive the LIGHT BAR and leave
+            // the keyboard alone, which is why "four-zone succeeded" was never evidence here.
+            caps.HasFourZoneRgb.Should().BeFalse();
+            caps.HasLightBar.Should().BeTrue();
             caps.HasKeyboardBacklight.Should().BeTrue();
             caps.HasFourZoneRgb.Should().BeFalse("HP gates the four-zone path off for lighting type 3");
         }

--- a/src/OmenCoreApp.Tests/Hardware/ModelCapabilityDatabase8D87Tests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/ModelCapabilityDatabase8D87Tests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+using OmenCore.Hardware;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Hardware
+{
+    /// <summary>
+    /// Pins the board 8D87 profile (OMEN MAX 16, 2025 AMD) to what was measured on the hardware,
+    /// and pins the Vibrance25C1 platform list that bounds any raw EC offset derived from it.
+    /// </summary>
+    public class ModelCapabilityDatabase8D87Tests
+    {
+        [Fact]
+        public void Board8D87_Profile_Matches_What_Was_Measured_On_Hardware()
+        {
+            var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
+
+            caps.ProductId.Should().Be("8D87");
+            // Not flipped: fan curves and performance modes are still inherited because confirming
+            // them needs writes, and UserVerified is all-or-nothing so it must report the weakest
+            // claim in the entry. See docs/8D87-VERIFICATION-CHECKLIST.md for exactly what remains.
+            caps.UserVerified.Should().BeFalse();
+
+            // The EC on this board is memory-mapped and does not follow the legacy offset layout, so
+            // neither EC fan control nor EC power-limit writes may be attempted on it. The power-limit
+            // flag is not merely unconfirmed here - forcing that block was measured to change nothing,
+            // because it is a mirror the SMU never reads back.
+            caps.SupportsFanControlEc.Should().BeFalse();
+            caps.SupportsEcPowerLimits.Should().BeFalse();
+
+            // AMD Ryzen AI part: the Intel MSR undervolt path does not apply.
+            caps.SupportsUndervolt.Should().BeFalse();
+
+            // Independently corroborated by the observed performance-mode decay on this machine.
+            caps.MaxModeDropChecksBeforeReapply.Should().Be(1);
+        }
+
+        [Fact]
+        public void Board8D87_MaxFanLevel_Is_The_Measured_V1_Ceiling_Not_The_V2_Percentage()
+        {
+            // Regression guard, and the same defect class as
+            // GetCapabilities_8C77_Wf1xxx_UsesExactV1WmiProfileNotV2Mismatch.
+            //
+            // This board reports thermal policy V1 and rejects the V2 fan commands outright (0x37 ->
+            // RTCD 6, 0x38 -> RTCD 4, at every input and output buffer size). Levels therefore come
+            // from the V1 0x2D fallback in krpm/100. MapFanPercentToWmiLevel scales a requested
+            // percent by MaxFanLevel, so leaving this at 100 makes it an identity and a request for
+            // 50% writes raw level 50 - about 5000 rpm on hardware whose ceiling is 6000.
+            //
+            // 60 is measured: 0x2D against the EC tachometers and OGH's own readout at four points,
+            // 0/0, 22/2220, 47/4680 and 60/6000, linear within ~1%.
+            var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
+
+            caps.MaxFanLevel.Should().Be(60);
+            caps.MaxFanLevel.Should().NotBe(100, "V1 levels are krpm/100, not a percentage");
+            caps.FanZoneCount.Should().Be(2);
+            caps.SupportsRpmReadback.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Board8D87_Is_PerKey_Rgb_And_Therefore_Not_FourZone()
+        {
+            // The keyboard topology probe - class 0x00020008, command 0x2B, null input, 4-byte
+            // return - reads 0x03 = NbKeyboardLightingType.RgbPerKey, stable across repeated reads.
+            // HP's own FourZoneHelper.IsSupported returns false for type 3, so the four-zone path
+            // does not drive this keyboard. HasFourZoneRgb defaults to true on ModelCapabilities,
+            // so it must be set explicitly here or the entry claims both at once.
+            var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
+
+            caps.HasPerKeyRgb.Should().BeTrue();
+            caps.HasKeyboardBacklight.Should().BeTrue();
+            caps.HasFourZoneRgb.Should().BeFalse("HP gates the four-zone path off for lighting type 3");
+        }
+
+        [Fact]
+        public void Board8D87_Has_A_Mux_But_Not_Advanced_Optimus()
+        {
+            // These two flags are different claims and this board splits them, so they are pinned
+            // together - setting either from the other is the mistake this test exists to catch.
+            //
+            // HasMuxSwitch: measured by switching BIOS setup from Hybrid to Discrete and back, with
+            // a reboot each way. In Discrete the sole display is the internal panel (CMN1652) at its
+            // native 2560x1600 driven by the RTX 5080, the Radeon reports no active mode, and
+            // nvidia-smi reports display_active = Enabled. Legacy 0x52 byte 0 moves 0x00 -> 0x01 and
+            // back. The panel changes which GPU drives it, which is what the flag claims.
+            //
+            // SupportsAdvancedOptimus: false, and inherited true. Advanced Optimus is the *dynamic*
+            // form - the mux moves under live ACPI control, no reboot. The AMD_PBS_SETUP Smart Mux
+            // block (0xB6 Support, 0xC7 Acpi Control, 0xC8 Display Panel Multiplexer, 0xCA MDM
+            // Support Level) reads 0 in Hybrid, in Discrete, and again after returning to Hybrid.
+            // It stays off through a switch that demonstrably works, so routing is decided at boot.
+            var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
+
+            caps.HasMuxSwitch.Should().BeTrue(
+                "in Discrete the internal panel is driven by the dGPU and Legacy 0x52 reads 0x01");
+            caps.SupportsAdvancedOptimus.Should().BeFalse(
+                "the Smart Mux block stays Disabled through a working mode switch, so there is no runtime control surface");
+        }
+
+        [Fact]
+        public void Board8D87_Does_Not_Opt_Into_The_Decoupled_Thermal_Policy_Fallback()
+        {
+            // Deliberate: that flag changes fan/thermal behaviour and is gated on field confirmation
+            // of the behaviour itself, which this board has not had. Read-only identification work
+            // does not license it.
+            ModelCapabilityDatabase.GetCapabilities("8D87")
+                .AllowDecoupledWmiThermalPolicyFallback.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Vibrance25C1_Platform_List_Covers_The_MAX_Sibling_Boards()
+        {
+            ModelCapabilityDatabase.Vibrance25C1BoardIds.Should()
+                .BeEquivalentTo(new[] { "8D87", "8D88", "8DD5", "8DD6" });
+
+            ModelCapabilityDatabase.IsVibrance25C1Board("8D87").Should().BeTrue();
+            ModelCapabilityDatabase.IsVibrance25C1Board("8d88").Should().BeTrue("board IDs are matched case-insensitively");
+            ModelCapabilityDatabase.IsVibrance25C1Board("8A44").Should().BeFalse();
+            ModelCapabilityDatabase.IsVibrance25C1Board(null).Should().BeFalse();
+            ModelCapabilityDatabase.IsVibrance25C1Board("").Should().BeFalse();
+        }
+
+        [Fact]
+        public void Vibrance25C1_Siblings_Are_Not_Given_Invented_Capability_Profiles()
+        {
+            // The list is a scope boundary for raw offsets, not a claim about these boards. Only 8D87
+            // has been measured; adding database entries for the others would assert fan, RGB and MUX
+            // behaviour nobody has confirmed. If a real owner of one of them submits a profile, this
+            // test is the thing to update - deliberately, not incidentally.
+            foreach (var boardId in new[] { "8D88", "8DD5", "8DD6" })
+            {
+                ModelCapabilityDatabase.GetCapabilities(boardId).ProductId
+                    .Should().NotBe(boardId, $"no measured profile exists for {boardId}");
+            }
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Hardware/ModelCapabilityDatabaseTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/ModelCapabilityDatabaseTests.cs
@@ -33,7 +33,10 @@ namespace OmenCoreApp.Tests.Hardware
         [InlineData("8A25", OmenModelFamily.Victus)]
         [InlineData("8C58", OmenModelFamily.Transcend)]
         [InlineData("8E41", OmenModelFamily.Transcend)]
-        [InlineData("8D87", OmenModelFamily.OMEN2024Plus)]
+        // 8D87 is deliberately NOT in this list: the shared assertion below pins newly added
+        // entries as UserVerified = false, and 8D87 is now fully owner-verified. Its ProductId,
+        // Family and UserVerified are covered by GetCapabilities_8D87_OmenMaxAk0xxx_* below and by
+        // ModelCapabilityDatabase8D87Tests, so nothing is lost by removing the row.
         [InlineData("8574", OmenModelFamily.Legacy)]
         [InlineData("8600", OmenModelFamily.Legacy)]
         [InlineData("8787", OmenModelFamily.Legacy)]
@@ -97,8 +100,8 @@ namespace OmenCoreApp.Tests.Hardware
             caps.MaxModeDropChecksBeforeReapply.Should().Be(1,
                 "8D87 field chat reports fans become disobedient after a while, so MAX-series Max hold should reassert on first low telemetry sample");
             caps.HasPerKeyRgb.Should().BeTrue();
-            caps.UserVerified.Should().BeFalse(
-                "power and thermal fields are owner-verified but the keyboard/RGB and fan-range fields are not, and the flag is all-or-nothing");
+            caps.UserVerified.Should().BeTrue(
+                "every board-specific claim in the entry is now owner-verified on the hardware, the last of them being the performance modes measured in delivered watts");
         }
 
         [Fact]

--- a/src/OmenCoreApp.Tests/Hardware/ModelCapabilityDatabaseTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/ModelCapabilityDatabaseTests.cs
@@ -97,7 +97,8 @@ namespace OmenCoreApp.Tests.Hardware
             caps.MaxModeDropChecksBeforeReapply.Should().Be(1,
                 "8D87 field chat reports fans become disobedient after a while, so MAX-series Max hold should reassert on first low telemetry sample");
             caps.HasPerKeyRgb.Should().BeTrue();
-            caps.UserVerified.Should().BeFalse();
+            caps.UserVerified.Should().BeFalse(
+                "power and thermal fields are owner-verified but the keyboard/RGB and fan-range fields are not, and the flag is all-or-nothing");
         }
 
         [Fact]

--- a/src/OmenCoreApp.Tests/Hardware/WmiV2VerificationTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/WmiV2VerificationTests.cs
@@ -835,6 +835,52 @@ namespace OmenCoreApp.Tests.Hardware
         }
 
         [Fact]
+        public void SetPerformanceMode_WhenReadbackNonStrict_DoesNotReadTheLegacyFanModeOffsetAtAll()
+        {
+            // The mismatch was already ignored, but only after three reads of EC 0x95 and two 40 ms
+            // sleeps, then a WARN pair - per fan-mode change. On a board where that offset does not
+            // hold the fan mode (8D87's EC is memory-mapped; 0x95 reads 0x02 where 0x30 is expected)
+            // the answer could not be used either way, so issuing the transaction was pure cost and
+            // the WARN was noise about a non-event.
+            var fake = new ModeCaptureFakeWmiBios();
+            var ec = new FanModeReadbackEcAccess(0x30);
+            var controller = new WmiFanController(
+                null,
+                null,
+                0,
+                injectedWmiBios: fake,
+                ecAccess: ec,
+                strictFanModeReadback: false);
+
+            controller.SetPerformanceMode("Performance").Should().BeTrue();
+
+            ec.ReadAddresses.Should().NotContain((ushort)0x95,
+                "a profile that cannot act on the readback should not spend an EC transaction taking it");
+        }
+
+        [Fact]
+        public void SetPerformanceMode_WhenReadbackStrict_StillReadsTheFanModeOffset()
+        {
+            // Guard on the other side: the skip must be scoped to non-strict profiles. Boards where
+            // the readback IS authoritative must keep taking it, or the confirmation above becomes
+            // unreachable and SetPerformanceMode would project unverified modes as applied.
+            var fake = new ModeCaptureFakeWmiBios();
+            var ec = new FanModeReadbackEcAccess(0x31);
+            var controller = new WmiFanController(
+                null,
+                null,
+                0,
+                injectedWmiBios: fake,
+                ecAccess: ec,
+                strictFanModeReadback: true);
+
+            controller.SetPerformanceMode("Performance").Should().BeTrue();
+
+            ec.ReadAddresses.Should().Contain((ushort)0x95,
+                "strict profiles depend on this readback to confirm the mode actually took");
+        }
+
+        [Fact]
         public void ApplyPreset_V1AutoHandoff_ClearsManualFloorAfterTransitionKick()
         {
             var fake = new V1AutoHandoffFakeWmiBios();
@@ -902,9 +948,18 @@ namespace OmenCoreApp.Tests.Hardware
                 _fanMode = fanMode;
             }
 
+            /// <summary>Addresses read through this stub, in order.</summary>
+            public System.Collections.Generic.List<ushort> ReadAddresses { get; } = new();
+
             public bool IsAvailable => true;
             public bool Initialize(string devicePath) => true;
-            public byte ReadByte(ushort address) => address == 0x95 ? _fanMode : (byte)0x00;
+
+            public byte ReadByte(ushort address)
+            {
+                ReadAddresses.Add(address);
+                return address == 0x95 ? _fanMode : (byte)0x00;
+            }
+
             public void WriteByte(ushort address, byte value) { }
             public void Dispose() { }
         }

--- a/src/OmenCoreApp.Tests/Hardware/WmiV2VerificationTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/WmiV2VerificationTests.cs
@@ -730,6 +730,31 @@ namespace OmenCoreApp.Tests.Hardware
         }
 
         [Theory]
+        [InlineData(HpWmiBios.GpuPowerLevel.Minimum)]
+        [InlineData(HpWmiBios.GpuPowerLevel.Medium)]
+        [InlineData(HpWmiBios.GpuPowerLevel.Maximum)]
+        [InlineData(HpWmiBios.GpuPowerLevel.Extended3)]
+        [InlineData(HpWmiBios.GpuPowerLevel.Extended4)]
+        public void BuildGpuPowerPayload_KeepsDStateAndGpsTemperatureBytesFixed(HpWmiBios.GpuPowerLevel level)
+        {
+            var payload = HpWmiBios.BuildGpuPowerPayload(level);
+
+            // dState: hardcoded to 1 to match HP, and not a knob - MAX-series firmware overwrites
+            // the ACPI field this sets from the EC's adapter verdict during the same call.
+            payload.dState.Should().Be(0x01);
+
+            // Byte 3 is a GPS temperature threshold in °C, not a spare - the output of HP's IRHandler
+            // loop. HP emits 87 only while the chassis IR sensor reads cool, and revises it down to
+            // 75 on overheat. This app has no such loop, so sending 87 would pin the firmware in the
+            // most permissive state permanently rather than reproduce HP's behaviour - and the 0x21
+            // readback cannot observe byte 3, so it could not be verified by outcome either.
+            //
+            // Held at 0 until someone measures. This assertion exists so that a future change is
+            // deliberate rather than discovered in a field report.
+            payload.peakTemperature.Should().Be(0x00);
+        }
+
+        [Theory]
         [InlineData(HpWmiBios.GpuPowerLevel.Minimum, false, 0, true)]
         [InlineData(HpWmiBios.GpuPowerLevel.Medium, true, 0, true)]
         [InlineData(HpWmiBios.GpuPowerLevel.Maximum, true, 1, true)]

--- a/src/OmenCoreApp.Tests/Services/BatteryInfoProviderTests.cs
+++ b/src/OmenCoreApp.Tests/Services/BatteryInfoProviderTests.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+using OmenCore.Services;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Services
+{
+    /// <summary>
+    /// The dashboard displayed a hardcoded 0 battery cycles on a machine whose battery reports
+    /// 14. The reading itself needs real WMI, so what is pinned here is the part that made the
+    /// old code wrong independently of any hardware: treating "unknown" and "zero" as the same
+    /// value. A new battery legitimately reads 0 cycles.
+    /// </summary>
+    public class BatteryInfoProviderTests
+    {
+        [Fact]
+        public void HealthPercent_IsFullChargeOverDesign()
+        {
+            // The measured values from the board that prompted this: 79416 of 83029 mWh.
+            var info = new BatteryInfoProvider.BatteryInfo
+            {
+                DesignedCapacityMilliwattHours = 83029,
+                FullChargedCapacityMilliwattHours = 79416
+            };
+
+            info.HealthPercent.Should().BeApproximately(95.65, 0.01);
+        }
+
+        [Theory]
+        [InlineData(null, 79416)]
+        [InlineData(83029, null)]
+        [InlineData(null, null)]
+        public void HealthPercent_IsUnknown_WhenEitherCapacityIsMissing(int? design, int? full)
+        {
+            var info = new BatteryInfoProvider.BatteryInfo
+            {
+                DesignedCapacityMilliwattHours = design,
+                FullChargedCapacityMilliwattHours = full
+            };
+
+            info.HealthPercent.Should().BeNull("half a ratio is not a health figure");
+        }
+
+        [Fact]
+        public void HealthPercent_IsUnknown_RatherThanInfinite_WhenDesignCapacityIsZero()
+        {
+            var info = new BatteryInfoProvider.BatteryInfo
+            {
+                DesignedCapacityMilliwattHours = 0,
+                FullChargedCapacityMilliwattHours = 79416
+            };
+
+            info.HealthPercent.Should().BeNull();
+        }
+
+        [Fact]
+        public void HealthPercent_IsNotClampedTo100()
+        {
+            // A pack reporting slightly over design is real and common. Trimming it to 100
+            // would hide a miscalibrated gauge behind a perfect-looking number.
+            var info = new BatteryInfoProvider.BatteryInfo
+            {
+                DesignedCapacityMilliwattHours = 80000,
+                FullChargedCapacityMilliwattHours = 82000
+            };
+
+            info.HealthPercent.Should().BeApproximately(102.5, 0.01);
+        }
+
+        [Fact]
+        public void ZeroCycles_IsAValue_NotAnAbsentReading()
+        {
+            // The distinction the old code collapsed: a brand-new battery reads 0, and that is
+            // not the same as a controller that declines to answer.
+            var newBattery = new BatteryInfoProvider.BatteryInfo { CycleCount = 0 };
+            var noReading = new BatteryInfoProvider.BatteryInfo { CycleCount = null };
+
+            newBattery.CycleCount.Should().Be(0);
+            newBattery.CycleCount.Should().NotBeNull();
+            noReading.CycleCount.Should().BeNull();
+        }
+
+        [Fact]
+        public void Get_DoesNotThrow_WhateverTheMachineReports()
+        {
+            // Runs against real WMI. The assertion is only that an unreadable counter is an
+            // expected outcome rather than an exception - this is called on every UI tick and
+            // on hardware with no battery at all.
+            var act = () => BatteryInfoProvider.Get();
+
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Services/FanChartUnitsTests.cs
+++ b/src/OmenCoreApp.Tests/Services/FanChartUnitsTests.cs
@@ -1,0 +1,88 @@
+using System.Reflection;
+using FluentAssertions;
+using OmenCore.Hardware;
+using OmenCore.Models;
+using OmenCore.Services;
+using OmenCore.Services.Diagnostics;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Services
+{
+    // Reported on board 8D87: the dashboard "Fan Speeds" card read 28 while the fans were turning
+    // at roughly 2800 RPM. The series was plotting HardwareMetrics.FanEfficiency - a 0-100 proxy
+    // computed as avgRpm/50 - under an axis that GetLabelForChartType labels "RPM", so every reading
+    // was understated by ~50x. These tests pin the axis label and the plotted value to the same
+    // unit, in both directions, so the two cannot drift apart again.
+    public class FanChartUnitsTests
+    {
+        private sealed class StubBridge : IHardwareMonitorBridge
+        {
+            public string MonitoringSource => "StubBridge";
+            public System.Threading.Tasks.Task<MonitoringSample> ReadSampleAsync(System.Threading.CancellationToken token)
+                => System.Threading.Tasks.Task.FromResult(new MonitoringSample());
+            public System.Threading.Tasks.Task<bool> TryRestartAsync() => System.Threading.Tasks.Task.FromResult(true);
+        }
+
+        private static HardwareMonitoringService CreateService()
+        {
+            var logging = new LoggingService();
+            logging.Initialize();
+            return new HardwareMonitoringService(
+                new StubBridge(), logging, new MonitoringPreferences(), new ResumeRecoveryDiagnosticsService());
+        }
+
+        private static object? Invoke(HardwareMonitoringService svc, string name, params object[] args)
+        {
+            var method = typeof(HardwareMonitoringService).GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic);
+            method.Should().NotBeNull($"{name} is the method under test");
+            return method!.Invoke(svc, args);
+        }
+
+        [Fact]
+        public void FanSpeedsChart_PlotsRpm_NotTheZeroToHundredProxy()
+        {
+            using var svc = CreateService();
+
+            var metrics = new HardwareMetrics
+            {
+                FanRpmAverage = 2800,
+                FanEfficiency = 56 // the proxy for the same reading: 2800 / 50
+            };
+
+            var value = (double)Invoke(svc, "GetValueForChartType", metrics, ChartType.FanSpeeds)!;
+
+            value.Should().Be(2800, "the axis is labelled RPM, so the series must carry RPM");
+            value.Should().NotBe(56, "plotting the 0-100 proxy under an RPM axis is what rendered 2800 RPM as 28");
+        }
+
+        [Fact]
+        public void FanSpeedsChart_LabelAndValue_AgreeOnTheUnit()
+        {
+            using var svc = CreateService();
+
+            var label = (string)Invoke(svc, "GetLabelForChartType", ChartType.FanSpeeds)!;
+            label.Should().Be("RPM");
+
+            // A mid-range fan speed must land in RPM's order of magnitude, not a percentage's.
+            var metrics = new HardwareMetrics { FanRpmAverage = 3200, FanEfficiency = 64 };
+            var value = (double)Invoke(svc, "GetValueForChartType", metrics, ChartType.FanSpeeds)!;
+
+            value.Should().BeGreaterThan(100,
+                "a real fan speed exceeds any percentage scale; a value under 100 here means the proxy leaked back in");
+        }
+
+        [Fact]
+        public void FanSpeedsChart_ReportsZero_WhenNoFanTelemetryIsAvailable()
+        {
+            // Distinct from the defect above: zero must stay zero rather than become a floor or an
+            // estimate. On boards with no usable tachometer this is the honest reading, and the
+            // dashboard should not invent motion it cannot measure.
+            using var svc = CreateService();
+
+            var value = (double)Invoke(svc, "GetValueForChartType",
+                new HardwareMetrics { FanRpmAverage = 0, FanEfficiency = 0 }, ChartType.FanSpeeds)!;
+
+            value.Should().Be(0);
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Services/FanVerificationServiceTests.cs
+++ b/src/OmenCoreApp.Tests/Services/FanVerificationServiceTests.cs
@@ -80,6 +80,124 @@ namespace OmenCoreApp.Tests.Services
                 "a matched firmware level should not be reported as a Poor/near-failed result solely because the generic expected RPM curve was too aggressive");
         }
 
+        [Fact]
+        public void VerifyAppliedState_Fails_WhenAPhysicalSourceReportsZeroRpm_AtALowTarget()
+        {
+            // Board 8D87, from the owner's log: 50% requested, level 28 echoed back by firmware,
+            // five consecutive RPM samples of 0 from a WmiBios source. The old code accepted level
+            // evidence unconditionally below 40% and reported "✓ verified ... score 5/100 Failed" -
+            // a pass and its own failing score on one line. A non-zero request answered by a flat
+            // zero from a physical source is a contradiction at ANY percentage.
+            var logging = new LoggingService();
+            logging.Initialize();
+            var service = new FanVerificationService(wmiBios: null, fanService: null, logging);
+
+            var result = new FanApplyResult
+            {
+                RequestedPercent = 30,
+                ExpectedRpm = 1800,
+                ActualRpmAfter = 0,
+                RpmSource = OmenCore.Models.RpmSource.WmiBios,
+                ExpectedLevel = 17,
+                ActualLevelAfter = 17,
+                LevelReadbackMatched = true,
+                WmiCallSucceeded = true
+            };
+
+            var method = typeof(FanVerificationService).GetMethod("VerifyAppliedState", BindingFlags.Instance | BindingFlags.NonPublic);
+            method.Should().NotBeNull();
+
+            var verified = (bool)method!.Invoke(service, new object[] { result })!;
+            verified.Should().BeFalse("a physical RPM source reading zero contradicts a non-zero fan request, whatever the level readback says");
+        }
+
+        [Fact]
+        public void VerifyAppliedState_StillPasses_WhenRpmIsMerelyEstimated_AndLevelMatches()
+        {
+            // The guard above must not break the legitimate case it sits next to: on a V1 board the
+            // GetFanLevel value is surfaced as an Estimated RPM, which is not independent evidence
+            // either way. Level-only confirmation stays acceptable there - only a *physical* source
+            // contradicting the request is treated as disqualifying.
+            var logging = new LoggingService();
+            logging.Initialize();
+            var service = new FanVerificationService(wmiBios: null, fanService: null, logging);
+
+            var result = new FanApplyResult
+            {
+                RequestedPercent = 30,
+                ExpectedRpm = 1800,
+                ActualRpmAfter = 0,
+                RpmSource = OmenCore.Models.RpmSource.Estimated,
+                ExpectedLevel = 17,
+                ActualLevelAfter = 17,
+                LevelReadbackMatched = true,
+                WmiCallSucceeded = true
+            };
+
+            var method = typeof(FanVerificationService).GetMethod("VerifyAppliedState", BindingFlags.Instance | BindingFlags.NonPublic);
+            method.Should().NotBeNull();
+
+            var verified = (bool)method!.Invoke(service, new object[] { result })!;
+            verified.Should().BeTrue("an estimated RPM is not a physical measurement, so it cannot contradict the level readback");
+        }
+
+        [Fact]
+        public void DescribeVerificationPass_DoesNotClaimTheFanMoved_OnLevelOnlyEvidence()
+        {
+            // The log line is the deliverable here: level-only evidence proves the firmware accepted
+            // the command, not that the fan turned. It must not read identically to a tachometer-
+            // corroborated pass, and it must not quote an RPM accuracy score it did not measure.
+            var result = new FanApplyResult
+            {
+                RequestedPercent = 30,
+                ExpectedRpm = 1800,
+                ActualRpmAfter = 0,
+                RpmSource = OmenCore.Models.RpmSource.Estimated,
+                ExpectedLevel = 17,
+                ActualLevelAfter = 17,
+                LevelReadbackMatched = true,
+                WmiCallSucceeded = true,
+                VerificationPassed = true,
+                VerificationEvidence = "Level"
+            };
+
+            var method = typeof(FanVerificationService).GetMethod("DescribeVerificationPass", BindingFlags.Static | BindingFlags.NonPublic);
+            method.Should().NotBeNull();
+
+            var text = (string)method!.Invoke(null, new object[] { 0, result })!;
+            text.Should().Contain("Fan motion NOT confirmed");
+            text.Should().NotContain("verified:", "that wording is reserved for a pass a tachometer corroborated");
+            text.Should().NotContain("/100", "the RPM accuracy score is meaningless on the level-only path");
+        }
+
+        [Fact]
+        public void DescribeVerificationPass_ReportsTheScore_WhenRpmCorroboratedThePass()
+        {
+            var result = new FanApplyResult
+            {
+                RequestedPercent = 60,
+                ExpectedRpm = 3600,
+                ActualRpmAfter = 3500,
+                RpmSource = OmenCore.Models.RpmSource.WmiBios,
+                ExpectedLevel = 33,
+                ActualLevelAfter = 33,
+                LevelReadbackMatched = true,
+                WmiCallSucceeded = true,
+                VerificationPassed = true,
+                VerificationEvidence = "RPM+Level",
+                RpmStandardDeviation = 20,
+                ActualRpmBefore = 1200
+            };
+
+            var method = typeof(FanVerificationService).GetMethod("DescribeVerificationPass", BindingFlags.Static | BindingFlags.NonPublic);
+            method.Should().NotBeNull();
+
+            var text = (string)method!.Invoke(null, new object[] { 0, result })!;
+            text.Should().Contain("verified:");
+            text.Should().Contain("/100");
+            text.Should().NotContain("NOT confirmed");
+        }
+
         [Theory]
         [InlineData(0, 0, true)]
         [InlineData(0, 2, true)]

--- a/src/OmenCoreApp.Tests/Services/GpuSwitchServiceModeMappingTests.cs
+++ b/src/OmenCoreApp.Tests/Services/GpuSwitchServiceModeMappingTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using OmenCore.Hardware;
+using OmenCore.Models;
+using OmenCore.Services;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Services
+{
+    /// <summary>
+    /// The firmware-to-UI GPU mode mapping used by <c>GpuSwitchService.DetectCurrentMode</c>.
+    ///
+    /// Mode detection used to be inferred entirely from which adapter was painting a display, which
+    /// gets the answer wrong on any healthy Optimus laptop: RTD3 idles the dGPU into D3, so
+    /// <c>Win32_VideoController</c> reports it Off Line with no resolution, and Hybrid was reported as
+    /// Integrated. These tests cover the mapping half - the part that can be exercised without a WMI
+    /// round trip or a live display topology.
+    /// </summary>
+    public class GpuSwitchServiceModeMappingTests
+    {
+        [Fact]
+        public void Discrete_Maps_To_Discrete()
+        {
+            GpuSwitchService.MapFirmwareGpuMode(HpWmiBios.GpuMode.Discrete)
+                .Should().Be(GpuSwitchMode.Discrete);
+        }
+
+        [Fact]
+        public void Hybrid_Maps_To_Hybrid()
+        {
+            GpuSwitchService.MapFirmwareGpuMode(HpWmiBios.GpuMode.Hybrid)
+                .Should().Be(GpuSwitchMode.Hybrid);
+        }
+
+        [Fact]
+        public void Optimus_Maps_To_Hybrid_Because_The_Ui_Has_No_Separate_Member()
+        {
+            // Optimus is a hybrid arrangement with dGPU-direct routing available. GpuSwitchMode
+            // declares only Integrated/Discrete/Hybrid, and Hybrid is what the UI means by it.
+            GpuSwitchService.MapFirmwareGpuMode(HpWmiBios.GpuMode.Optimus)
+                .Should().Be(GpuSwitchMode.Hybrid);
+        }
+
+        [Fact]
+        public void An_Undeclared_Firmware_Value_Maps_To_Null_Rather_Than_Guessing()
+        {
+            // A machine routed to iGPU-only - the BIOS calls it UMA on board 8D87 - is a state
+            // HpWmiBios.GpuMode does not declare, and no capture has pinned what Legacy 0x52 reads
+            // there. Null hands the question back to adapter inference, which is at its most reliable
+            // in exactly that case: a machine with no usable dGPU really does have one active adapter.
+            GpuSwitchService.MapFirmwareGpuMode((HpWmiBios.GpuMode)0x7F)
+                .Should().BeNull("an unmapped firmware byte must not be forced into a UI mode");
+        }
+
+        [Fact]
+        public void Never_Maps_Any_Firmware_Value_To_Integrated()
+        {
+            // The firmware enum has no iGPU-only member, so nothing it reports should produce
+            // Integrated. This pins the specific defect: Integrated was being concluded from a
+            // sleeping dGPU, never from anything the firmware actually said.
+            foreach (var mode in new[]
+                     {
+                         HpWmiBios.GpuMode.Hybrid,
+                         HpWmiBios.GpuMode.Discrete,
+                         HpWmiBios.GpuMode.Optimus
+                     })
+            {
+                GpuSwitchService.MapFirmwareGpuMode(mode)
+                    .Should().NotBe(GpuSwitchMode.Integrated,
+                        $"{mode} is not an iGPU-only state");
+            }
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Services/PerformanceModeNoOpReportingTests.cs
+++ b/src/OmenCoreApp.Tests/Services/PerformanceModeNoOpReportingTests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using OmenCore.Hardware;
+using OmenCore.Models;
+using OmenCore.Services;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Services
+{
+    /// <summary>
+    /// Pins the case where applying a performance mode changes nothing about the hardware.
+    ///
+    /// On board 8D87 all three effect paths decline: direct EC power-limit writes are disabled for the
+    /// model (that EC block is a mirror the SMU never reads back), the decoupled WMI thermal-policy
+    /// fallback is not permitted for it, and fan policy is decoupled from performance mode by default.
+    /// The mode switch therefore changes only the Windows power plan - which is a legitimate outcome,
+    /// but was being reported as an unqualified "applied successfully".
+    ///
+    /// These tests assert on the apply trace rather than on log text, so they pin the state the
+    /// summary line is derived from without coupling to its wording.
+    /// </summary>
+    public class PerformanceModeNoOpReportingTests
+    {
+        private sealed class NullFanController : IFanController
+        {
+            public bool IsAvailable => false;
+            public string Status => "null";
+            public string Backend => "null";
+            public bool ApplyPreset(FanPreset preset) => false;
+            public bool ApplyCustomCurve(IEnumerable<FanCurvePoint> curve) => false;
+            public bool SetFanSpeed(int percent) => false;
+            public bool SetFanSpeeds(int cpu, int gpu) => false;
+            public bool SetMaxFanSpeed(bool enabled) => false;
+            public bool SetPerformanceMode(string modeName) => false;
+            public bool RestoreAutoControl() => false;
+            public IEnumerable<FanTelemetry> ReadFanSpeeds() => new[] { new FanTelemetry() };
+            public bool ApplyMaxCooling() => true;
+            public void ApplyAutoMode() { }
+            public void ApplyQuietMode() { }
+            public bool ResetEcToDefaults() => false;
+            public bool ApplyThrottlingMitigation() => false;
+            public bool VerifyMaxApplied(out string details) { details = ""; return false; }
+            public void Dispose() { }
+        }
+
+        private static PerformanceModeService BuildService(ModelCapabilities? caps)
+        {
+            var log = new LoggingService();
+            return new PerformanceModeService(new NullFanController(), new PowerPlanService(log), null, log,
+                modelCapabilities: caps);
+        }
+
+        [Fact]
+        public void Board8D87_AppliesNoHardwareEffect_AndTheTraceSaysSo()
+        {
+            var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
+            caps.Should().NotBeNull();
+
+            var service = BuildService(caps);
+            service.LinkFanToPerformanceMode = false;
+
+            service.Apply(new PerformanceMode
+            {
+                Name = "Quiet",
+                CpuPowerLimitWatts = 35,
+                GpuPowerLimitWatts = 60
+            });
+
+            var trace = service.GetApplyTraceSnapshot().Should().ContainSingle().Subject;
+
+            trace.EffectiveModeName.Should().Be("Quiet");
+            trace.EcPowerLimitApplied.Should().BeFalse("SupportsEcPowerLimits is false for this board");
+            trace.WmiPolicyFallbackApplied.Should().BeFalse(
+                "AllowDecoupledWmiThermalPolicyFallback is false for this board, so the fallback the " +
+                "skip message advertises does not actually run");
+            trace.FanPolicyAction.Should().Be("Unchanged",
+                "LinkFanToPerformanceMode defaults off, so fan policy is untouched");
+        }
+
+        [Fact]
+        public void Board8D87_DoesNotClaimTheWmiFallbackWasEvenAttempted()
+        {
+            // The skip message says "using WMI thermal policy fallback when available". On this board
+            // it is not available, and the distinction matters: attempted-and-failed is a hardware
+            // problem worth chasing, never-attempted is a capability flag worth knowing about.
+            var service = BuildService(ModelCapabilityDatabase.GetCapabilities("8D87"));
+            service.LinkFanToPerformanceMode = false;
+
+            service.Apply(new PerformanceMode { Name = "Quiet", CpuPowerLimitWatts = 35, GpuPowerLimitWatts = 60 });
+
+            var trace = service.GetApplyTraceSnapshot().Should().ContainSingle().Subject;
+            trace.WmiPolicyFallbackAttempted.Should().BeFalse();
+            trace.AllowWmiThermalPolicyFallback.Should().BeFalse();
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/ViewModels/MainViewModelTests.cs
+++ b/src/OmenCoreApp.Tests/ViewModels/MainViewModelTests.cs
@@ -645,5 +645,54 @@ namespace OmenCoreApp.Tests.ViewModels
             StartupRestorePolicy.IsEnabled(config, StartupRestoreCategory.Fans).Should().BeFalse(
                 because: "the broad safety gate remains the master switch");
         }
+
+        // ── The adapter panel's explanation text ──────────────────────────────────────────────
+        //
+        // The panel exists to tell a user what the firmware said about their supply, so the one
+        // thing it must not do is attribute a verdict to the firmware that the firmware did not
+        // reach. Both cases below are real captures from board 8D87.
+
+        private static void SetAdapterInfo(MainViewModel vm, byte[] reply)
+        {
+            var decoded = HpWmiBios.DecodeAdapterData(reply);
+            decoded.Should().NotBeNull(because: "the capture is a valid 4-byte reply");
+
+            typeof(MainViewModel)
+                .GetField("_adapterInfo", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(vm, decoded);
+        }
+
+        [Fact]
+        public void PowerAdapterExplanation_Quotes_The_Firmware_On_A_Barrel_Adapter()
+        {
+            using var vm = new MainViewModel();
+            SetAdapterInfo(vm, new byte[] { 0x02, 0xC2, 0x00, 0x38 });   // 280 W, BelowRequirement
+
+            var text = vm.PowerAdapterExplanation;
+
+            text.Should().NotBeNull();
+            text.Should().Contain("280 W");
+            text.Should().Contain("firmware reports",
+                because: "on a barrel adapter the firmware really does say BelowRequirement");
+        }
+
+        [Fact]
+        public void PowerAdapterExplanation_Does_Not_Put_BelowRequirement_In_The_Firmwares_Mouth_On_UsbC()
+        {
+            using var vm = new MainViewModel();
+            SetAdapterInfo(vm, new byte[] { 0x05, 0xC2, 0x00, 0x14 });   // 100 W dock, ConnectedTypeC
+
+            var text = vm.PowerAdapterExplanation;
+
+            // The warning must still appear - HP's rule does call this supply under-rated, and the
+            // GPU really is clamped - so the bug would be fixed just as wrongly by silencing it.
+            text.Should().NotBeNull(because: "the barrel special case makes this supply low-wattage");
+            text.Should().Contain("100 W");
+            text.Should().Contain("USB-C");
+
+            text.Should().NotContain("adapter as below this machine's requirement",
+                because: "the firmware reported ConnectedTypeC, a description of the supply; the " +
+                         "under-rated judgement is HP's rule about the chassis, not the firmware's verdict");
+        }
     }
 }

--- a/src/OmenCoreApp/App.xaml.cs
+++ b/src/OmenCoreApp/App.xaml.cs
@@ -955,7 +955,7 @@ namespace OmenCore
             services.AddSingleton(_ => new BiosUpdateService(Logging));
             services.AddSingleton(_ => new TelemetryService(Logging, Configuration));
             services.AddSingleton(_ => new SystemOptimizationService(Logging));
-            services.AddSingleton(_ => new GpuSwitchService(Logging));
+            services.AddSingleton(sp => new GpuSwitchService(Logging, sp.GetRequiredService<HpWmiBios>()));
             services.AddSingleton(_ => new ProcessMonitoringService(Logging));
             services.AddSingleton(_ => new HotkeyService(Logging));
             services.AddSingleton(_ => new OmenKeyService(Logging, Configuration));

--- a/src/OmenCoreApp/Controls/HardwareMonitoringDashboard.xaml
+++ b/src/OmenCoreApp/Controls/HardwareMonitoringDashboard.xaml
@@ -335,7 +335,7 @@
                     <Border Style="{StaticResource MetricCardStyle}">
                         <StackPanel>
                             <TextBlock Text="Battery Status" Style="{StaticResource MetricTitleStyle}"/>
-                            <TextBlock x:Name="BatteryCyclesValue" Text="127" Style="{StaticResource MetricValueStyle}"/>
+                            <TextBlock x:Name="BatteryCyclesValue" Text="--" Style="{StaticResource MetricValueStyle}"/>
                             <TextBlock Text="cycles" Style="{StaticResource MetricUnitStyle}"/>
                             <TextBlock x:Name="BatteryLifeEstimate" Text="3.0 years remaining" FontSize="10" Foreground="{DynamicResource SecondaryTextBrush}"/>
                         </StackPanel>

--- a/src/OmenCoreApp/Controls/HardwareMonitoringDashboard.xaml.cs
+++ b/src/OmenCoreApp/Controls/HardwareMonitoringDashboard.xaml.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
-using System.Management;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -484,9 +483,26 @@ namespace OmenCore.Controls
                     PowerEfficiencyRating.Foreground = GetEfficiencyBrush(efficiency);
                 }
 
-                // Thermal status - FIXED with null safety
-                if (BatteryCyclesValue != null) BatteryCyclesValue.Text = "0";
-                if (BatteryLifeEstimate != null) BatteryLifeEstimate.Text = "~3.0 years remaining";
+                // Battery wear. Both of these were constants: the cycle count was literally
+                // "0" and the caption was literally "~3.0 years remaining", neither derived
+                // from the machine. The cycle count is readable (root\wmi:BatteryCycleCount)
+                // and is shown; remaining-life in years is not derivable from anything we
+                // measure, so the caption now reports the capacities it actually has.
+                var batteryInfo = BatteryInfoProvider.Get(App.Logging);
+                if (BatteryCyclesValue != null)
+                {
+                    BatteryCyclesValue.Text = batteryInfo.CycleCount?.ToString() ?? "--";
+                }
+                if (BatteryLifeEstimate != null)
+                {
+                    BatteryLifeEstimate.Text =
+                        batteryInfo.FullChargedCapacityMilliwattHours is int full &&
+                        batteryInfo.DesignedCapacityMilliwattHours is int design
+                            ? $"{full:N0} of {design:N0} mWh"
+                            : batteryInfo.CycleCount == null
+                                ? "Not reported by this battery"
+                                : "Capacity unavailable";
+                }
 
                 if (ThermalStatusValue != null)
                 {
@@ -572,62 +588,28 @@ namespace OmenCore.Controls
         /// Uses WMI BatteryStaticData for DesignCapacity and BatteryFullChargedCapacity for current capacity.
         /// Caches result for 5 minutes to avoid excessive WMI queries.
         /// </summary>
+        /// <summary>
+        /// Battery capacity health, or <see cref="double.NaN"/> when the pack does not report
+        /// both capacities. Delegates to <see cref="BatteryInfoProvider"/> so the dashboard and
+        /// the monitoring service read the same numbers from the same place - they used to run
+        /// separate copies of these WMI queries, which is how the cycle count came to be
+        /// hardcoded in one of them.
+        /// </summary>
         private async Task<double> GetBatteryHealthPercentAsync()
         {
-            // Return cached value if recent (battery health doesn't change often)
             if (_lastBatteryHealthCheck > DateTime.MinValue && (DateTime.Now - _lastBatteryHealthCheck).TotalMinutes < 5)
             {
                 return _cachedBatteryHealth;
             }
 
+            // Off the UI thread: BatteryInfoProvider is synchronous WMI, and a cold call has
+            // to wait on the battery class driver.
             return await Task.Run(() =>
             {
-                try
-                {
-                    uint designCapacity = 0;
-                    uint fullChargeCapacity = 0;
-
-                    // Get DesignCapacity from BatteryStaticData (requires admin/elevated access on some systems)
-                    using (var searcher = new ManagementObjectSearcher("root\\WMI", "SELECT DesignedCapacity FROM BatteryStaticData"))
-                    {
-                        foreach (var obj in searcher.Get())
-                        {
-                            designCapacity = Convert.ToUInt32(obj["DesignedCapacity"]);
-                            break;
-                        }
-                    }
-
-                    // Get FullChargeCapacity from BatteryFullChargedCapacity
-                    using (var searcher = new ManagementObjectSearcher("root\\WMI", "SELECT FullChargedCapacity FROM BatteryFullChargedCapacity"))
-                    {
-                        foreach (var obj in searcher.Get())
-                        {
-                            fullChargeCapacity = Convert.ToUInt32(obj["FullChargedCapacity"]);
-                            break;
-                        }
-                    }
-
-                    if (designCapacity > 0 && fullChargeCapacity > 0)
-                    {
-                        _cachedBatteryHealth = (fullChargeCapacity * 100.0) / designCapacity;
-                        _cachedBatteryHealth = Math.Min(100.0, Math.Max(0.0, _cachedBatteryHealth)); // Clamp to 0-100
-                        _lastBatteryHealthCheck = DateTime.Now;
-                        App.Logging.Debug($"[Dashboard] Battery health: {_cachedBatteryHealth:F1}% (FullCharge={fullChargeCapacity} mWh, Design={designCapacity} mWh)");
-                        return _cachedBatteryHealth;
-                    }
-
-                    App.Logging.Debug("[Dashboard] Battery capacity WMI data unavailable; capacity health will be shown as unavailable");
-                    _cachedBatteryHealth = double.NaN;
-                    _lastBatteryHealthCheck = DateTime.Now;
-                    return _cachedBatteryHealth;
-                }
-                catch (Exception ex)
-                {
-                    App.Logging.Debug($"[Dashboard] Failed to get battery health: {ex.Message}");
-                    _cachedBatteryHealth = double.NaN;
-                    _lastBatteryHealthCheck = DateTime.Now;
-                    return _cachedBatteryHealth;
-                }
+                var info = BatteryInfoProvider.Get(App.Logging);
+                _cachedBatteryHealth = info.HealthPercent ?? double.NaN;
+                _lastBatteryHealthCheck = DateTime.Now;
+                return _cachedBatteryHealth;
             });
         }
 

--- a/src/OmenCoreApp/Hardware/FanControllerFactory.cs
+++ b/src/OmenCoreApp/Hardware/FanControllerFactory.cs
@@ -423,7 +423,12 @@ namespace OmenCore.Hardware
                     ecAccess: _ecAccess,
                     strictFanModeReadback: !conservativeWmiProfile,
                     allowV1AutoModeFloorClear: allowV1AutoModeFloorClear,
-                    maxModeDropChecksBeforeReapply: _capabilities?.ModelConfig?.MaxModeDropChecksBeforeReapply);
+                    maxModeDropChecksBeforeReapply: _capabilities?.ModelConfig?.MaxModeDropChecksBeforeReapply,
+                    // Not gated on conservativeWmiProfile: that gate is about EC *writes*, and
+                    // these offsets are read-only. A board with EC fan control disabled can
+                    // still have a perfectly readable tachometer, and on the boards where
+                    // GetFanRpmDirect is refused it is the only physical RPM source there is.
+                    ecFanTachometerOffsets: _capabilities?.ModelConfig?.EcFanTachometerOffsets);
                 if (controller.IsAvailable)
                 {
                     if (conservativeWmiProfile)

--- a/src/OmenCoreApp/Hardware/HpWmiBios.cs
+++ b/src/OmenCoreApp/Hardware/HpWmiBios.cs
@@ -112,6 +112,7 @@ namespace OmenCore.Hardware
         private const uint CMD_GPU_GET_POWER = 0x21;  // GetGpuPower (OmenMon 0x21)
         private const uint CMD_GPU_SET_POWER = 0x22;  // SetGpuPower (OmenMon 0x22)
         private const uint CMD_GPU_GET_MODE = 0x52;   // GetGpuMode - uses Legacy cmd
+        private const uint CMD_ADAPTER_GET = 0x0F;    // GetAdapter (smart adapter status + wattage) - uses Legacy cmd
         private const uint CMD_GPU_SET_MODE = 0x52;   // SetGpuMode - uses GpuMode cmd
         private const uint CMD_TEMP_GET = 0x23;       // GetTemperature (OmenMon 0x23)
         private const uint CMD_BACKLIGHT_SET = 0x05;  // SetBacklight - uses Keyboard cmd
@@ -163,6 +164,27 @@ namespace OmenCore.Hardware
             Extended4 = 0x04
         }
 
+        /// <summary>
+        /// Build the 4-byte <c>Default 0x22</c> GPU power payload.
+        /// </summary>
+        /// <remarks>
+        /// Three things about this payload that are easy to re-derive incorrectly:
+        ///
+        /// <para><b>Byte 2 (<c>dState</c>) is hardcoded to 1, matching HP.</b> It is not a knob. On
+        /// MAX-series firmware the 0x22 handler sets the ACPI <c>DSTA</c> field and then immediately
+        /// calls the EC query that overwrites <c>DSTA</c> from the EC's own adapter verdict, so the
+        /// value written here does not survive the call that writes it. Verified on both a compliant
+        /// and an under-rated adapter. Do not add a parameter for it expecting to steer anything.</para>
+        ///
+        /// <para><b>Byte 3 is a GPS temperature threshold in °C, not a spare byte.</b> The
+        /// <c>peakTemperature</c> naming here is correct; a firmware note describing it as a spare is
+        /// wrong on this board. This method sends 0. See <see cref="HpGpsTemperatureThresholdC"/> for
+        /// what HP sends and why matching it is deferred.</para>
+        ///
+        /// <para><b>0x22 is not always 4 bytes.</b> HP has a second call site (<c>SetTGPAsync</c>)
+        /// that issues the same command with a single byte. Nothing here needs that arity today, but
+        /// code reading a 0x22 payload out of a trace should not assume it is 4 bytes wide.</para>
+        /// </remarks>
         public static (byte customTgp, byte ppab, byte dState, byte peakTemperature) BuildGpuPowerPayload(GpuPowerLevel level)
         {
             byte customTgp = 0;
@@ -189,8 +211,44 @@ namespace OmenCore.Hardware
                     break;
             }
 
+            // Byte 3 stays 0. See HpGpsTemperatureThresholdC for what HP sends and why matching it
+            // is deferred rather than declined.
             return (customTgp, ppab, 0x01, 0x00);
         }
+
+        /// <summary>
+        /// The GPS temperature threshold (°C) written in byte 3 of the <c>Default 0x22</c> payload -
+        /// HP's <c>GpsMaxTemperature</c>, the un-throttled setpoint.
+        ///
+        /// <para>Byte 3 is not a per-preset constant in HP's code. It is the output of their
+        /// <c>IRHandler</c>, a closed loop driven by the chassis infra-red (skin) temperature sensor,
+        /// bounded by two <c>PlatformSettings</c> values (<c>GpsMaxTemperature = 87</c>,
+        /// <c>GpsMinTemperature = 75</c>, both JSON-overridable per platform):</para>
+        /// <code>
+        /// IrTemp >= Overheat        -> GpsMinTemperature (75), and dState may be bumped
+        /// Gps &lt;= IrTemp &lt; Overheat  -> clamp(GpuTemp - irGap, 75, 87)
+        /// IrTemp &lt;= Release         -> GpsMaxTemperature (87)
+        /// </code>
+        ///
+        /// <para><b>Recorded, deliberately not applied.</b> Sending 87 is not simply "matching HP",
+        /// and three things argue against it until someone measures:</para>
+        /// <list type="bullet">
+        /// <item>87 is what HP emits <i>only while the IR sensor reports the chassis is cool</i>. It
+        /// is the loop's most permissive output, revised down to 75 the moment skin temperature
+        /// crosses overheat. This application has no such loop and would never revise it, so it would
+        /// pin the firmware permanently in HP's chassis-is-cool state rather than reproduce HP's
+        /// behaviour.</item>
+        /// <item>Both bounds are overridable from HP's per-platform JSON. 87 is one build's default,
+        /// not a universal constant, and <see cref="BuildGpuPowerPayload"/> is not board-gated.</item>
+        /// <item>It cannot be verified by outcome: the <c>0x21</c> readback returns cTGP, PPAB and
+        /// dState only - byte 3 is not observable. There is no way to confirm the firmware did
+        /// anything with it.</item>
+        /// </list>
+        ///
+        /// <para>What would settle it: a before/after on real hardware in watts <i>and</i> GPU and
+        /// skin temperature, on a board where the value can be attributed.</para>
+        /// </summary>
+        public const byte HpGpsTemperatureThresholdC = 87;
 
         public static bool IsGpuPowerReadbackMatch(GpuPowerLevel requestedLevel, bool customTgp, int ppabLevel)
         {
@@ -225,10 +283,254 @@ namespace OmenCore.Hardware
             V2 = 0x02   // OMEN Max 2025+ (new fan commands)
         }
 
+        /// <summary>
+        /// HP's smart adapter verdict, reported in byte 0 of the <c>Legacy 0x0F</c> reply.
+        ///
+        /// Six values, not five: most third-party tables (including OmenMon-Reborn's) stop at 4 and
+        /// treat everything above <see cref="MeetsRequirement"/> as a fault. <see cref="ConnectedTypeC"/>
+        /// is not a fault - it means USB-C PD is supplying the machine, and HP applies a different
+        /// comparison to it (see <see cref="AdapterInfo.IsLowWattage"/>).
+        ///
+        /// <see cref="Error"/> is documented both as -1 and as 0xFF on the wire, so the backing type
+        /// is <c>sbyte</c> - a byte of 0xFF must decode to <see cref="Error"/> and not to 255.
+        /// </summary>
+        public enum SmartAdapterStatus : sbyte
+        {
+            Error = -1,
+            NotSupported = 0,
+            MeetsRequirement = 1,
+            BelowRequirement = 2,
+            BatteryPower = 3,
+            NotFunctioning = 4,
+            ConnectedTypeC = 5
+        }
+
+        /// <summary>
+        /// Decoded <c>Legacy 0x0F</c> reply: the machine's own view of the power adapter attached to it.
+        ///
+        /// This is the only interface in the BIOS that reports the *connected* adapter's wattage as a
+        /// real number rather than a binary meets/below verdict. Paired with
+        /// <see cref="SystemDesignData.ShippingAdapterPowerRatingWatts"/> (the wattage the SKU shipped
+        /// with) it gives both halves of the comparison the firmware itself is making.
+        ///
+        /// Why it matters: on boards that clamp GPU power when the supply is under-rated, a user on a
+        /// low-wattage adapter otherwise sees only the symptom (a GPU pinned well below its rating)
+        /// with nothing anywhere in the UI to explain it.
+        /// </summary>
+        public readonly struct AdapterInfo
+        {
+            /// <summary>Byte 0 - the firmware's verdict on the attached supply.</summary>
+            public SmartAdapterStatus Status { get; init; }
+
+            /// <summary>Byte 1 bit 7 - whether this chassis has a barrel jack at all.</summary>
+            public bool SupportsBarrelConnector { get; init; }
+
+            /// <summary>Byte 2 x 5 - the USB-C *design* rating in watts (a chassis property, not the attached supply).</summary>
+            public int UsbcDesignRatingWatts { get; init; }
+
+            /// <summary>
+            /// Byte 3 x 5 - the connected adapter's rating in watts, or 0 when the firmware reports
+            /// the 0xFF "unknown" sentinel. Check <see cref="PowerRatingKnown"/> before reading a 0
+            /// here as "nothing plugged in".
+            /// </summary>
+            public int PowerRatingWatts { get; init; }
+
+            /// <summary>False when byte 3 was the 0xFF unknown sentinel.</summary>
+            public bool PowerRatingKnown { get; init; }
+
+            /// <summary>The raw 4-byte reply, for diagnostics.</summary>
+            public byte[] RawData { get; init; }
+
+            /// <summary>
+            /// Whether the firmware considers the attached supply under-rated, matching the rule HP's
+            /// own software applies (<c>HP.Omen.Core.Model.Device.IsLowWattage</c>).
+            ///
+            /// The rule has two branches. For USB-C PD the connected rating is compared against the
+            /// chassis USB-C design rating, and a barrel-capable chassis reporting a 0 design rating
+            /// counts as under-rated outright. For everything else, any status other than
+            /// MeetsRequirement is under-rated. Type-C is deliberately not folded into that second
+            /// branch - doing so misreports a PD supply that is exactly what the chassis was designed
+            /// for.
+            /// </summary>
+            public bool IsLowWattage => !HasVerdict
+                ? false
+                : Status == SmartAdapterStatus.ConnectedTypeC
+                    ? (PowerRatingWatts > 0 && PowerRatingWatts < UsbcDesignRatingWatts)
+                      || (SupportsBarrelConnector && UsbcDesignRatingWatts == 0)
+                    : Status != SmartAdapterStatus.MeetsRequirement;
+
+            /// <summary>
+            /// False when the firmware gave no usable answer - <see cref="SmartAdapterStatus.Error"/>
+            /// or <see cref="SmartAdapterStatus.NotSupported"/>.
+            ///
+            /// HP only evaluates its low-wattage rule after a successful query. Applying the
+            /// "anything that isn't MeetsRequirement" branch to a non-answer turns "no verdict" into
+            /// "bad adapter" - which, on a board that replies with zeroes, produces a confident
+            /// on-screen instruction to go and check a power supply that is probably fine.
+            /// </summary>
+            public bool HasVerdict => Status != SmartAdapterStatus.Error
+                                   && Status != SmartAdapterStatus.NotSupported;
+
+            public override string ToString()
+            {
+                var watts = PowerRatingKnown ? $"{PowerRatingWatts}W" : "unknown wattage";
+                return $"{Status} ({watts})";
+            }
+        }
+
+        /// <summary>
+        /// Decoded <c>Default 0x28</c> reply - HP's <c>SystemDesignData</c> block.
+        ///
+        /// The firmware answers 128 bytes here and this class historically parsed exactly one of them
+        /// (byte 3, the thermal policy version). The rest is a per-board capability declaration, and
+        /// HP's own software gates features on it at runtime rather than on a board-ID table.
+        /// </summary>
+        public readonly struct SystemDesignData
+        {
+            /// <summary>Bytes 0-1, 16-bit LE - the wattage of the adapter this SKU shipped with.</summary>
+            public int ShippingAdapterPowerRatingWatts { get; init; }
+
+            /// <summary>Byte 3 - thermal policy version, the one field this class already read.</summary>
+            public ThermalPolicyVersion ThermalPolicyVersion { get; init; }
+
+            /// <summary>Byte 4 bit 0.</summary>
+            public bool IsSwFanControlSupport { get; init; }
+
+            /// <summary>Byte 4 bit 1.</summary>
+            public bool IsExtremeModeSupport { get; init; }
+
+            /// <summary>Byte 4 bit 2. Observed false on a board that reports <see cref="IsExtremeModeSupport"/> true; unexplained.</summary>
+            public bool IsExtremeModeUnlock { get; init; }
+
+            /// <summary>Byte 4 bit 3.</summary>
+            public bool IsDTBiosControl { get; init; }
+
+            /// <summary>
+            /// Byte 4 bit 4. Changes the wire format of <c>Default 0x29 SetPL4</c> from one byte to two.
+            /// Nothing in this repo issues 0x29 yet; this is decoded so that whatever does can branch on
+            /// it rather than assuming a width. Guessing wrong here is a silent write-corruption bug on
+            /// any board where the bit is set.
+            /// </summary>
+            public bool IsTwoBytePL4Support { get; init; }
+
+            /// <summary>Byte 5.</summary>
+            public int PL4DefaultValue { get; init; }
+
+            /// <summary>Byte 6 bit 0.</summary>
+            public bool IsBiosDefinedOcSupport { get; init; }
+
+            /// <summary>Byte 7 - GPU mode switch capability bitfield.</summary>
+            public byte GpuModeSwitch { get; init; }
+
+            /// <summary>Byte 8 - the CPU power budget the platform uses while the dGPU is loaded, in watts.</summary>
+            public int DefaultCpuPowerLimitWithGpuWatts { get; init; }
+
+            /// <summary>Byte 9 low nibble.</summary>
+            public int LoadLineSupportLevels { get; init; }
+
+            /// <summary>Byte 9 high nibble.</summary>
+            public int DefaultLoadLine { get; init; }
+
+            /// <summary>Byte 10 bit 0.</summary>
+            public bool ChangeIrSensorToBoard { get; init; }
+
+            /// <summary>Byte 10 bit 2.</summary>
+            public bool IsPchOverheatSupport { get; init; }
+
+            /// <summary>Byte 10 bit 3.</summary>
+            public bool IsVrSensorSupport { get; init; }
+
+            /// <summary>Byte 11 bit 0.</summary>
+            public bool IsHotkeySupportFnP { get; init; }
+
+            /// <summary>Byte 11 bit 1.</summary>
+            public bool IsHotkeySupportFnF1 { get; init; }
+
+            /// <summary>The first 12 bytes of the reply, for diagnostics.</summary>
+            public byte[] RawData { get; init; }
+        }
+
+        /// <summary>
+        /// Decode the 4-byte <c>Legacy 0x0F</c> reply. Static and side-effect free so it can be tested
+        /// against captured replies without hardware.
+        /// </summary>
+        /// <remarks>
+        /// Byte map, from HP's own accessors (<c>GetSmartAdapterStatus</c>, <c>GetSupportBarrel</c>,
+        /// <c>GetUsbcDesignRating</c>, <c>GetPowerRating</c>):
+        /// <code>
+        /// [0]        SmartAdapterStatus
+        /// [1] bit 7  barrel jack supported
+        /// [2] x 5    USB-C design rating, W
+        /// [3] x 5    connected adapter rating, W  (0xFF = unknown)
+        /// </code>
+        /// </remarks>
+        public static AdapterInfo? DecodeAdapterData(byte[]? data)
+        {
+            if (data == null || data.Length < 4)
+                return null;
+
+            // 0xFF is HP's "I don't know" sentinel, not 1275 W. Decoding it as a wattage would make an
+            // unknown adapter look like the healthiest one on record.
+            bool ratingKnown = data[3] != 0xFF;
+
+            return new AdapterInfo
+            {
+                Status = (SmartAdapterStatus)data[0],
+                SupportsBarrelConnector = (data[1] & 0x80) != 0,
+                UsbcDesignRatingWatts = data[2] * 5,
+                PowerRatingWatts = ratingKnown ? data[3] * 5 : 0,
+                PowerRatingKnown = ratingKnown,
+                RawData = new[] { data[0], data[1], data[2], data[3] }
+            };
+        }
+
+        /// <summary>
+        /// Decode HP's <c>SystemDesignData</c> block from a <c>Default 0x28</c> reply. Static and
+        /// side-effect free so it can be tested against captured replies without hardware.
+        /// </summary>
+        public static SystemDesignData? DecodeSystemDesignData(byte[]? data)
+        {
+            // 12 bytes is everything HP's accessors read, even though the command returns 128.
+            if (data == null || data.Length < 12)
+                return null;
+
+            return new SystemDesignData
+            {
+                ShippingAdapterPowerRatingWatts = data[0] | (data[1] << 8),
+                ThermalPolicyVersion = (ThermalPolicyVersion)data[3],
+                IsSwFanControlSupport = (data[4] & 0x01) != 0,
+                IsExtremeModeSupport = (data[4] & 0x02) != 0,
+                IsExtremeModeUnlock = (data[4] & 0x04) != 0,
+                IsDTBiosControl = (data[4] & 0x08) != 0,
+                IsTwoBytePL4Support = (data[4] & 0x10) != 0,
+                PL4DefaultValue = data[5],
+                IsBiosDefinedOcSupport = (data[6] & 0x01) != 0,
+                GpuModeSwitch = data[7],
+                DefaultCpuPowerLimitWithGpuWatts = data[8],
+                LoadLineSupportLevels = data[9] & 0x0F,
+                DefaultLoadLine = (data[9] & 0xF0) >> 4,
+                // Two bits, not one: HP's rule is bit 0 clear AND bit 1 set. Reading bit 0 alone gets
+                // the wrong answer on a byte 10 of 0x03, which is what this board actually reports.
+                ChangeIrSensorToBoard = (data[10] & 0x03) == 0x02,
+                IsPchOverheatSupport = (data[10] & 0x04) != 0,
+                IsVrSensorSupport = (data[10] & 0x08) != 0,
+                IsHotkeySupportFnP = (data[11] & 0x01) != 0,
+                IsHotkeySupportFnF1 = (data[11] & 0x02) != 0,
+                RawData = data.Take(12).ToArray()
+            };
+        }
+
         public bool IsAvailable => _isAvailable;
         public bool IsConnected => _isAvailable; // Alias for IsAvailable
         public string Status { get; private set; } = "Not initialized";
         public ThermalPolicyVersion ThermalPolicy { get; private set; } = ThermalPolicyVersion.V1;
+
+        /// <summary>
+        /// HP's <c>SystemDesignData</c> capability block, decoded from the same <c>Default 0x28</c>
+        /// reply this class already issues at startup. Null until that query succeeds, or on firmware
+        /// that answers with fewer than 12 bytes.
+        /// </summary>
+        public SystemDesignData? SystemDesign { get; private set; }
         public int FanCount { get; private set; } = 2;
         
         /// <summary>
@@ -266,6 +568,7 @@ namespace OmenCore.Hardware
         // Cache static WMI data to avoid repeated queries
         private bool _staticDataCached = false;
         private readonly object _cacheLock = new();
+
 
         public HpWmiBios(LoggingService? logging = null)
         {
@@ -518,7 +821,32 @@ namespace OmenCore.Hardware
                 {
                     ThermalPolicy = (ThermalPolicyVersion)result[3];
                     _logging?.Info($"  Thermal Policy: V{(int)ThermalPolicy}");
-                    
+
+                    // The same reply carries HP's whole SystemDesignData capability block. Decoding it
+                    // costs nothing extra - it is the bytes we already asked for - and it is what HP's
+                    // own software gates features on at runtime.
+                    SystemDesign = DecodeSystemDesignData(result);
+                    if (SystemDesign is SystemDesignData design)
+                    {
+                        _logging?.Info(
+                            $"  System design: shipping adapter {design.ShippingAdapterPowerRatingWatts}W, " +
+                            $"CPU-with-GPU budget {design.DefaultCpuPowerLimitWithGpuWatts}W, " +
+                            $"SW fan control {design.IsSwFanControlSupport}, BIOS OC {design.IsBiosDefinedOcSupport}, " +
+                            $"2-byte PL4 {design.IsTwoBytePL4Support}");
+
+                        // Recorded, deliberately not acted on: a board has been seen declaring Extreme
+                        // Mode supported while reporting it locked. Nothing is known about what unlocks it.
+                        if (design.IsExtremeModeSupport && !design.IsExtremeModeUnlock)
+                        {
+                            _logging?.Debug("  Extreme Mode declared supported but reports locked (no action taken)");
+                        }
+                    }
+
+                    // Note the ordering: ThermalPolicy is assigned from the firmware byte above and may
+                    // be overridden by the model-name check below. SystemDesign.ThermalPolicyVersion is
+                    // NOT overridden - it stays the value the firmware actually reported, so diagnostics
+                    // can show when the two disagree.
+
                     // OMEN Max 2025+ detection - check model name as well
                     // Some OMEN Max models report V1 but need V2 commands for fan reading
                     if (ThermalPolicy >= ThermalPolicyVersion.V2)
@@ -1058,6 +1386,32 @@ namespace OmenCore.Hardware
                 _logging?.Warn($"Failed to get GPU mode: {ex.Message}");
             }
             return null;
+        }
+
+        /// <summary>
+        /// Read the power adapter's status and wattage. Read-only; issues <c>Legacy 0x0F</c>.
+        ///
+        /// Returns null when the board does not answer, or when WMI is unavailable for any other
+        /// reason. Deliberately does <b>not</b> cache "unsupported": a null here is indistinguishable
+        /// from a transient WMI failure - <c>SendBiosCommand</c> returns null for a disabled command
+        /// path, a dead CIM session and a genuine unimplemented command alike - so latching would let
+        /// one hiccup permanently, and silently, assert something false about the hardware. Nothing
+        /// polls this; it is read when the user opens Diagnostics, so a round trip per call is free.
+        /// </summary>
+        public AdapterInfo? GetAdapter()
+        {
+            if (!_isAvailable) return null;
+
+            try
+            {
+                var result = SendBiosCommand(BiosCmd.Legacy, CMD_ADAPTER_GET, null, 4);
+                return DecodeAdapterData(result);
+            }
+            catch (Exception ex)
+            {
+                _logging?.Warn($"Failed to get adapter status: {ex.Message}");
+                return null;
+            }
         }
 
         /// <summary>

--- a/src/OmenCoreApp/Hardware/HpWmiBios.cs
+++ b/src/OmenCoreApp/Hardware/HpWmiBios.cs
@@ -857,12 +857,34 @@ namespace OmenCore.Hardware
                     {
                         // Check model name for OMEN Max which may report V1 but need V2
                         var modelName = GetModelName();
-                        if (!string.IsNullOrEmpty(modelName) && 
+                        if (!string.IsNullOrEmpty(modelName) &&
                             modelName.Contains("MAX", StringComparison.OrdinalIgnoreCase) &&
                             modelName.Contains("OMEN", StringComparison.OrdinalIgnoreCase))
                         {
-                            _logging?.Info($"  ⚠️ OMEN Max detected by name but reports V1 - forcing V2 for fan commands");
-                            ThermalPolicy = ThermalPolicyVersion.V2;
+                            // Ask the firmware instead of asserting from the model name. Some OMEN Max
+                            // models do report V1 and answer the V2 fan commands - that is what this
+                            // branch exists for - but others report V1 and mean it. Board 8D87 (OMEN
+                            // MAX 16, 2025 AMD) is the second kind: it refuses 0x37 with BIOS return
+                            // code 6 and 0x38 with 4, at every input and output buffer size tried.
+                            //
+                            // This matters beyond which command to send, because DetectMaxFanLevel
+                            // reads ThermalPolicy to decide what UNIT fan levels are in - V2 means
+                            // percent and MaxFanLevel 100, V1 means krpm/100 and MaxFanLevel 55.
+                            // Force-switching a board whose levels are krpm/100 into the percentage
+                            // range makes WmiFanController.MapFanPercentToWmiLevel an identity, so a
+                            // request for 50% writes raw level 50 - roughly 5000 rpm, near maximum
+                            // rather than half. That is the same V1/V2 unit mismatch recorded in
+                            // ModelCapabilityDatabaseTests.GetCapabilities_8C77_Wf1xxx_UsesExactV1WmiProfileNotV2Mismatch,
+                            // which reached the reporter's device as a crash.
+                            if (ProbeV2FanCommands())
+                            {
+                                _logging?.Info("  ✓ OMEN Max reports V1 but answers the V2 fan commands - using V2");
+                                ThermalPolicy = ThermalPolicyVersion.V2;
+                            }
+                            else
+                            {
+                                _logging?.Info($"  OMEN Max detected by name, but the V2 fan commands were refused - keeping firmware-reported {ThermalPolicy}");
+                            }
                         }
                     }
 
@@ -889,6 +911,42 @@ namespace OmenCore.Hardware
             catch (Exception ex)
             {
                 _logging?.Warn($"Failed to query system data: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Ask the firmware whether it implements the V2 (OMEN Max 2025+) fan commands, instead of
+        /// inferring it from the model name.
+        ///
+        /// The two directions are not equally trustworthy, so they are not treated the same way:
+        ///
+        /// <b>Refusal is authoritative.</b> A refused command comes back with a non-zero BIOS return
+        /// code - 6 for 0x37 and 4 for 0x38 on board 8D87 - and <see cref="SendBiosCommand"/> returns
+        /// null for it. The ACPI timeout path cannot produce those codes; it returns zero (see the
+        /// remark on <see cref="SendBiosCommand"/>), so a null here really is the firmware saying no.
+        ///
+        /// <b>Acceptance is weak</b> for exactly that reason: a timeout looks like success. So both
+        /// V2 commands must be accepted before overriding the policy version the firmware itself
+        /// reported. Getting this wrong in the permissive direction changes the unit fan levels are
+        /// interpreted in, which is a user-visible fan-speed error, so the conservative default is to
+        /// believe the firmware's own byte.
+        ///
+        /// Deliberately does not require a non-zero reading: a stopped fan legitimately reads zero,
+        /// and the question here is whether the command exists, not what it currently says.
+        /// </summary>
+        private bool ProbeV2FanCommands()
+        {
+            try
+            {
+                if (SendBiosCommand(BiosCmd.Default, CMD_FAN_GET_LEVEL_V2, new byte[4], 128) == null)
+                    return false;
+
+                return SendBiosCommand(BiosCmd.Default, CMD_FAN_GET_RPM, new byte[4], 128) != null;
+            }
+            catch (Exception ex)
+            {
+                _logging?.Debug($"V2 fan command probe failed, assuming not supported: {ex.Message}");
                 return false;
             }
         }
@@ -1365,8 +1423,29 @@ namespace OmenCore.Hardware
         }
 
         /// <summary>
+        /// Decode the <c>Legacy 0x52</c> reply into a <see cref="GpuMode"/>, or null when the board
+        /// did not report one this method understands.
+        ///
+        /// The validation is the point. <see cref="GpuMode"/> declares 0x00-0x02, and casting an
+        /// out-of-range byte straight to the enum produces an undeclared value that compares equal to
+        /// none of Hybrid/Discrete/Optimus while printing as a bare number in logs - so a caller sees
+        /// neither a valid mode nor a failure. Same defect shape as the SmartAdapterStatus decode,
+        /// where a 0xFF wire byte rendered as the literal "255" instead of Error.
+        /// </summary>
+        public static GpuMode? DecodeGpuMode(byte[]? result)
+        {
+            if (result == null || result.Length < 1) return null;
+            if (!Enum.IsDefined(typeof(GpuMode), result[0])) return null;
+            return (GpuMode)result[0];
+        }
+
+        /// <summary>
         /// Get GPU mode (Hybrid/Discrete/Optimus).
         /// OmenMon: Cmd.Legacy, 0x52 (returns BIOS error 4 on unsupported)
+        ///
+        /// A zero reply decodes to <see cref="GpuMode.Hybrid"/>, which on this transport is also what
+        /// an ACPI timeout looks like - see the remark on <see cref="SendBiosCommand"/>. Treat a
+        /// Hybrid reading as weak evidence unless something else corroborates it.
         /// </summary>
         public GpuMode? GetGpuMode()
         {
@@ -1376,10 +1455,12 @@ namespace OmenCore.Hardware
             {
                 // Use Legacy command for GPU mode get (OmenMon)
                 var result = SendBiosCommand(BiosCmd.Legacy, CMD_GPU_GET_MODE, null, 4);
-                if (result != null && result.Length >= 1)
+                var mode = DecodeGpuMode(result);
+                if (mode == null && result != null && result.Length >= 1)
                 {
-                    return (GpuMode)result[0];
+                    _logging?.Warn($"GPU mode byte 0x{result[0]:X2} is outside the declared GpuMode range - ignoring");
                 }
+                return mode;
             }
             catch (Exception ex)
             {
@@ -1460,19 +1541,49 @@ namespace OmenCore.Hardware
         }
         
         /// <summary>
+        /// Decode the <c>Keyboard 0x01</c> reply into a <see cref="KbdType"/>, or null when the byte
+        /// is not one this method declares.
+        ///
+        /// Board 8D87 returns 0xFF here. Cast straight to the enum that becomes <c>(KbdType)255</c> -
+        /// outside the declared 0x00-0x03 range, logged as a bare "255", and indistinguishable to
+        /// callers from a real keyboard type. Null says what is actually true: the board did not
+        /// answer this question.
+        /// </summary>
+        public static KbdType? DecodeKeyboardType(byte[]? result)
+        {
+            if (result == null || result.Length < 1) return null;
+            if (!Enum.IsDefined(typeof(KbdType), result[0])) return null;
+            return (KbdType)result[0];
+        }
+
+        /// <summary>
         /// Get keyboard type.
         /// OmenMon: Cmd.Keyboard, 0x01
+        ///
+        /// Not every board answers this. Board 8D87 (OMEN MAX 16, 2025 AMD) returns 0xFF here, which
+        /// is not a KbdType at all, so this returns null on it. The keyboard topology probe HP's own
+        /// software gates on for that platform is a different command - Default 0x2B, null input,
+        /// 4-byte reply, whose byte 0 is NbKeyboardLightingType (3 = per-key RGB) - and it answers
+        /// correctly where Keyboard 0x01 does not. Adding it needs confirmation on more than one
+        /// board, so it is noted rather than done here; ModelCapabilities.HasPerKeyRgb carries the
+        /// answer for 8D87 in the meantime.
         /// </summary>
         public KbdType? GetKeyboardType()
         {
             if (!_isAvailable) return null;
-            
+
             try
             {
                 var result = SendBiosCommand(BiosCmd.Keyboard, CMD_KBD_TYPE_GET, new byte[4], 4);
                 if (result != null && result.Length > 0)
                 {
-                    var kbdType = (KbdType)result[0];
+                    var kbdType = DecodeKeyboardType(result);
+                    if (kbdType == null)
+                    {
+                        _logging?.Info($"Keyboard type byte 0x{result[0]:X2} is outside the declared KbdType range - reporting unknown");
+                        return null;
+                    }
+
                     _logging?.Info($"Keyboard type: {kbdType} (0x{result[0]:X2})");
                     return kbdType;
                 }
@@ -1934,6 +2045,35 @@ namespace OmenCore.Hardware
 
         /// <summary>
         /// Send a command to the BIOS via CIM/WMI using OmenMon's exact implementation.
+        ///
+        /// <b>A zero return code is not proof that the EC answered.</b> These WMI methods are ACPI
+        /// handlers that post the request into an EC mailbox and then poll a doorbell for about
+        /// 100 ms. On timeout they return the result package with the return code still zero and the
+        /// output buffer untouched, because the return code is only assigned on the dispatch switch's
+        /// default arm. So a zero return code means "the ACPI method ran", never "the hardware
+        /// replied", and a success carrying an all-zero buffer is indistinguishable from a timeout.
+        ///
+        /// That matters because the mailbox is a single shared buffer with no locking between OS
+        /// agents, and OMEN Gaming Hub polls it continuously. Running alongside it is not the
+        /// supported configuration, but it is a common one, and the failure is silent: during
+        /// reverse-engineering on board 8D87, repeated identical reads returned four different
+        /// values that were traceable to OGH's replies to its own questions - one byte tracked
+        /// MSAcpi_ThermalZoneTemperature exactly. Stopping OGH made every reading stable.
+        ///
+        /// Callers should therefore validate the reply's content, not just its return code:
+        /// <list type="bullet">
+        /// <item>treat an all-zero buffer from a command that must report something non-zero as a
+        /// failure, the way <see cref="GetFanLevel"/> already does before falling back;</item>
+        /// <item>range-check decoded values where a range is known, the way
+        /// <see cref="ParseFanRpmBuffer"/> already does;</item>
+        /// <item>for anything that drives a write, prefer reading a second time and requiring
+        /// agreement over trusting a single reply.</item>
+        /// </list>
+        ///
+        /// A non-zero return code is the trustworthy direction: the firmware produced it
+        /// deliberately, and the timeout path cannot. Note that 5 specifically means the output
+        /// buffer was the wrong size, not that the command is unsupported - a genuine refusal
+        /// persists across every size.
         /// </summary>
         /// <param name="command">The BIOS command class (Default, Keyboard, Legacy, GpuMode)</param>
         /// <param name="commandType">The specific command type/ID</param>

--- a/src/OmenCoreApp/Hardware/IHpWmiBios.cs
+++ b/src/OmenCoreApp/Hardware/IHpWmiBios.cs
@@ -29,6 +29,12 @@ namespace OmenCore.Hardware
         bool SetGpuPower(HpWmiBios.GpuPowerLevel level);
         HpWmiBios.GpuMode? GetGpuMode();
 
+        // GetAdapter() and SystemDesign are deliberately NOT on this interface. Every consumer holds
+        // the concrete HpWmiBios, so putting them here would add unused surface whose only effect is
+        // to make "silently return null" the default for any future implementer - and null is
+        // rendered as the affirmative claim "this board does not report an adapter". A wrong
+        // diagnostic statement is a worse failure than a compile error.
+
         void Dispose();
     }
 }

--- a/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
+++ b/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
@@ -1077,12 +1077,18 @@ namespace OmenCore.Hardware
                 // Stays false until the whole profile is confirmed. Power, thermal policy, EC, the
                 // fan range, the keyboard topology and both MUX flags are now owner-verified on
                 // hardware - the MUX rows by an actual mode switch and reboot, not by inference.
-                // What is still inherited: SupportsFanCurves and SupportsIndependentFanCurves, and
-                // the named PerformanceModes including "L5P" - all three need writes to confirm, and
-                // read-only identification work does not license them. The flag is all-or-nothing,
-                // so it reports the weakest claim in the entry.
+                // SupportsFanCurves is now MEASURED on this board, not inherited. With the fans
+                // coasting down from a previous command, a commanded 100% reversed the decay and
+                // drove them from ~3500 to 6000 rpm - the ceiling implied by MaxFanLevel 60 - read
+                // at the EC tachometers by an instrument outside the app. At 60% the same run
+                // measured 3600 rpm against an expected 3600. Levels move these fans.
+                //
+                // What is still inherited: the named PerformanceModes, including "L5P". Confirming
+                // those means showing each is accepted AND changes delivered power, which is a
+                // separate measurement. UserVerified is all-or-nothing across the entry, so it
+                // still reports the weakest claim - this one.
                 UserVerified = false,
-                Notes = "OMEN MAX Gaming Laptop 16-ak0xxx (GitHub #117), Product ID 8D87 — Ryzen AI 9 HX 375 + RTX 5080, BIOS F.07 / EC 40.38. Power, thermal-policy, fan-range, keyboard-topology and MUX fields owner-verified on hardware; fan curves and performance modes are still inherited from the adjacent MAX generation. Firmware reports thermal policy V1 and rejects the V2 fan commands (0x37/0x38), so fan levels come from the V1 0x2D fallback in krpm/100 — hence MaxFanLevel 60, measured, not 100. Keyboard is per-key RGB (topology probe 0x2B returns 3), so the four-zone path does not apply. Display MUX confirmed by switching modes: BIOS offers Hybrid/Discrete/UMA, and in Discrete the internal panel is driven by the dGPU while Legacy 0x52 reads 0x01 — but it is routed at boot, not under live ACPI control, so Advanced Optimus is false. EC is memory-mapped, so legacy EC offsets do not apply; the EC mailbox power block was forced with no effect."
+                Notes = "OMEN MAX Gaming Laptop 16-ak0xxx (GitHub #117), Product ID 8D87 — Ryzen AI 9 HX 375 + RTX 5080, BIOS F.07 / EC 40.38. Power, thermal-policy, fan-range, fan-curve, keyboard-topology and MUX fields owner-verified on hardware; only the named performance modes are still inherited from the adjacent MAX generation. Fan curves measured: a commanded 100% drove the fans to 6000 rpm against a decaying baseline, and 60% measured 3600 rpm against an expected 3600, read at the EC tachometers independently of the app. Firmware reports thermal policy V1 and rejects the V2 fan commands (0x37/0x38), so fan levels come from the V1 0x2D fallback in krpm/100 — hence MaxFanLevel 60, measured, not 100. Keyboard is per-key RGB (topology probe 0x2B returns 3), so the four-zone path does not apply. Display MUX confirmed by switching modes: BIOS offers Hybrid/Discrete/UMA, and in Discrete the internal panel is driven by the dGPU while Legacy 0x52 reads 0x01 — but it is routed at boot, not under live ACPI control, so Advanced Optimus is false. EC is memory-mapped, so legacy EC offsets do not apply; the EC mailbox power block was forced with no effect."
             });
             // -----------------------------------------------------------------------------------
             // OMEN 17 Series (17.3" laptops)

--- a/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
+++ b/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
@@ -58,6 +58,29 @@ namespace OmenCore.Hardware
         
         /// <summary>Whether RPM readback is available.</summary>
         public bool SupportsRpmReadback { get; set; } = true;
+
+        /// <summary>
+        /// EC RAM offsets of the fan tachometers, one per fan, each a 16-bit little-endian raw
+        /// RPM value at <c>offset</c> / <c>offset + 1</c>. Null (the default) means no EC
+        /// tachometer is known for this model and RPM comes from WMI, as before.
+        ///
+        /// Deliberately independent of <see cref="SupportsFanControlEc"/>. That flag gates EC
+        /// *writes*; this is a read, and the two have different risk profiles and different
+        /// evidence behind them - board 8D87 has EC fan control disabled and still has perfectly
+        /// readable tachometers. Nothing here may be used to derive a write address.
+        ///
+        /// Why this exists: on boards where the V2 command GetFanRpmDirect (0x38) is refused,
+        /// the only remaining RPM source is GetFanLevel x 100, which is the *commanded* level
+        /// echoed back. Under BIOS-automatic fan control nothing has been commanded, so that
+        /// reads 0 while the fans are physically turning - measured on 8D87 as 0 RPM reported
+        /// against 2760 RPM actual. An estimate derived from a command can never verify that a
+        /// command took effect; a tachometer can.
+        ///
+        /// Populate this only from a measured capture on the model in question. The legacy
+        /// single-byte offsets (0x34/0x35, krpm units) are NOT a safe default: on 8D87 they land
+        /// in the middle of the ASCII serial number and decode as a plausible-looking 6500 RPM.
+        /// </summary>
+        public ushort[]? EcFanTachometerOffsets { get; set; }
         
         /// <summary>Number of fan zones (typically 2: CPU + GPU).</summary>
         public int FanZoneCount { get; set; } = 2;
@@ -994,6 +1017,13 @@ namespace OmenCore.Hardware
                 SupportsFanCurves = true,
                 SupportsIndependentFanCurves = false,
                 SupportsRpmReadback = true, // measured: V1 0x2D tracks the EC tachometers at four points
+                // Fan 1 at 0x70, fan 2 at 0x5C, both 16-bit little-endian raw RPM. Read through
+                // the ACPI EC port pair, which aliases the MMIO state window: measured 2026-08-05
+                // over PawnIO's LpcACPIEC - the same module PawnIOEcAccess loads - at 99.2%
+                // agreement on stable bytes with 7 of 7 entropy-carrying anchors matching, 0x70
+                // reading 2760 through both views simultaneously. Reads only; this board keeps
+                // SupportsFanControlEc = false and nothing here implies a write address.
+                EcFanTachometerOffsets = new ushort[] { 0x70, 0x5C },
                 FanZoneCount = 2,
                 // Measured, not inherited: 60. This board reports thermal policy V1 and REJECTS the
                 // V2 fan commands outright - 0x37 returns RTCD 6 and 0x38 returns RTCD 4, at every

--- a/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
+++ b/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
@@ -211,6 +211,38 @@ namespace OmenCore.Hardware
         };
         
         /// <summary>
+        /// Boards on HP's <c>Vibrance25C1</c> platform - the 2025 OMEN MAX family that shares one
+        /// firmware base and one EC layout with <c>8D87</c>, the board that layout was reverse
+        /// engineered on.
+        ///
+        /// This is a <b>scope list for raw EC offsets, not a capability claim.</b> Only 8D87 has been
+        /// measured; the others are listed because they share the firmware, so an offset derived from
+        /// 8D87 is plausible on them and definitely wrong off-platform. Anything that writes a raw EC
+        /// offset derived from this platform should refuse to run on a board outside this list.
+        ///
+        /// Note that it is deliberately not a set of database entries: HP's own software gates power
+        /// features on the runtime <c>Default 0x28</c> capability query rather than on board ID, and
+        /// inventing three unmeasured profiles here would assert fan, RGB and MUX behaviour nobody
+        /// has confirmed. Prefer <see cref="HpWmiBios.SystemDesignData"/> for capability; use this
+        /// list only to bound raw-offset access.
+        /// </summary>
+        public static readonly IReadOnlyList<string> Vibrance25C1BoardIds = new[]
+        {
+            "8D87", // OMEN MAX 16-ak0xxx AMD - the measured board
+            "8D88",
+            "8DD5",
+            "8DD6"
+        };
+
+        /// <summary>
+        /// True when the board is on the <c>Vibrance25C1</c> platform. See
+        /// <see cref="Vibrance25C1BoardIds"/> for what this does and does not license.
+        /// </summary>
+        public static bool IsVibrance25C1Board(string? productId) =>
+            !string.IsNullOrWhiteSpace(productId) &&
+            Vibrance25C1BoardIds.Contains(productId, StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
         /// Default capabilities used when model is not in the database.
         /// Assumes standard OMEN laptop capabilities.
         /// </summary>
@@ -926,6 +958,25 @@ namespace OmenCore.Hardware
             });
 
             // OMEN MAX 16 (2025) - ak0xxx family (GitHub #117 / Product ID 8D87)
+            //
+            // Field-confirmed by the board's owner (BIOS F.07, EC 40.38) via ACPI decompilation plus
+            // live measurement. See docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md. Two things worth knowing
+            // before editing this entry:
+            //
+            //   * The firmware reports thermal policy V1 (Default 0x28 byte 3 = 0x01), but HpWmiBios
+            //     force-switches this board to V2 on a model-name substring match. That switch is
+            //     wrong here - the board refuses the V2 fan commands - and MaxFanLevel = 60 below is
+            //     what currently contains the damage, because it reaches DetectMaxFanLevel as the
+            //     model override and returns before the V2 branch. The diagnostics export prints
+            //     both the firmware-reported and effective values when they disagree.
+            //   * The EC here is memory-mapped, not at the legacy port offsets. The legacy EC map
+            //     does not apply: 0x9F on this board is battery remaining capacity in mAh, not a GPU
+            //     tachometer. The real fan tachometers are 0x70 (fan 1) and 0x5C (fan 2), both
+            //     16-bit raw rpm in the state window at 0xFE700600. 0x7E is NOT the second
+            //     tachometer - it is a commanded setpoint gated by the level byte at 0x5B, it reads
+            //     0 whenever nothing has been commanded, and it stays fixed while the fan it
+            //     supposedly measures changes speed. OmenCore has never inherited the legacy
+            //     mistake; the note is here so nobody introduces it.
             AddModel(new ModelCapabilities
             {
                 ProductId = "8D87",
@@ -935,22 +986,73 @@ namespace OmenCore.Hardware
                 Family = OmenModelFamily.OMEN2024Plus,
                 SupportsFanControlWmi = true,
                 SupportsFanControlEc = false, // MAX-series EC layout diverges from legacy mappings
+                // The EC mailbox power block at 0xF5-0xF8 (mailbox window, not the state window) was
+                // forced to its high-power values with no effect - it is a mirror the SMU never reads
+                // back. PowerLimitController's own 0xC0-0xC5 offsets are a different window and have
+                // not been tested here, so this stays false for both reasons.
+                SupportsEcPowerLimits = false,
                 SupportsFanCurves = true,
                 SupportsIndependentFanCurves = false,
-                SupportsRpmReadback = true,
+                SupportsRpmReadback = true, // measured: V1 0x2D tracks the EC tachometers at four points
                 FanZoneCount = 2,
-                MaxFanLevel = 100,
+                // Measured, not inherited: 60. This board reports thermal policy V1 and REJECTS the
+                // V2 fan commands outright - 0x37 returns RTCD 6 and 0x38 returns RTCD 4, at every
+                // input and output buffer size tried. Fan levels therefore arrive through the V1
+                // 0x2D fallback in krpm/100, not percent, so MaxFanLevel = 100 made
+                // MapFanPercentToWmiLevel an identity: a request for 50% wrote raw level 50, which
+                // is ~5000 rpm - near maximum, not half. Sampled against the EC tachometers and
+                // OGH's own readout at four points (0/0, 22/2220, 47/4680, 60/6000), linear within
+                // ~1%, ceiling 60. This value reaches DetectMaxFanLevel as the model override and
+                // returns before the V2 branch, so it is what actually takes effect.
+                // Same defect class as GetCapabilities_8C77_Wf1xxx_UsesExactV1WmiProfileNotV2Mismatch.
+                MaxFanLevel = 60,
                 MaxModeDropChecksBeforeReapply = 1,
                 SupportsPerformanceModes = true,
                 PerformanceModes = new[] { "Default", "Performance", "Cool", "L5P" },
+                // Measured across a reboot in each direction. BIOS setup offers Hybrid / Discrete /
+                // UMA; switching to Discrete moves Legacy 0x52 byte 0 from 0x00 to 0x01 and moves
+                // the INTERNAL PANEL to the dGPU - in Discrete the sole display is the built-in
+                // CMN1652 at its native 2560x1600 driven by the RTX 5080, with the Radeon reporting
+                // no active mode and nvidia-smi reporting display_active = Enabled. The panel does
+                // not merely stay lit, it changes which GPU lights it, which is what HasMuxSwitch
+                // claims. Fully reversible: the restored capture matches the baseline on every WMI
+                // and AMD_PBS_SETUP field.
                 HasMuxSwitch = true,
                 SupportsGpuPowerBoost = true,
-                SupportsAdvancedOptimus = true,
+                // Measured false, and it was inherited true. Advanced Optimus is the *dynamic* kind
+                // of switching - the display mux moves under live ACPI control with no reboot - and
+                // that whole block is switched off in firmware: AMD_PBS_SETUP 0xB6 Smart Mux Support
+                // = 0 (Disabled), 0xC7 Smart Mux Acpi Control = 0, 0xCA MDM Support Level = 0 (No
+                // Support), 0xC8 Display Panel Multiplexer = 0.
+                //
+                // The mode switch above is what makes this conclusive rather than merely suggestive:
+                // that block still read 0 in Discrete and again after returning to Hybrid. It stays
+                // off through a switch that demonstrably works, so the routing decision is taken at
+                // boot by firmware and there is no runtime control surface. A mux without Advanced
+                // Optimus is exactly this board.
+                SupportsAdvancedOptimus = false,
+                // Measured via the keyboard topology probe - class 0x00020008, command 0x2B, null
+                // input, 4-byte return - which returns 0x03 = NbKeyboardLightingType.RgbPerKey,
+                // stable across repeated reads. That is the probe HP itself gates on for this
+                // platform; the Keyboard command class (0x00020009) is NOT the gate here and
+                // returns an 0xFF sentinel for the type query.
                 HasKeyboardBacklight = true,
                 HasPerKeyRgb = true,
+                // False, and deliberately explicit rather than left to the property default of
+                // true. HP's own gate (FourZoneHelper.IsSupported) returns false for lighting type
+                // 3, so the four-zone command path does not drive a per-key keyboard. Without this
+                // line the entry claimed per-key AND four-zone simultaneously.
+                HasFourZoneRgb = false,
                 SupportsUndervolt = false, // AMD Ryzen AI path does not use Intel MSR undervolt
+                // Stays false until the whole profile is confirmed. Power, thermal policy, EC, the
+                // fan range, the keyboard topology and both MUX flags are now owner-verified on
+                // hardware - the MUX rows by an actual mode switch and reboot, not by inference.
+                // What is still inherited: SupportsFanCurves and SupportsIndependentFanCurves, and
+                // the named PerformanceModes including "L5P" - all three need writes to confirm, and
+                // read-only identification work does not license them. The flag is all-or-nothing,
+                // so it reports the weakest claim in the entry.
                 UserVerified = false,
-                Notes = "GitHub #117 — OMEN MAX Gaming Laptop 16-ak0xxx, Product ID 8D87. Model profile inferred from adjacent MAX ak/ah generation; verify keyboard/fan behavior on real hardware."
+                Notes = "OMEN MAX Gaming Laptop 16-ak0xxx (GitHub #117), Product ID 8D87 — Ryzen AI 9 HX 375 + RTX 5080, BIOS F.07 / EC 40.38. Power, thermal-policy, fan-range, keyboard-topology and MUX fields owner-verified on hardware; fan curves and performance modes are still inherited from the adjacent MAX generation. Firmware reports thermal policy V1 and rejects the V2 fan commands (0x37/0x38), so fan levels come from the V1 0x2D fallback in krpm/100 — hence MaxFanLevel 60, measured, not 100. Keyboard is per-key RGB (topology probe 0x2B returns 3), so the four-zone path does not apply. Display MUX confirmed by switching modes: BIOS offers Hybrid/Discrete/UMA, and in Discrete the internal panel is driven by the dGPU while Legacy 0x52 reads 0x01 — but it is routed at boot, not under live ACPI control, so Advanced Optimus is false. EC is memory-mapped, so legacy EC offsets do not apply; the EC mailbox power block was forced with no effect."
             });
             // -----------------------------------------------------------------------------------
             // OMEN 17 Series (17.3" laptops)

--- a/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
+++ b/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
@@ -1038,7 +1038,28 @@ namespace OmenCore.Hardware
                 MaxFanLevel = 60,
                 MaxModeDropChecksBeforeReapply = 1,
                 SupportsPerformanceModes = true,
-                PerformanceModes = new[] { "Default", "Performance", "Cool", "L5P" },
+                // Measured in watts, not return codes. SetFanMode (Default 0x1A) writes NPCF.MODE,
+                // and the firmware consumes it as (MODE & 0x0F) - so the three mode bytes collapse
+                // onto two profiles. With the OGHP gate armed, on the 330 W adapter:
+                //
+                //   Default     0x30 -> nibble 0 -> enforced.power.limit ~102 W (floating)
+                //   Performance 0x31 -> nibble 1 -> enforced.power.limit  175.00 W (pinned)
+                //   Cool        0x50 -> nibble 0 -> enforced.power.limit ~103 W  <- same as Default
+                //
+                // Performance was re-run as a positive control between every pair of readings and
+                // hit 175.00 W every time, so the gate was up throughout; a dropped gate reads
+                // 80.00 W and would otherwise masquerade as MODE 0. All three bytes return RTCD 0,
+                // including the two that select the same profile, which is why acceptance was never
+                // evidence here.
+                //
+                // "L5P" IS REMOVED, and it was inherited from the adjacent AK0003NR entry rather
+                // than measured. HpWmiBios.FanMode has no L5P member at all, so the string could
+                // never reach SetFanMode - it resolves only inside OghServiceProxy.ThermalPolicy,
+                // a different transport. Listing it here advertised a mode the WMI path cannot
+                // send. The firmware does have a fourth profile - MODE 4, reachable with a raw
+                // byte whose low nibble is 4, measured at 175.00 W approached from MODE 0 - but it
+                // is not L5P and no consumer project names it, so nothing is claimed for it here.
+                PerformanceModes = new[] { "Default", "Performance", "Cool" },
                 // Measured across a reboot in each direction. BIOS setup offers Hybrid / Discrete /
                 // UMA; switching to Discrete moves Legacy 0x52 byte 0 from 0x00 to 0x01 and moves
                 // the INTERNAL PANEL to the dGPU - in Discrete the sole display is the built-in
@@ -1072,23 +1093,75 @@ namespace OmenCore.Hardware
                 // true. HP's own gate (FourZoneHelper.IsSupported) returns false for lighting type
                 // 3, so the four-zone command path does not drive a per-key keyboard. Without this
                 // line the entry claimed per-key AND four-zone simultaneously.
-                HasFourZoneRgb = false,
-                SupportsUndervolt = false, // AMD Ryzen AI path does not use Intel MSR undervolt
-                // Stays false until the whole profile is confirmed. Power, thermal policy, EC, the
-                // fan range, the keyboard topology and both MUX flags are now owner-verified on
-                // hardware - the MUX rows by an actual mode switch and reboot, not by inference.
-                // SupportsFanCurves is now MEASURED on this board, not inherited. With the fans
-                // coasting down from a previous command, a commanded 100% reversed the decay and
-                // drove them from ~3500 to 6000 rpm - the ceiling implied by MaxFanLevel 60 - read
-                // at the EC tachometers by an instrument outside the app. At 60% the same run
-                // measured 3600 rpm against an expected 3600. Levels move these fans.
                 //
-                // What is still inherited: the named PerformanceModes, including "L5P". Confirming
-                // those means showing each is accepted AND changes delivered power, which is a
-                // separate measurement. UserVerified is all-or-nothing across the entry, so it
-                // still reports the weakest claim - this one.
-                UserVerified = false,
-                Notes = "OMEN MAX Gaming Laptop 16-ak0xxx (GitHub #117), Product ID 8D87 — Ryzen AI 9 HX 375 + RTX 5080, BIOS F.07 / EC 40.38. Power, thermal-policy, fan-range, fan-curve, keyboard-topology and MUX fields owner-verified on hardware; only the named performance modes are still inherited from the adjacent MAX generation. Fan curves measured: a commanded 100% drove the fans to 6000 rpm against a decaying baseline, and 60% measured 3600 rpm against an expected 3600, read at the EC tachometers independently of the app. Firmware reports thermal policy V1 and rejects the V2 fan commands (0x37/0x38), so fan levels come from the V1 0x2D fallback in krpm/100 — hence MaxFanLevel 60, measured, not 100. Keyboard is per-key RGB (topology probe 0x2B returns 3), so the four-zone path does not apply. Display MUX confirmed by switching modes: BIOS offers Hybrid/Discrete/UMA, and in Discrete the internal panel is driven by the dGPU while Legacy 0x52 reads 0x01 — but it is routed at boot, not under live ACPI control, so Advanced Optimus is false. EC is memory-mapped, so legacy EC offsets do not apply; the EC mailbox power block was forced with no effect."
+                // What the four-zone path DOES drive here is the light bar. Owner-observed: issuing
+                // the four-zone colour commands on this board visibly changes the light bar colour
+                // and leaves the keyboard untouched. So "four-zone returned success" was never a
+                // null result on this machine - it was landing on a different lighting surface than
+                // the one being watched, which is a more misleading failure than an outright
+                // refusal. Read this flag as "four-zone KEYBOARD", which is what it gates.
+                HasFourZoneRgb = false,
+                // True, owner-confirmed by the above: this chassis has a light bar and it is the
+                // surface that responds to the four-zone commands. Previously left at the property
+                // default of false, which the entry would now be asserting as verified.
+                HasLightBar = true,
+                // TRUE, and it was previously false with the comment "AMD Ryzen AI path does not use
+                // Intel MSR undervolt" - which gave the wrong reason by conflating "not Intel MSR"
+                // with "not undervoltable". This part undervolts fine via AMD Curve Optimizer;
+                // owner-confirmed on this machine.
+                //
+                // The distinction this field has to keep straight: it describes what the HARDWARE
+                // supports, not whether OmenCore's SMU backend can drive it today. Those are
+                // separate gates and DeviceCapabilities.ShowUndervolt already ANDs both -
+                //     CanUndervolt && UndervoltRuntimeReady && ModelConfig.SupportsUndervolt
+                // - so a missing or unmapped SMU is caught by UndervoltRuntimeReady, which surfaces
+                // AmdUndervoltProvider's own RuntimeBlockReason text. Setting this false as a proxy
+                // for backend readiness suppressed the feature twice and hid the actionable message
+                // behind a capability claim that was simply untrue.
+                //
+                // Nothing here rules Curve Optimizer out either: RyzenControl's exclusion is
+                // (family == 0x1A && model >= 0x40), and this part reports AMD64 Family 26 Model 36
+                // - family 0x1A, model 0x24 - so it is below that bound and not excluded.
+                SupportsUndervolt = true,
+                // Same reason as SupportsUndervolt, and previously left at the property default of
+                // true: TCC offset is an Intel thermal-control-circuit knob and there is no such
+                // register on a Ryzen AI 9 HX 375. Explicit rather than defaulted so the entry does
+                // not claim an Intel-only capability on an AMD board.
+                SupportsTccOffset = false,
+                // Explicit, and it agrees with the property default. Default 0x28 byte 4 = 0x03:
+                // bit 0 SwFanCtl set, bit 1 ExtremeMode SUPPORTED - but bit 2 ExtremeModeUnlock is
+                // CLEAR. The SKU knows the feature and the firmware has not unlocked it, so the
+                // effective capability is false. Recorded here so a later reader does not see
+                // "ExtremeMode supported" in the capability block and flip this to true.
+                SupportsOverboost = false,
+                // TRUE. Every board-specific claim in this entry is now owner-verified on the
+                // hardware itself, by outcome rather than by return code:
+                //
+                //   power / thermal policy   Default 0x28 decoded and cross-checked; V1 confirmed
+                //                            by the V2 fan commands being refused outright
+                //   EC layout                memory-mapped window located; port view cross-checked
+                //                            against MMIO at 99.2% on stable bytes
+                //   fan range                MaxFanLevel 60 sampled at four points, linear to ~1%
+                //   fan curves               a commanded 100% reversed a coast-down, ~3500 -> 6000
+                //                            rpm; 60% measured 3600 against an expected 3600, read
+                //                            at the EC tachometers by an instrument outside the app
+                //   RPM readback             0x70 / 0x5C tracking the rotor through a full ramp
+                //   keyboard topology        probe 0x2B returns 3 = RgbPerKey, stable on reread
+                //   both MUX flags           an actual BIOS mode switch and reboot, in both
+                //                            directions, not inference from adapter activity
+                //   performance modes        the sweep documented above, with a positive control
+                //                            between every reading
+                //
+                // What is NOT claimed, so that this flag is not read as more than it is. The
+                // remaining fields are property defaults that were never board-specific claims:
+                // SupportsNetworkBoost and SupportsPowerLimits are untested here, and
+                // SupportsIndependentFanCurves is set false as the conservative choice rather than
+                // because independent curves were shown impossible. UserVerified is all-or-nothing
+                // across the entry, so it is being flipped on the strength of the measured rows;
+                // a defect in one of those defaults is a reason to fix the field, not to reset
+                // this flag.
+                UserVerified = true,
+                Notes = "OMEN MAX Gaming Laptop 16-ak0xxx (GitHub #117), Product ID 8D87 — Ryzen AI 9 HX 375 + RTX 5080, BIOS F.07 / EC 40.38. Fully owner-verified on hardware. Performance modes measured in delivered watts: SetFanMode writes NPCF.MODE and the firmware consumes (MODE & 0x0F), so Default (0x30) and Cool (0x50) both select nibble 0 and deliver the same ~102 W GPU limit, while Performance (0x31) selects nibble 1 and pins enforced.power.limit at 175 W — Cool differs from Default as fan policy, not as a power tier. All three return RTCD 0, so acceptance was never the evidence. \"L5P\" has been removed: it was inherited from the adjacent AK0003NR entry and HpWmiBios.FanMode has no byte for it, so the WMI path could never send it. Fan curves measured: a commanded 100% drove the fans to 6000 rpm against a decaying baseline, and 60% measured 3600 rpm against an expected 3600, read at the EC tachometers independently of the app. Firmware reports thermal policy V1 and rejects the V2 fan commands (0x37/0x38), so fan levels come from the V1 0x2D fallback in krpm/100 — hence MaxFanLevel 60, measured, not 100. Keyboard is per-key RGB (topology probe 0x2B returns 3), so the four-zone keyboard path does not apply — the four-zone commands instead drive this chassis's light bar, owner-observed, which is why they appeared to succeed while the keyboard never changed. Display MUX confirmed by switching modes: BIOS offers Hybrid/Discrete/UMA, and in Discrete the internal panel is driven by the dGPU while Legacy 0x52 reads 0x01 — but it is routed at boot, not under live ACPI control, so Advanced Optimus is false. EC is memory-mapped, so legacy EC offsets do not apply; the EC mailbox power block was forced with no effect."
             });
             // -----------------------------------------------------------------------------------
             // OMEN 17 Series (17.3" laptops)

--- a/src/OmenCoreApp/Hardware/WmiFanController.cs
+++ b/src/OmenCoreApp/Hardware/WmiFanController.cs
@@ -24,6 +24,22 @@ namespace OmenCore.Hardware
     {
         private readonly IHpWmiBios _wmiBios;
         private readonly IEcAccess? _ecAccess;
+
+        /// <summary>
+        /// Per-fan EC offsets of 16-bit little-endian raw RPM tachometers, or null when this
+        /// model has none. See <see cref="ModelCapabilities.EcFanTachometerOffsets"/>; this is
+        /// a read-only capability and is not tied to EC fan control.
+        /// </summary>
+        private readonly ushort[]? _ecFanTachometerOffsets;
+
+        /// <summary>
+        /// Above this, a tachometer pair is not a fan speed - it is a mis-aimed offset reading
+        /// whatever else lives in EC RAM. Matches the existing WMI RPM sanity ceiling.
+        /// </summary>
+        private const int MaxPlausibleFanRpm = 8000;
+
+        /// <summary>Set once the EC tachometer read has failed, to stop retrying every tick.</summary>
+        private bool _ecTachometerUnavailable;
         private readonly LibreHardwareMonitorImpl? _hwMonitor;
         private readonly LoggingService? _logging;
         private readonly bool _strictFanModeReadback;
@@ -185,12 +201,14 @@ namespace OmenCore.Hardware
             IEcAccess? ecAccess = null,
             bool strictFanModeReadback = true,
             bool allowV1AutoModeFloorClear = true,
-            int? maxModeDropChecksBeforeReapply = null)
+            int? maxModeDropChecksBeforeReapply = null,
+            ushort[]? ecFanTachometerOffsets = null)
         {
             _hwMonitor = hwMonitor;
             _logging = logging;
             _wmiBios = injectedWmiBios ?? new HpWmiBios(logging);
             _ecAccess = ecAccess;
+            _ecFanTachometerOffsets = ecFanTachometerOffsets;
             _strictFanModeReadback = strictFanModeReadback;
             _allowV1AutoModeFloorClear = allowV1AutoModeFloorClear;
             _maxModeDropChecksBeforeReapply = Math.Clamp(
@@ -1335,6 +1353,24 @@ namespace OmenCore.Hardware
                     }
                 }
                 
+                // Try the EC tachometers before falling back to the fan level. Order matters:
+                // the level fallback below is the *commanded* value echoed back, so preferring
+                // it over a physical tachometer would replace a measurement with an estimate.
+                if (!gotValidData)
+                {
+                    var ecRpm = TryReadEcTachometers();
+                    if (ecRpm.HasValue)
+                    {
+                        fan1Rpm = ecRpm.Value.fan1Rpm;
+                        fan2Rpm = ecRpm.Value.fan2Rpm;
+                        fan1Percent = Math.Clamp((fan1Rpm * 100) / 5500, 0, 100);
+                        fan2Percent = Math.Clamp((fan2Rpm * 100) / 5500, 0, 100);
+                        gotValidData = true;
+                        rpmSource = RpmSource.EcDirect;
+                        _logging?.Debug($"[FanRPM] EC tachometers: CPU={fan1Rpm} ({fan1Percent}%), GPU={fan2Rpm} ({fan2Percent}%)");
+                    }
+                }
+
                 // Try fan level if direct RPM unavailable
                 if (!gotValidData)
                 {
@@ -1832,6 +1868,73 @@ namespace OmenCore.Hardware
 
             _lastCountdownExtendUtc = nowUtc;
             _wmiBios.ExtendFanCountdown();
+        }
+
+        /// <summary>
+        /// Read the fan tachometers straight out of EC RAM, for models whose profile supplies
+        /// their offsets. Returns null when this model has none, when EC access is unavailable,
+        /// or when the values read back are not plausible fan speeds.
+        ///
+        /// A zero from here is reported as a zero. That is the point: on a board where the only
+        /// other RPM source is the commanded level echoed back, "0 RPM" and "no reading" were
+        /// indistinguishable, and a fan-speed change could be declared verified against a
+        /// reading that came from the request itself.
+        ///
+        /// No transition debounce is applied, unlike the WMI paths below. Those filter readings
+        /// taken while the BIOS is still reporting a stale *target*; a tachometer has no target
+        /// to be stale about, and suppressing its output during spin-up or spin-down would
+        /// discard exactly the measurements that show the fan responding.
+        /// </summary>
+        private (int fan1Rpm, int fan2Rpm)? TryReadEcTachometers()
+        {
+            if (_ecFanTachometerOffsets is not { Length: >= 2 } offsets ||
+                _ecAccess?.IsAvailable != true ||
+                _ecTachometerUnavailable)
+            {
+                return null;
+            }
+
+            try
+            {
+                var fan1Rpm = ReadEcTachometer(offsets[0]);
+                var fan2Rpm = ReadEcTachometer(offsets[1]);
+
+                // A mis-aimed offset usually reads as something far too large rather than as an
+                // error - on this board's neighbours the legacy offsets land in an ASCII serial
+                // number and decode to a believable-looking four-digit RPM. Refuse the pair
+                // rather than publish a number no fan could produce.
+                if (fan1Rpm > MaxPlausibleFanRpm || fan2Rpm > MaxPlausibleFanRpm)
+                {
+                    _logging?.Warn($"[FanRPM] EC tachometers at 0x{offsets[0]:X2}/0x{offsets[1]:X2} " +
+                                   $"read {fan1Rpm}/{fan2Rpm} RPM, beyond {MaxPlausibleFanRpm} - " +
+                                   "treating the offsets as wrong for this board and falling back");
+                    _ecTachometerUnavailable = true;
+                    return null;
+                }
+
+                return (fan1Rpm, fan2Rpm);
+            }
+            catch (Exception ex)
+            {
+                // PawnIOEcAccess throws rather than returning 0 on a failed transaction, which
+                // is what makes a returned 0 above trustworthy. Stop asking after the first
+                // failure; an EC that will not answer this tick will not answer the next either,
+                // and retrying every tick is how EC contention gets amplified.
+                _logging?.Warn($"[FanRPM] EC tachometer read failed ({ex.GetType().Name}: {ex.Message}); " +
+                               "falling back to WMI fan level for RPM");
+                _ecTachometerUnavailable = true;
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// One 16-bit little-endian raw RPM value at <paramref name="offset"/> / offset + 1.
+        /// </summary>
+        private int ReadEcTachometer(ushort offset)
+        {
+            int low = _ecAccess!.ReadByte(offset);
+            int high = _ecAccess.ReadByte((ushort)(offset + 1));
+            return low | (high << 8);
         }
 
         private bool ConfirmFanModeReadback(HpWmiBios.FanMode expectedMode, string operation)

--- a/src/OmenCoreApp/Hardware/WmiFanController.cs
+++ b/src/OmenCoreApp/Hardware/WmiFanController.cs
@@ -1842,6 +1842,21 @@ namespace OmenCore.Hardware
                 return true;
             }
 
+            // Decide this BEFORE reading. EcFanModeRegister is the legacy port-EC offset, and on
+            // boards whose profile disables direct EC fan control it does not hold the fan mode at
+            // all - on 8D87 (memory-mapped EC) it reads 0x02 where 0x30 is expected. The mismatch
+            // was already being ignored, but only after three reads, two 40 ms sleeps and a WARN
+            // pair per fan-mode change: a scary log line and an EC transaction, both for an answer
+            // that could not be used either way.
+            if (!_strictFanModeReadback)
+            {
+                _logging?.Debug(
+                    $"Fan mode readback skipped for {operation}; model profile does not allow direct " +
+                    $"EC fan-mode verification (EC[0x{EcFanModeRegister:X2}] is the legacy offset and " +
+                    "is not authoritative on this board)");
+                return true;
+            }
+
             byte expected = (byte)expectedMode;
             byte? lastRead = null;
 
@@ -1871,12 +1886,6 @@ namespace OmenCore.Hardware
 
             var actualText = lastRead.HasValue ? $"0x{lastRead.Value:X2}" : "n/a";
             _logging?.Warn($"Fan mode readback mismatch for {operation}: expected EC[0x{EcFanModeRegister:X2}]=0x{expected:X2}, got {actualText}");
-            if (!_strictFanModeReadback)
-            {
-                _logging?.Warn($"Fan mode readback mismatch ignored for {operation}; model profile does not allow direct EC fan-mode verification");
-                return true;
-            }
-
             return false;
         }
 

--- a/src/OmenCoreApp/Hardware/WmiFanController.cs
+++ b/src/OmenCoreApp/Hardware/WmiFanController.cs
@@ -38,8 +38,36 @@ namespace OmenCore.Hardware
         /// </summary>
         private const int MaxPlausibleFanRpm = 8000;
 
-        /// <summary>Set once the EC tachometer read has failed, to stop retrying every tick.</summary>
+        /// <summary>
+        /// Consecutive EC transaction failures before the tachometer path backs off. A single
+        /// timeout is normal: the ACPI EC port pair is shared with the firmware's own traffic and
+        /// a busy tick returns "output buffer not full" rather than an answer. Measured on 8D87 -
+        /// one run of the app logged a single timeout 39 seconds in and none before or after,
+        /// while the run before it logged none at all.
+        /// </summary>
+        private const int EcTachometerFailuresBeforeBackoff = 3;
+
+        /// <summary>
+        /// How long to stop asking after a run of failures. Long enough that a genuinely dead EC
+        /// costs almost no traffic, short enough that a recovered one is picked up in seconds.
+        /// </summary>
+        private static readonly TimeSpan EcTachometerBackoff = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Consecutive implausible readings before the offsets are written off for this board.
+        /// A tachometer is read as two separate byte transactions, so a single garbage pair can
+        /// be a torn read; a run of them means the offsets are pointed at something else.
+        /// </summary>
+        private const int EcTachometerImplausibleReadsBeforeGivingUp = 3;
+
+        /// <summary>
+        /// Set only when the offsets are judged wrong for this board - a permanent condition.
+        /// A failed *transaction* never sets this; it backs off and retries instead.
+        /// </summary>
         private bool _ecTachometerUnavailable;
+        private int _ecTachometerFailureStreak;
+        private int _ecTachometerImplausibleStreak;
+        private DateTime _ecTachometerRetryAfterUtc = DateTime.MinValue;
         private readonly LibreHardwareMonitorImpl? _hwMonitor;
         private readonly LoggingService? _logging;
         private readonly bool _strictFanModeReadback;
@@ -1873,7 +1901,10 @@ namespace OmenCore.Hardware
         /// <summary>
         /// Read the fan tachometers straight out of EC RAM, for models whose profile supplies
         /// their offsets. Returns null when this model has none, when EC access is unavailable,
-        /// or when the values read back are not plausible fan speeds.
+        /// when the transaction fails, or when the values read back are not plausible fan speeds.
+        ///
+        /// Both failure kinds are treated as transient until proven otherwise - see the streak
+        /// counters above. A single refused transaction is ordinary EC contention.
         ///
         /// A zero from here is reported as a zero. That is the point: on a board where the only
         /// other RPM source is the commanded level echoed back, "0 RPM" and "no reading" were
@@ -1889,7 +1920,8 @@ namespace OmenCore.Hardware
         {
             if (_ecFanTachometerOffsets is not { Length: >= 2 } offsets ||
                 _ecAccess?.IsAvailable != true ||
-                _ecTachometerUnavailable)
+                _ecTachometerUnavailable ||
+                DateTime.UtcNow < _ecTachometerRetryAfterUtc)
             {
                 return null;
             }
@@ -1905,24 +1937,49 @@ namespace OmenCore.Hardware
                 // rather than publish a number no fan could produce.
                 if (fan1Rpm > MaxPlausibleFanRpm || fan2Rpm > MaxPlausibleFanRpm)
                 {
+                    if (++_ecTachometerImplausibleStreak < EcTachometerImplausibleReadsBeforeGivingUp)
+                    {
+                        _logging?.Debug($"[FanRPM] EC tachometers read {fan1Rpm}/{fan2Rpm} RPM, beyond " +
+                                        $"{MaxPlausibleFanRpm} - discarding as a torn read " +
+                                        $"({_ecTachometerImplausibleStreak}/{EcTachometerImplausibleReadsBeforeGivingUp})");
+                        return null;
+                    }
+
                     _logging?.Warn($"[FanRPM] EC tachometers at 0x{offsets[0]:X2}/0x{offsets[1]:X2} " +
-                                   $"read {fan1Rpm}/{fan2Rpm} RPM, beyond {MaxPlausibleFanRpm} - " +
-                                   "treating the offsets as wrong for this board and falling back");
+                                   $"read {fan1Rpm}/{fan2Rpm} RPM, beyond {MaxPlausibleFanRpm}, " +
+                                   $"{_ecTachometerImplausibleStreak} times running - treating the " +
+                                   "offsets as wrong for this board and falling back for good");
                     _ecTachometerUnavailable = true;
                     return null;
                 }
 
+                _ecTachometerFailureStreak = 0;
+                _ecTachometerImplausibleStreak = 0;
                 return (fan1Rpm, fan2Rpm);
             }
             catch (Exception ex)
             {
-                // PawnIOEcAccess throws rather than returning 0 on a failed transaction, which
-                // is what makes a returned 0 above trustworthy. Stop asking after the first
-                // failure; an EC that will not answer this tick will not answer the next either,
-                // and retrying every tick is how EC contention gets amplified.
-                _logging?.Warn($"[FanRPM] EC tachometer read failed ({ex.GetType().Name}: {ex.Message}); " +
-                               "falling back to WMI fan level for RPM");
-                _ecTachometerUnavailable = true;
+                // PawnIOEcAccess throws rather than returning 0 on a failed transaction, which is
+                // what makes a returned 0 above trustworthy. A failure is not evidence the EC will
+                // keep refusing: the port pair is shared with the firmware's own traffic, so a
+                // single "output buffer not full" is contention, not absence. Back off after a run
+                // of them so a genuinely dead EC costs no traffic, but always come back - giving up
+                // on the first timeout leaves the board on the fan-level estimate for the rest of
+                // the session, which is what shipped and what a verification run then scored.
+                if (++_ecTachometerFailureStreak >= EcTachometerFailuresBeforeBackoff)
+                {
+                    _ecTachometerRetryAfterUtc = DateTime.UtcNow + EcTachometerBackoff;
+                    _ecTachometerFailureStreak = 0;
+                    _logging?.Warn($"[FanRPM] EC tachometer read failed ({ex.GetType().Name}: {ex.Message}) " +
+                                   $"{EcTachometerFailuresBeforeBackoff} times running; using the WMI fan " +
+                                   $"level for RPM and retrying in {EcTachometerBackoff.TotalSeconds:F0}s");
+                }
+                else
+                {
+                    _logging?.Debug($"[FanRPM] EC tachometer read failed ({ex.GetType().Name}: {ex.Message}); " +
+                                    "falling back to the WMI fan level for this tick");
+                }
+
                 return null;
             }
         }

--- a/src/OmenCoreApp/Services/BatteryInfoProvider.cs
+++ b/src/OmenCoreApp/Services/BatteryInfoProvider.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Management;
+
+namespace OmenCore.Services
+{
+    /// <summary>
+    /// Battery facts that Win32_Battery does not carry.
+    ///
+    /// The dashboard previously showed a hardcoded cycle count because Win32_Battery has no
+    /// cycle-count property. That is true of Win32_Battery and false of Windows: the battery
+    /// class driver publishes these values under <c>root\wmi</c>, which is where powercfg's
+    /// own battery report gets them. Measured on an OMEN MAX 16 whose dashboard was showing
+    /// 0 cycles and "Capacity unavailable": 14 cycles, 79416 of 83029 mWh.
+    ///
+    /// Not every pack populates these - plenty leave the fields unimplemented and the query
+    /// then throws or returns nothing. Every accessor here distinguishes "read a value" from
+    /// "could not read" instead of folding both into 0. A battery that genuinely has 0 cycles
+    /// is a real state; a controller that declines to answer is not the same thing, and
+    /// showing them identically is what made the old reading indistinguishable from a
+    /// placeholder.
+    /// </summary>
+    public static class BatteryInfoProvider
+    {
+        /// <summary>
+        /// These change on the order of once per full discharge, so re-querying them on the
+        /// monitoring cadence would be pure overhead. Long enough to be free, short enough
+        /// that a long uptime still tracks reality.
+        /// </summary>
+        private static readonly TimeSpan CacheLifetime = TimeSpan.FromMinutes(30);
+
+        private static readonly object Gate = new();
+        private static BatteryInfo _cached = BatteryInfo.Unknown;
+        private static DateTime _cachedAtUtc = DateTime.MinValue;
+        private static bool _unavailableLogged;
+
+        /// <summary>
+        /// Everything readable about the pack's wear state. Any member may be <c>null</c>,
+        /// independently of the others - the three values come from three separate WMI
+        /// classes and a pack can implement one without the others.
+        /// </summary>
+        public readonly struct BatteryInfo
+        {
+            public int? CycleCount { get; init; }
+            public int? DesignedCapacityMilliwattHours { get; init; }
+            public int? FullChargedCapacityMilliwattHours { get; init; }
+
+            public static BatteryInfo Unknown => default;
+
+            /// <summary>
+            /// Remaining capacity as a percentage of design capacity, or <c>null</c> when
+            /// either capacity is unreadable. Not clamped to 100: a pack reporting slightly
+            /// over design is a real (and common) reading, and silently trimming it would
+            /// hide a miscalibrated gauge.
+            /// </summary>
+            public double? HealthPercent =>
+                DesignedCapacityMilliwattHours is > 0 && FullChargedCapacityMilliwattHours is > 0
+                    ? FullChargedCapacityMilliwattHours.Value * 100.0 / DesignedCapacityMilliwattHours.Value
+                    : null;
+        }
+
+        /// <summary>
+        /// Cached battery wear state. Never throws: unreadable counters are an expected
+        /// outcome on many packs, not an error.
+        /// </summary>
+        public static BatteryInfo Get(LoggingService? logging = null)
+        {
+            lock (Gate)
+            {
+                if (DateTime.UtcNow - _cachedAtUtc < CacheLifetime)
+                {
+                    return _cached;
+                }
+
+                _cached = Query(logging);
+                _cachedAtUtc = DateTime.UtcNow;
+                return _cached;
+            }
+        }
+
+        private static BatteryInfo Query(LoggingService? logging)
+        {
+            var info = new BatteryInfo
+            {
+                CycleCount = ReadFirst("BatteryCycleCount", "CycleCount", logging),
+
+                // WARNING: this MUST stay a projected query. "SELECT * FROM BatteryStaticData"
+                // fails outright with "Generic failure" on this hardware - one of the class's
+                // string properties does not marshal, and asking for all of them poisons the
+                // whole result set. Naming the one column needed returns it fine. Anything
+                // added here should name its columns for the same reason.
+                DesignedCapacityMilliwattHours =
+                    ReadFirst("BatteryStaticData", "DesignedCapacity", logging),
+
+                FullChargedCapacityMilliwattHours =
+                    ReadFirst("BatteryFullChargedCapacity", "FullChargedCapacity", logging)
+            };
+
+            if (info.CycleCount == null &&
+                info.DesignedCapacityMilliwattHours == null &&
+                info.FullChargedCapacityMilliwattHours == null &&
+                !_unavailableLogged)
+            {
+                logging?.Debug("[Battery] No root\\wmi battery wear data available on this system");
+                _unavailableLogged = true;
+            }
+
+            return info;
+        }
+
+        private static int? ReadFirst(string className, string property, LoggingService? logging)
+        {
+            try
+            {
+                using var searcher = new ManagementObjectSearcher(
+                    @"root\wmi", $"SELECT {property}, Active FROM {className}");
+                using var results = searcher.Get();
+
+                int? firstSeen = null;
+                foreach (ManagementObject instance in results)
+                {
+                    using (instance)
+                    {
+                        var raw = instance[property];
+                        if (raw == null)
+                        {
+                            continue;
+                        }
+
+                        var value = Convert.ToInt32(raw);
+
+                        // Multi-battery machines enumerate every bay, including empty ones.
+                        // Prefer the active pack; fall back to the first that answered so a
+                        // single-battery machine reporting Active = false still gets a value.
+                        if (instance["Active"] is bool active && active)
+                        {
+                            return value;
+                        }
+
+                        firstSeen ??= value;
+                    }
+                }
+
+                return firstSeen;
+            }
+            catch (Exception ex)
+            {
+                // ManagementException "Not supported" is the normal answer from a controller
+                // that does not implement the counter. Debug, not Warn - this is not a fault.
+                logging?.Debug($"[Battery] {className}.{property} unavailable: {ex.Message}");
+                return null;
+            }
+        }
+    }
+}

--- a/src/OmenCoreApp/Services/Diagnostics/DiagnosticExportService.cs
+++ b/src/OmenCoreApp/Services/Diagnostics/DiagnosticExportService.cs
@@ -111,6 +111,7 @@ namespace OmenCore.Services.Diagnostics
                     CollectEcStateAsync(exportPath, effectiveEcAccess),
                     CollectHardwareInfoAsync(exportPath, effectiveMonitoringService),
                     CollectWmiCommandHistoryAsync(exportPath, effectiveWmiController, effectiveFanService),
+                    CollectPowerAdapterSnapshotAsync(exportPath, effectiveWmiController),
                     CollectTuningAndFanFocusAsync(exportPath, effectiveWmiController, effectiveFanService),
                     CollectMonitoringCadenceAndFanHoldAsync(exportPath, effectiveMonitoringService, effectiveFanService, effectiveWmiController),
                     CollectResumeRecoveryDiagnosticsAsync(exportPath)
@@ -2487,6 +2488,109 @@ namespace OmenCore.Services.Diagnostics
             catch (Exception ex)
             {
                 _logging.Warn($"Failed to collect WMI command history: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Capture the machine's own view of its power adapter and its SystemDesignData capability
+        /// block. Both are read-only BIOS queries.
+        ///
+        /// This is in the export because an under-rated adapter is invisible in every other artifact:
+        /// the firmware silently reduces power limits, and the resulting report reads as "GPU stuck
+        /// well below its rating" with nothing to attribute it to. Carrying the adapter verdict means
+        /// a reviewer can rule that out in one line instead of a round trip to the reporter.
+        /// </summary>
+        private async Task CollectPowerAdapterSnapshotAsync(string exportPath, object? wmiController)
+        {
+            try
+            {
+                if (wmiController is not HpWmiBios bios)
+                {
+                    await Task.CompletedTask;
+                    return;
+                }
+
+                var sb = new StringBuilder();
+                sb.AppendLine("=== POWER ADAPTER + SYSTEM DESIGN DATA ===");
+                sb.AppendLine($"Captured: {DateTime.UtcNow:O}");
+                sb.AppendLine("Source: BIOS Legacy 0x0F (adapter) and Default 0x28 (system design). Both read-only.");
+                sb.AppendLine();
+
+                sb.AppendLine("--- Adapter (Legacy 0x0F) ---");
+
+                // Deliberately dispatched off the task-list thread and awaited. This is the only
+                // collector that issues a hardware command rather than reading cached state, and
+                // SendBiosCommand appends to the same WMI command history that
+                // CollectWmiCommandHistoryAsync is capturing concurrently - running it inline made the
+                // export non-deterministically include its own query in the artifact describing the
+                // session, and perturbed the success-rate statistics reported alongside it.
+                var adapter = await Task.Run(() => bios.GetAdapter());
+                if (adapter is HpWmiBios.AdapterInfo info)
+                {
+                    sb.AppendLine($"Raw:                    {BitConverter.ToString(info.RawData)}");
+                    sb.AppendLine($"Status:                 {info.Status} ({(int)info.Status})");
+                    sb.AppendLine($"Connected rating:       {(info.PowerRatingKnown ? $"{info.PowerRatingWatts} W" : "unknown (0xFF sentinel)")}");
+                    sb.AppendLine($"USB-C design rating:    {info.UsbcDesignRatingWatts} W");
+                    sb.AppendLine($"Barrel jack supported:  {info.SupportsBarrelConnector}");
+                    sb.AppendLine($"Firmware gave a usable verdict: {info.HasVerdict}");
+                    sb.AppendLine($"Low wattage (HP logic): {(info.HasVerdict ? info.IsLowWattage.ToString() : "n/a - no verdict")}");
+
+                    if (info.IsLowWattage)
+                    {
+                        sb.AppendLine();
+                        sb.AppendLine("NOTE: the firmware considers this supply under-rated. Some HP firmware reduces");
+                        sb.AppendLine("      CPU and GPU power limits in this state. Rule this out before reading any");
+                        sb.AppendLine("      low-power-limit symptom in this export as an OmenCore or driver fault.");
+                    }
+                }
+                else
+                {
+                    sb.AppendLine("Not reported (board does not answer Legacy 0x0F, or WMI unavailable).");
+                }
+
+                sb.AppendLine();
+                sb.AppendLine("--- System design data (Default 0x28) ---");
+                if (bios.SystemDesign is HpWmiBios.SystemDesignData design)
+                {
+                    sb.AppendLine($"Raw (first 12 bytes):        {BitConverter.ToString(design.RawData)}");
+                    sb.AppendLine($"Shipping adapter rating:     {design.ShippingAdapterPowerRatingWatts} W");
+                    sb.AppendLine($"Thermal policy (firmware):   V{(int)design.ThermalPolicyVersion}");
+                    sb.AppendLine($"Thermal policy (in use):     V{(int)bios.ThermalPolicy}");
+                    if (design.ThermalPolicyVersion != bios.ThermalPolicy)
+                    {
+                        sb.AppendLine("  ^ These disagree: the firmware reported one version and OmenCore is running");
+                        sb.AppendLine("    another. That override is a model-name substring match, not a per-board");
+                        sb.AppendLine("    decision - worth checking if fan behaviour on this machine looks wrong.");
+                    }
+                    sb.AppendLine($"SW fan control support:      {design.IsSwFanControlSupport}");
+                    sb.AppendLine($"Extreme mode support:        {design.IsExtremeModeSupport}");
+                    sb.AppendLine($"Extreme mode unlocked:       {design.IsExtremeModeUnlock}");
+                    sb.AppendLine($"DT BIOS control:             {design.IsDTBiosControl}");
+                    sb.AppendLine($"Two-byte PL4 support:        {design.IsTwoBytePL4Support}");
+                    sb.AppendLine($"PL4 default value:           {design.PL4DefaultValue}");
+                    sb.AppendLine($"BIOS-defined OC support:     {design.IsBiosDefinedOcSupport}");
+                    sb.AppendLine($"GPU mode switch:             0x{design.GpuModeSwitch:X2}");
+                    sb.AppendLine($"CPU power limit with GPU:    {design.DefaultCpuPowerLimitWithGpuWatts} W");
+                    sb.AppendLine($"Load line levels / default:  {design.LoadLineSupportLevels} / {design.DefaultLoadLine}");
+                    sb.AppendLine($"IR sensor on board:          {design.ChangeIrSensorToBoard}");
+                    sb.AppendLine($"PCH overheat support:        {design.IsPchOverheatSupport}");
+                    sb.AppendLine($"VR sensor support:           {design.IsVrSensorSupport}");
+                    sb.AppendLine($"Hotkey Fn+P / Fn+F1:         {design.IsHotkeySupportFnP} / {design.IsHotkeySupportFnF1}");
+                    sb.AppendLine("  ^ These are known to read false on boards that do have the keys.");
+                    sb.AppendLine("    Treat as firmware's declaration, not as a hardware inventory.");
+                }
+                else
+                {
+                    sb.AppendLine("Not available (0x28 query failed, or the reply was shorter than 12 bytes).");
+                }
+
+                File.WriteAllText(Path.Combine(exportPath, "power-adapter.txt"), sb.ToString());
+                _logging.Info("Collected power adapter snapshot");
+                await Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                _logging.Warn($"Failed to collect power adapter snapshot: {ex.Message}");
             }
         }
 

--- a/src/OmenCoreApp/Services/FanVerificationService.cs
+++ b/src/OmenCoreApp/Services/FanVerificationService.cs
@@ -353,13 +353,7 @@ namespace OmenCore.Services
 
                     if (result.VerificationPassed)
                     {
-                        var verificationBasis = result.VerificationEvidence switch
-                        {
-                            "Level" => $"level readback matched ({result.ActualLevelAfter}/{result.ExpectedLevel})",
-                            "RPM+Level" => $"RPM + level matched (~{result.ExpectedRpm}, {result.ActualLevelAfter}/{result.ExpectedLevel})",
-                            _ => $"RPM matched (expected ~{result.ExpectedRpm})"
-                        };
-                        _logging.Info($"✓ Fan {fanIndex} verified: {result.ActualRpmAfter} RPM, level {result.ActualLevelAfter} ({verificationBasis}, deviation {result.DeviationPercent:F1}%, score {result.VerificationScore}/100 {result.ScoreRating})");
+                        _logging.Info(DescribeVerificationPass(fanIndex, result));
                         break;
                     }
                     else if (attempt < VerificationRetries)
@@ -496,13 +490,7 @@ namespace OmenCore.Services
 
                     if (result.VerificationPassed)
                     {
-                        var verificationBasis = result.VerificationEvidence switch
-                        {
-                            "Level" => $"level readback matched ({result.ActualLevelAfter}/{result.ExpectedLevel})",
-                            "RPM+Level" => $"RPM + level matched (~{result.ExpectedRpm}, {result.ActualLevelAfter}/{result.ExpectedLevel})",
-                            _ => $"RPM matched (expected ~{result.ExpectedRpm})"
-                        };
-                        _logging.Info($"✓ Fan {fanIndex} verified: {result.ActualRpmAfter} RPM, level {result.ActualLevelAfter} ({verificationBasis}, deviation {result.DeviationPercent:F1}%, score {result.VerificationScore}/100 {result.ScoreRating})");
+                        _logging.Info(DescribeVerificationPass(fanIndex, result));
                         break;
                     }
                     else if (attempt < VerificationRetries)
@@ -690,6 +678,19 @@ namespace OmenCore.Services
                 return false;
             }
 
+            // A level readback is the firmware echoing back the value we just wrote. That is real
+            // evidence the command was accepted, but it is NOT evidence the fan moved, and on a
+            // board whose RPM tachometer is unavailable it is the ONLY thing that can ever be
+            // checked - so accepting it unconditionally makes this method incapable of failing.
+            // Requesting a non-zero speed and measuring a flat zero from a physical source is a
+            // contradiction at any percentage, so it is rejected here rather than at >40% only.
+            if (IsPhysicalRpmSource(result.RpmSource) &&
+                result.ActualRpmAfter <= 0 &&
+                result.RequestedPercent > 0)
+            {
+                return false;
+            }
+
             if (result.RequestedPercent <= 40)
             {
                 return true;
@@ -772,6 +773,33 @@ namespace OmenCore.Services
             if (rpmMatched) return "RPM";
             if (levelMatched) return "Level";
             return "None";
+        }
+
+        /// <summary>
+        /// Render a passing verification for the log, stating WHICH evidence carried it.
+        /// </summary>
+        /// <remarks>
+        /// A pass on level evidence alone is a weaker claim than a pass corroborated by a
+        /// tachometer, and the two used to be logged with identical wording - so a result with no
+        /// physical RPM reading at all was reported as "✓ verified" alongside its own
+        /// "score 5/100 Failed". The score is not restated here: it grades RPM accuracy and
+        /// stability, which is not what was measured when the evidence is level-only, so quoting it
+        /// on that path invited exactly the contradiction it produced.
+        /// </remarks>
+        private static string DescribeVerificationPass(int fanIndex, FanApplyResult result)
+        {
+            if (result.VerificationEvidence == "Level")
+            {
+                return $"✓ Fan {fanIndex} command accepted: level {result.ActualLevelAfter}/{result.ExpectedLevel} " +
+                       $"read back from firmware. Fan motion NOT confirmed - {result.RpmDisplay}.";
+            }
+
+            var basis = result.VerificationEvidence == "RPM+Level"
+                ? $"RPM + level matched (~{result.ExpectedRpm}, {result.ActualLevelAfter}/{result.ExpectedLevel})"
+                : $"RPM matched (expected ~{result.ExpectedRpm})";
+
+            return $"✓ Fan {fanIndex} verified: {result.ActualRpmAfter} RPM, level {result.ActualLevelAfter} " +
+                   $"({basis}, deviation {result.DeviationPercent:F1}%, score {result.VerificationScore}/100 {result.ScoreRating})";
         }
 
         private bool VerifyAppliedState(FanApplyResult result)

--- a/src/OmenCoreApp/Services/GpuSwitchService.cs
+++ b/src/OmenCoreApp/Services/GpuSwitchService.cs
@@ -9,12 +9,19 @@ namespace OmenCore.Services
     public class GpuSwitchService
     {
         private readonly LoggingService _logging;
+        private readonly Hardware.HpWmiBios? _wmiBios;
         private bool _gpuModeSupported = false;
         private string _unsupportedReason = "";
 
-        public GpuSwitchService(LoggingService logging)
+        /// <summary>
+        /// <paramref name="wmiBios"/> is optional so the existing call sites - and the tests - keep
+        /// working without it. When supplied, <see cref="DetectCurrentMode"/> asks the firmware
+        /// instead of inferring the mode from which adapter happens to be painting a display.
+        /// </summary>
+        public GpuSwitchService(LoggingService logging, Hardware.HpWmiBios? wmiBios = null)
         {
             _logging = logging;
+            _wmiBios = wmiBios;
             CheckGpuModeSwitchingSupport();
         }
         
@@ -122,12 +129,32 @@ namespace OmenCore.Services
         public string UnsupportedReason => _unsupportedReason;
 
         /// <summary>
-        /// Detect current GPU mode through WMI and NVIDIA/AMD control panels
+        /// Detect the current GPU mode, preferring the firmware's own answer over inference.
+        ///
+        /// <para><b>Why the firmware comes first.</b> The adapter-activity methods below decide the
+        /// mode from which GPU is currently driving a display, and a healthy Optimus laptop spends
+        /// most of its time with the dGPU powered down by RTD3 - <c>Win32_VideoController</c> reports
+        /// it <c>Availability: 8</c> (Off Line) with no resolution, refresh rate or bit depth. That is
+        /// indistinguishable, to those methods, from a machine whose dGPU is switched off in firmware,
+        /// so Hybrid gets reported as Integrated whenever the dGPU happens to be asleep. Waking it to
+        /// find out would be worse than the wrong answer.</para>
+        ///
+        /// <para>Adapter activity stays as a fallback and as corroboration, because a zero reply from
+        /// <c>Legacy 0x52</c> is not unambiguous either: zero decodes to Hybrid and is also what an
+        /// ACPI timeout leaves in the buffer (see the remark on <c>HpWmiBios.SendBiosCommand</c>). So
+        /// a firmware Hybrid reading is cross-checked, and only a disagreement is logged - the
+        /// firmware still wins, since a sleeping dGPU is the far more likely explanation.</para>
         /// </summary>
         public GpuSwitchMode DetectCurrentMode()
         {
             try
             {
+                // Method 0: ask the firmware. Authoritative for Discrete/Optimus; cross-checked for
+                // Hybrid, which shares its encoding with an ACPI timeout.
+                var firmwareMode = DetectFirmwareGpuMode();
+                if (firmwareMode.HasValue)
+                    return firmwareMode.Value;
+
                 // Method 1: Check NVIDIA Optimus status via WMI
                 var nvidiaMode = DetectNvidiaOptimusMode();
                 if (nvidiaMode.HasValue)
@@ -160,6 +187,76 @@ namespace OmenCore.Services
             {
                 _logging.Error("Failed to detect GPU mode", ex);
                 return GpuSwitchMode.Hybrid;
+            }
+        }
+
+        /// <summary>
+        /// The firmware's own GPU mode via <c>Legacy 0x52</c>, or null when it cannot answer or
+        /// answers something this maps no meaning onto.
+        ///
+        /// Returning null on an unrecognised byte is deliberate rather than defensive. The firmware
+        /// enum covers Hybrid, Discrete and Optimus; a machine routed to iGPU-only (the BIOS calls it
+        /// UMA on board 8D87) is a state <c>GpuMode</c> does not declare, and no capture has pinned
+        /// what 0x52 reads there. Falling through to adapter inference is the honest answer for a byte
+        /// nobody has mapped - and inference is at its most reliable in exactly that case, because a
+        /// machine with no usable dGPU really does have only one adapter driving displays.
+        /// </summary>
+        /// <summary>
+        /// Map the firmware's <see cref="Hardware.HpWmiBios.GpuMode"/> onto the UI's
+        /// <see cref="GpuSwitchMode"/>, or null for a value this does not map.
+        ///
+        /// Static and public so the mapping is test-covered without a WMI round trip, following the
+        /// same pattern as <c>HpWmiBios.DecodeAdapterData</c> and <c>DecodeGpuMode</c>.
+        /// </summary>
+        public static GpuSwitchMode? MapFirmwareGpuMode(Hardware.HpWmiBios.GpuMode mode) => mode switch
+        {
+            Hardware.HpWmiBios.GpuMode.Discrete => GpuSwitchMode.Discrete,
+            // Optimus is a hybrid arrangement with dGPU-direct display routing available;
+            // GpuSwitchMode has no separate member, and Hybrid is what the UI means by it.
+            Hardware.HpWmiBios.GpuMode.Optimus => GpuSwitchMode.Hybrid,
+            Hardware.HpWmiBios.GpuMode.Hybrid => GpuSwitchMode.Hybrid,
+            _ => null
+        };
+
+        private GpuSwitchMode? DetectFirmwareGpuMode()
+        {
+            if (_wmiBios == null) return null;
+
+            try
+            {
+                var mode = _wmiBios.GetGpuMode();
+                if (mode == null) return null;
+
+                var mapped = MapFirmwareGpuMode(mode.Value);
+                if (mapped == null) return null;
+
+                // A Hybrid reading is the ambiguous one - 0x00 is also what an ACPI timeout leaves
+                // behind. Corroborate it, but do not overturn it: a dGPU asleep under RTD3 is the
+                // ordinary reason the adapter check would disagree here.
+                if (mode.Value == Hardware.HpWmiBios.GpuMode.Hybrid)
+                {
+                    var inferred = DetectNvidiaOptimusMode();
+                    if (inferred.HasValue && inferred.Value != GpuSwitchMode.Hybrid)
+                    {
+                        _logging.Info(
+                            $"GPU mode: firmware reports Hybrid, adapter activity suggests {inferred.Value} " +
+                            "- using the firmware's answer (a dGPU idled by RTD3 reads as inactive)");
+                    }
+                    else
+                    {
+                        _logging.Info("Detected GPU mode via firmware (Legacy 0x52): Hybrid");
+                    }
+
+                    return GpuSwitchMode.Hybrid;
+                }
+
+                _logging.Info($"Detected GPU mode via firmware (Legacy 0x52): {mode.Value}");
+                return mapped.Value;
+            }
+            catch (Exception ex)
+            {
+                _logging.Debug($"Firmware GPU mode query failed, falling back to adapter inference: {ex.Message}");
+                return null;
             }
         }
 

--- a/src/OmenCoreApp/Services/HardwareMonitoringService.cs
+++ b/src/OmenCoreApp/Services/HardwareMonitoringService.cs
@@ -964,6 +964,7 @@ namespace OmenCore.Services
         private void UpdateDashboardMetrics(MonitoringSample sample)
         {
             var now = DateTime.Now;
+            var batteryInfo = BatteryInfoProvider.Get(_logging);
             var metrics = new HardwareMetrics
             {
                 Timestamp = now,
@@ -973,11 +974,12 @@ namespace OmenCore.Services
                 BatteryChargePercentage = sample.BatteryChargePercent > 0
                     ? Math.Clamp(sample.BatteryChargePercent, 0, 100)
                     : -1,
-                // Battery health is not the same as current charge. Leave health unknown
-                // until a real full-charge/design-capacity source is available.
-                BatteryHealthPercentage = -1,
-                BatteryCycles = 0, // Win32_Battery does not expose cycle count; reserved for future use
-                EstimatedBatteryLifeYears = 3.0, // Static estimate; expandable via HP WMI in a future revision
+                // Battery health is not the same as current charge: it is full-charge capacity
+                // against design capacity. Both come from root\wmi via BatteryInfoProvider,
+                // which caches them - this runs on every monitoring tick. -1 means the pack
+                // did not report the capacities, and must stay distinguishable from a real 0.
+                BatteryHealthPercentage = batteryInfo.HealthPercent ?? -1,
+                BatteryCycles = batteryInfo.CycleCount ?? -1,
                 PowerEfficiency = CalculatePowerEfficiency(sample),
                 // Use average RPM from the two fan sensors as an efficiency proxy (0-100 scale)
                 FanEfficiency = sample.Fan1Rpm > 0 || sample.Fan2Rpm > 0

--- a/src/OmenCoreApp/Services/HardwareMonitoringService.cs
+++ b/src/OmenCoreApp/Services/HardwareMonitoringService.cs
@@ -982,6 +982,12 @@ namespace OmenCore.Services
                 // Use average RPM from the two fan sensors as an efficiency proxy (0-100 scale)
                 FanEfficiency = sample.Fan1Rpm > 0 || sample.Fan2Rpm > 0
                     ? Math.Min(100, ((sample.Fan1Rpm + sample.Fan2Rpm) / 2.0) / 50.0)
+                    : 0,
+                // The same mean, unscaled. The fan chart's axis is labelled "RPM", so it needs the
+                // RPM figure rather than the 0-100 proxy above; plotting the proxy there rendered
+                // ~2800 RPM as "28 RPM".
+                FanRpmAverage = sample.Fan1Rpm > 0 || sample.Fan2Rpm > 0
+                    ? (sample.Fan1Rpm + sample.Fan2Rpm) / 2.0
                     : 0
             };
 
@@ -1147,7 +1153,9 @@ namespace OmenCore.Services
                 ChartType.PowerConsumption => metrics.PowerConsumption,
                 ChartType.BatteryHealth => metrics.BatteryChargePercentage >= 0 ? metrics.BatteryChargePercentage : 0,
                 ChartType.Temperature => (metrics.CpuTemperature + metrics.GpuTemperature) / 2,
-                ChartType.FanSpeeds => metrics.FanEfficiency, // Real average fan efficiency derived from RPM sample data
+                // Must match GetLabelForChartType, which labels this series "RPM". FanEfficiency is
+                // a 0-100 proxy, so charting it under an RPM axis understated the reading by ~50x.
+                ChartType.FanSpeeds => metrics.FanRpmAverage,
                 _ => 0
             };
         }

--- a/src/OmenCoreApp/Services/IHardwareMonitoringService.cs
+++ b/src/OmenCoreApp/Services/IHardwareMonitoringService.cs
@@ -28,6 +28,16 @@ namespace OmenCore.Services
         public double GpuTemperature { get; set; }
         public double PowerEfficiency { get; set; }
         public double FanEfficiency { get; set; }
+
+        /// <summary>
+        /// Mean of the two fan tachometer readings, in RPM. Distinct from
+        /// <see cref="FanEfficiency"/>, which is that same mean rescaled to a 0-100 proxy: the fan
+        /// chart is labelled "RPM" and must plot this, not the proxy. Zero when no fan telemetry
+        /// source is reporting, which on some boards is the normal state rather than a stopped fan
+        /// - a true RPM tachometer is not available on every model.
+        /// </summary>
+        public double FanRpmAverage { get; set; }
+
         public DateTime Timestamp { get; set; }
     }
 

--- a/src/OmenCoreApp/Services/IHardwareMonitoringService.cs
+++ b/src/OmenCoreApp/Services/IHardwareMonitoringService.cs
@@ -21,9 +21,20 @@ namespace OmenCore.Services
         public double PowerConsumption { get; set; }
         public double PowerConsumptionTrend { get; set; }
         public double BatteryChargePercentage { get; set; }
+
+        /// <summary>
+        /// Full-charge capacity as a percentage of design capacity, or -1 when the pack does
+        /// not report both capacities. -1 rather than 0 because a worn-to-nothing battery and
+        /// an unreadable one are different states and the UI shows them differently.
+        /// </summary>
         public double BatteryHealthPercentage { get; set; }
+
+        /// <summary>
+        /// Charge/discharge cycles the pack has recorded, or -1 when it does not report them.
+        /// A new battery legitimately reads 0, so 0 cannot double as "unknown".
+        /// </summary>
         public int BatteryCycles { get; set; }
-        public double EstimatedBatteryLifeYears { get; set; }
+
         public double CpuTemperature { get; set; }
         public double GpuTemperature { get; set; }
         public double PowerEfficiency { get; set; }

--- a/src/OmenCoreApp/Services/KeyboardLighting/HidPerKeyBackend.cs
+++ b/src/OmenCoreApp/Services/KeyboardLighting/HidPerKeyBackend.cs
@@ -20,11 +20,11 @@ namespace OmenCore.Services.KeyboardLighting
     ///   0x0538 – OMEN 16 (2023) Intel/AMD internal keyboard
     ///   0x0547 – OMEN 16 (2024) internal keyboard
     ///   0x0549 – OMEN 17 (2024) internal keyboard
-    ///   0x054E – OMEN MAX 16 (2025) ah0xxx – pending field verification
-    ///   0x054F – OMEN MAX 16 (2025) ak0xxx – pending field verification
     ///
-    /// Unrecognized HP HID devices (VID 0x03F0) are logged at Info level so field
-    /// reports can supply the correct PID for addition to the list above.
+    /// The internal keyboard is not always under HP's own vendor ID - on OMEN MAX 16 ak0xxx
+    /// it is Darfon 0x0D62:0x54BF - so the scan covers the ODM vendor IDs too and logs every
+    /// candidate with its output report length. A device is only opened if it is listed in
+    /// KnownPerKeyPids AND has a 65-byte output report; scanning is not using.
     ///
     /// Current capability: zone-mapped static colors (maps 4 WMI zone colors across
     /// the full key matrix). Full per-key editor addressing is a follow-up once PIDs
@@ -42,18 +42,45 @@ namespace OmenCore.Services.KeyboardLighting
         // HP Inc. USB vendor ID
         private const int HP_VID = 0x03F0;
 
-        // Known OMEN per-key laptop keyboard controller PIDs.
-        // Sources: OpenRGB device database, OmenHubLighter decompilation, community reports.
-        // PIDs marked [probable] are inferred from adjacent model generations and need
-        // confirmation from a field log on actual hardware.
-        private static readonly Dictionary<int, string> KnownPerKeyPids = new()
+        /// <summary>
+        /// Vendor IDs worth scanning. Restricting this to HP_VID made whole models invisible:
+        /// on OMEN MAX 16 ak0xxx (board 8D87) the internal keyboard enumerates under Darfon
+        /// (0x0D62), HP's keyboard ODM, and nothing at all under 0x03F0 except a HyperX
+        /// wireless receiver and, if docked, a Thunderbolt dock. Scanning is not using: a
+        /// device still has to appear in <see cref="KnownPerKeyPids"/> before anything is
+        /// written to it. This list only decides what gets *looked at and logged*.
+        /// </summary>
+        private static readonly Dictionary<int, string> ScannedVendorIds = new()
         {
-            { 0x0538, "OMEN 16 (2023) Intel/AMD keyboard" },
-            { 0x053A, "OMEN Sequoia / external gaming keyboard" },
-            { 0x0547, "OMEN 16 (2024) keyboard" },
-            { 0x0549, "OMEN 17 (2024) keyboard" },
-            { 0x054E, "OMEN MAX 16 (2025) ah0xxx keyboard [probable - needs field confirmation]" },
-            { 0x054F, "OMEN MAX 16 (2025) ak0xxx keyboard [probable - needs field confirmation]" },
+            { HP_VID, "HP" },
+            { 0x0D62, "Darfon (HP keyboard ODM)" },
+        };
+
+        // Known OMEN per-key laptop keyboard controller PIDs, keyed by (VID, PID).
+        // Sources: OpenRGB device database, OmenHubLighter decompilation, community reports.
+        // A device is only opened and written to if it appears here AND its output report
+        // length matches PACKET_SIZE - see the report-length check in InitializeAsync.
+        private static readonly Dictionary<(int Vid, int Pid), string> KnownPerKeyPids = new()
+        {
+            { (HP_VID, 0x0538), "OMEN 16 (2023) Intel/AMD keyboard" },
+            { (HP_VID, 0x053A), "OMEN Sequoia / external gaming keyboard" },
+            { (HP_VID, 0x0547), "OMEN 16 (2024) keyboard" },
+            { (HP_VID, 0x0549), "OMEN 17 (2024) keyboard" },
+
+            // NOT listed, deliberately, and the reason is worth keeping:
+            //
+            //   0x03F0:0x054E / 0x054F were guesses at the OMEN MAX 16 keyboards, inferred from
+            //   adjacent generations. Measured on an ak0xxx (8D87): neither exists. The internal
+            //   keyboard is 0x0D62:0x54BF "HP Gaming Keyboard II", on the board's own USB
+            //   controller with a null serial and RemovalPolicy = ExpectNoRemoval, exposing two
+            //   vendor collections at exactly 65-byte output reports (MI_00 and MI_03) - the
+            //   right shape for PACKET_SIZE. What is NOT established is whether it speaks the
+            //   command set below (CMD_BYTE 0x0F / SUB_* from the 0x03F0 family), and adding it
+            //   here would send those bytes to it on every start to find out.
+            //
+            // Add it once someone has confirmed the protocol on hardware they are willing to
+            // power-cycle - not before. A wrong PID that does nothing is a much cheaper mistake
+            // than a right PID with a wrong protocol.
         };
 
         // HID packet layout.
@@ -97,45 +124,60 @@ namespace OmenCore.Services.KeyboardLighting
         {
             try
             {
-                _logging.Info("[HidPerKey] Scanning for HP OMEN per-key keyboard (VID 0x03F0)...");
+                var vendorList = string.Join(", ", ScannedVendorIds.Select(v => $"0x{v.Key:X4} {v.Value}"));
+                _logging.Info($"[HidPerKey] Scanning for OMEN per-key keyboard ({vendorList})...");
 
-                var allHpHidDevices = DeviceList.Local
+                var scannedDevices = DeviceList.Local
                     .GetHidDevices()
-                    .Where(d => d.VendorID == HP_VID)
+                    .Where(d => ScannedVendorIds.ContainsKey(d.VendorID))
                     .ToList();
 
-                if (allHpHidDevices.Count == 0)
+                if (scannedDevices.Count == 0)
                 {
-                    _logging.Info("[HidPerKey] No HP HID devices found (VID 0x03F0)");
+                    _logging.Info($"[HidPerKey] No candidate HID devices found ({vendorList})");
                     _initialized = false;
                     return Task.FromResult(false);
                 }
 
-                _logging.Info($"[HidPerKey] Found {allHpHidDevices.Count} HP HID device(s):");
+                _logging.Info($"[HidPerKey] Found {scannedDevices.Count} candidate HID device(s):");
 
                 HidDevice? candidate = null;
-                foreach (var d in allHpHidDevices)
+                foreach (var d in scannedDevices)
                 {
+                    var vid  = d.VendorID;
                     var pid  = d.ProductID;
                     var name = SafeGetProductName(d);
 
-                    if (KnownPerKeyPids.TryGetValue(pid, out var knownName))
+                    // A composite keyboard exposes several collections under one PID - a keyboard
+                    // collection, a consumer-control one, a mouse one, and the vendor collection
+                    // that carries lighting. Only the last has an output report the size of a
+                    // per-key packet, so this is what distinguishes it. Selecting on PID alone
+                    // took whichever collection Windows happened to enumerate first.
+                    var outputLength = SafeGetMaxOutputReportLength(d);
+                    var usable = outputLength == PACKET_SIZE;
+
+                    if (KnownPerKeyPids.TryGetValue((vid, pid), out var knownName) && usable)
                     {
-                        _logging.Info($"[HidPerKey]   OK PID 0x{pid:X4} - {knownName} ('{name}')");
-                        candidate ??= d; // prefer first recognized device
+                        _logging.Info($"[HidPerKey]   OK {vid:X4}:{pid:X4} out={outputLength} - {knownName} ('{name}')");
+                        candidate ??= d;
                     }
                     else
                     {
-                        // Log every unrecognized HP device so field reports can supply the correct PID.
-                        _logging.Info($"[HidPerKey]   ? PID 0x{pid:X4} - '{name}' (not in per-key PID list; " +
-                            "if this is an OMEN MAX 16 keyboard, report this PID for inclusion)");
+                        // Log every candidate with its report length. The lengths are the part
+                        // that makes a field report actionable: a device with out=65 is a
+                        // plausible lighting endpoint, one with out=0 never is.
+                        var why = usable
+                            ? "not in the per-key device list"
+                            : $"output report {outputLength} != {PACKET_SIZE}, not a lighting endpoint";
+                        _logging.Info($"[HidPerKey]   ? {vid:X4}:{pid:X4} out={outputLength} - '{name}' ({why})");
                     }
                 }
 
                 if (candidate == null)
                 {
-                    _logging.Info("[HidPerKey] No recognized OMEN per-key keyboard PID found. " +
-                        "If your OMEN MAX 16 is connected, please report the PID(s) logged above.");
+                    _logging.Info("[HidPerKey] No confirmed OMEN per-key keyboard found; zone lighting " +
+                        "will fall back to WMI, which on some models reaches only the light bar. " +
+                        "Please report the VID:PID and out= values logged above.");
                     _initialized = false;
                     return Task.FromResult(false);
                 }
@@ -432,6 +474,25 @@ namespace OmenCore.Services.KeyboardLighting
             {
                 _logging.Warn($"[HidPerKey] Reopen failed: {ex.Message}");
                 _stream = null;
+            }
+        }
+
+        /// <summary>
+        /// Output report length, or -1 if the device will not report it. Some collections
+        /// throw here rather than answering, and an unreadable length must not read as 0 -
+        /// 0 is a meaningful value meaning "no output reports at all".
+        /// </summary>
+        private int SafeGetMaxOutputReportLength(HidDevice d)
+        {
+            try
+            {
+                return d.GetMaxOutputReportLength();
+            }
+            catch (Exception ex)
+            {
+                _logging.Debug($"[HidPerKey] Could not read output report length for " +
+                               $"{d.VendorID:X4}:{d.ProductID:X4}: {ex.Message}");
+                return -1;
             }
         }
 

--- a/src/OmenCoreApp/Services/PerformanceModeService.cs
+++ b/src/OmenCoreApp/Services/PerformanceModeService.cs
@@ -251,7 +251,38 @@ namespace OmenCore.Services
                     }
                 }
 
-                _logging.Info($"✓ Performance mode '{effectiveMode.Name}' applied successfully");
+                // Say what actually happened. Every path above can decline to do anything - EC writes
+                // blocked for the model, the WMI policy fallback not permitted, fan policy decoupled
+                // by default - and on a board where all three decline, the only real effect of an
+                // "applied successfully" is the Windows power plan. Reporting success there trains a
+                // user to believe a mode switch did something it did not, and hides the one line that
+                // would tell them why: the skip reason. The flags are already tracked for the trace
+                // entry below; this just stops discarding them on the way to the log.
+                var appliedEffects = new List<string>();
+                if (!string.IsNullOrEmpty(effectiveMode.LinkedPowerPlanGuid)) appliedEffects.Add("Windows power plan");
+                if (ecPowerLimitApplied) appliedEffects.Add("EC power limits");
+                if (wmiPolicyFallbackApplied) appliedEffects.Add("WMI thermal policy");
+                if (LinkFanToPerformanceMode && fanPolicyAction.StartsWith("Linked", StringComparison.Ordinal))
+                    appliedEffects.Add(fanPolicyAction == "Linked fan policy" ? "fan policy" : "fan curve");
+
+                var hardwareEffectApplied = ecPowerLimitApplied || wmiPolicyFallbackApplied ||
+                    (LinkFanToPerformanceMode && fanPolicyAction.StartsWith("Linked", StringComparison.Ordinal));
+
+                if (appliedEffects.Count == 0)
+                {
+                    _logging.Warn($"⚠️ Performance mode '{effectiveMode.Name}': nothing was applied" +
+                        (string.IsNullOrEmpty(ecPowerLimitSkipReason) ? "" : $" ({ecPowerLimitSkipReason})"));
+                }
+                else if (!hardwareEffectApplied)
+                {
+                    _logging.Info($"✓ Performance mode '{effectiveMode.Name}' applied: {string.Join(", ", appliedEffects)}" +
+                        " — no hardware power or fan change" +
+                        (string.IsNullOrEmpty(ecPowerLimitSkipReason) ? "" : $" ({ecPowerLimitSkipReason})"));
+                }
+                else
+                {
+                    _logging.Info($"✓ Performance mode '{effectiveMode.Name}' applied: {string.Join(", ", appliedEffects)}");
+                }
 
                 RecordApplyTrace(new PerformanceModeApplyTraceEntry
                 {

--- a/src/OmenCoreApp/ViewModels/FanDiagnosticsViewModel.cs
+++ b/src/OmenCoreApp/ViewModels/FanDiagnosticsViewModel.cs
@@ -284,6 +284,7 @@ namespace OmenCore.ViewModels
             var testLevels = new[] { 30, 60, 100 };
             var fanNames = new[] { "CPU", "GPU" };
             var results = new System.Collections.Generic.List<(string fan, int target, bool passed, string rpm, double deviation, int score, string rating, string evidence)>();
+            var sourcesSeen = new System.Collections.Generic.List<RpmSource>();
             
             // v2.7.1: Save current preset before diagnostic
             _preTestPreset = _fanService.ActivePreset;
@@ -312,6 +313,7 @@ namespace OmenCore.ViewModels
                             var passed = result.VerificationPassed;
                             var evidence = string.IsNullOrWhiteSpace(result.VerificationEvidence) ? "None" : result.VerificationEvidence;
                             results.Add((fanName, targetPercent, passed, result.RpmDisplay, result.DeviationPercent, result.VerificationScore, result.ScoreRating, evidence));
+                            sourcesSeen.Add(result.RpmSource);
                             
                             // Add to history
                             History.Insert(0, result);
@@ -347,7 +349,14 @@ namespace OmenCore.ViewModels
                 
                 var summary = new System.Text.StringBuilder();
                 summary.AppendLine($"=== DIAGNOSTIC COMPLETE: {(overallPassed ? "✅ PASS" : "❌ FAIL")} ===");
-                summary.AppendLine($"Backend: {_fanService.Backend} | RPM source: {RpmSourceDisplay}");
+                // Report the sources this run actually read from, not RpmSourceDisplay - that is
+                // the "current state" panel's property, refreshed on its own schedule, and it read
+                // "?" on a run whose every result was EcDirect. A header that disagrees with the
+                // lines beneath it is worse than no header.
+                var sourceLabel = sourcesSeen.Count == 0
+                    ? "none"
+                    : string.Join(" + ", sourcesSeen.Distinct().OrderBy(s => s.ToString()));
+                summary.AppendLine($"Backend: {_fanService.Backend} | RPM source: {sourceLabel}");
                 summary.AppendLine($"Tests: {passCount}/{totalTests} passed | Overall Score: {avgScore}/100 ({overallRating})");
                 summary.AppendLine();
                 

--- a/src/OmenCoreApp/ViewModels/FanDiagnosticsViewModel.cs
+++ b/src/OmenCoreApp/ViewModels/FanDiagnosticsViewModel.cs
@@ -60,7 +60,7 @@ namespace OmenCore.ViewModels
         public bool IsDiagnosticActive
         {
             get => _isDiagnosticActive;
-            private set { _isDiagnosticActive = value; OnPropertyChanged(); }
+            private set { _isDiagnosticActive = value; OnPropertyChanged(); RaiseTestCommandStates(); }
         }
 
         public bool IsVerificationAvailable => _verifier?.IsAvailable ?? false;
@@ -76,6 +76,18 @@ namespace OmenCore.ViewModels
 
             RefreshStateCommand = new RelayCommand(_ => _ = UpdateCurrentStateAsync());
             ApplyAndVerifyCommand = new AsyncRelayCommand(_ => ApplyAndVerifyAsync(), _ => IsVerificationAvailable && !IsDiagnosticActive);
+
+            // Constructed once and kept. These were previously expression-bodied properties that
+            // returned a new command on every get: the button bound to whatever instance existed
+            // when the binding first evaluated - at load, with no results yet - and since nothing
+            // held that instance, its CanExecute could never be re-run. Copy Results was disabled
+            // for the life of the window.
+            RunGuidedDiagnosticCommand = new AsyncRelayCommand(
+                _ => RunGuidedDiagnosticAsync(),
+                _ => IsVerificationAvailable && !IsDiagnosticActive && !IsGuidedTestRunning);
+            CopyGuidedResultCommand = new RelayCommand(
+                _ => CopyGuidedResult(),
+                _ => !string.IsNullOrEmpty(GuidedTestResult) && !IsGuidedTestRunning);
 
             // Default to CPU fan
             SelectedFanIndex = 0;
@@ -191,7 +203,7 @@ namespace OmenCore.ViewModels
         public bool IsGuidedTestRunning
         {
             get => _isGuidedTestRunning;
-            private set { _isGuidedTestRunning = value; OnPropertyChanged(); }
+            private set { _isGuidedTestRunning = value; OnPropertyChanged(); RaiseTestCommandStates(); }
         }
         
         /// <summary>
@@ -209,7 +221,7 @@ namespace OmenCore.ViewModels
         public string GuidedTestResult
         {
             get => _guidedTestResult;
-            private set { _guidedTestResult = value; OnPropertyChanged(); }
+            private set { _guidedTestResult = value; OnPropertyChanged(); RaiseTestCommandStates(); }
         }
         
         /// <summary>
@@ -221,13 +233,27 @@ namespace OmenCore.ViewModels
             private set { _guidedTestProgress = value; OnPropertyChanged(); }
         }
         
-        public ICommand RunGuidedDiagnosticCommand => new AsyncRelayCommand(_ => RunGuidedDiagnosticAsync(), _ => IsVerificationAvailable && !IsDiagnosticActive && !IsGuidedTestRunning);
-
+        public ICommand RunGuidedDiagnosticCommand { get; }
 
         /// <summary>
         /// Copy the guided diagnostic result summary to the clipboard.
         /// </summary>
-        public ICommand CopyGuidedResultCommand => new RelayCommand(_ => CopyGuidedResult(), _ => !string.IsNullOrEmpty(GuidedTestResult) && !IsGuidedTestRunning);
+        public ICommand CopyGuidedResultCommand { get; }
+
+        /// <summary>
+        /// Re-evaluate every command whose CanExecute depends on test state.
+        ///
+        /// This has to be explicit. RelayCommand raises CanExecuteChanged only when asked - it
+        /// does not chain off CommandManager.RequerySuggested - so a command that is not held in
+        /// a field and poked here can never change its enabled state after the binding first
+        /// evaluates it.
+        /// </summary>
+        private void RaiseTestCommandStates()
+        {
+            (RunGuidedDiagnosticCommand as AsyncRelayCommand)?.RaiseCanExecuteChanged();
+            (CopyGuidedResultCommand as RelayCommand)?.RaiseCanExecuteChanged();
+            (ApplyAndVerifyCommand as AsyncRelayCommand)?.RaiseCanExecuteChanged();
+        }
 
         private void CopyGuidedResult()
         {

--- a/src/OmenCoreApp/ViewModels/MainViewModel.cs
+++ b/src/OmenCoreApp/ViewModels/MainViewModel.cs
@@ -547,6 +547,126 @@ namespace OmenCore.ViewModels
         /// </summary>
         public string? CapabilityWarning { get; private set; }
 
+        // ═══════════════════════════════════════════════════════════════════════════════════
+        // Power adapter (Legacy 0x0F) - read-only, refreshed when the Diagnostics tab opens
+        // ═══════════════════════════════════════════════════════════════════════════════════
+
+        private HpWmiBios.AdapterInfo? _adapterInfo;
+
+        /// <summary>
+        /// True when the board answered the adapter query at least once. Boards that don't implement
+        /// it keep the whole panel hidden rather than showing an empty or misleading one.
+        /// </summary>
+        public bool HasPowerAdapterInfo => _adapterInfo is HpWmiBios.AdapterInfo info && info.HasVerdict;
+
+        /// <summary>
+        /// One-line adapter summary, e.g. "330 W - meets this machine's requirement".
+        /// </summary>
+        public string PowerAdapterSummary
+        {
+            get
+            {
+                if (_adapterInfo is not HpWmiBios.AdapterInfo info)
+                    return "Not reported by this board";
+
+                // On battery there is no adapter to describe, and the wattage byte reads 0 - pairing
+                // that with "running on battery" would render as the nonsensical "0 W - running on
+                // battery".
+                if (info.Status == HpWmiBios.SmartAdapterStatus.BatteryPower)
+                    return "None — running on battery";
+
+                var watts = info.PowerRatingKnown
+                    ? $"{info.PowerRatingWatts} W"
+                    : "Wattage not reported";
+
+                var verdict = info.Status switch
+                {
+                    HpWmiBios.SmartAdapterStatus.MeetsRequirement => "meets this machine's requirement",
+                    HpWmiBios.SmartAdapterStatus.BelowRequirement => "below this machine's requirement",
+                    HpWmiBios.SmartAdapterStatus.BatteryPower => "running on battery",
+                    HpWmiBios.SmartAdapterStatus.NotFunctioning => "not functioning correctly",
+                    HpWmiBios.SmartAdapterStatus.ConnectedTypeC => "USB-C Power Delivery",
+                    HpWmiBios.SmartAdapterStatus.NotSupported => "adapter detection not supported",
+                    _ => info.Status.ToString()
+                };
+
+                return $"{watts} — {verdict}";
+            }
+        }
+
+        /// <summary>
+        /// The wattage this SKU shipped with, when the firmware reports it. Shown next to the
+        /// connected wattage so the user can see both halves of the comparison the firmware makes.
+        /// </summary>
+        public string PowerAdapterRequirement
+        {
+            get
+            {
+                var shipping = _wmiBios?.SystemDesign?.ShippingAdapterPowerRatingWatts ?? 0;
+                return shipping > 0 ? $"{shipping} W" : "Not reported";
+            }
+        }
+
+        /// <summary>
+        /// A plain explanation when the supply is under-rated, or null when there is nothing to say.
+        ///
+        /// This exists because the symptom is otherwise unattributable: on boards that clamp GPU power
+        /// on an under-rated supply, the user sees a GPU pinned far below its rating and nothing
+        /// anywhere in the app connects that to the adapter they plugged in.
+        /// </summary>
+        public string? PowerAdapterExplanation
+        {
+            get
+            {
+                if (_adapterInfo is not HpWmiBios.AdapterInfo info || !info.HasVerdict)
+                    return null;
+
+                if (info.Status == HpWmiBios.SmartAdapterStatus.BatteryPower)
+                {
+                    return "Running on battery. Expect reduced CPU and GPU power limits until an adapter is connected.";
+                }
+
+                if (!info.IsLowWattage)
+                    return null;
+
+                var shipping = _wmiBios?.SystemDesign?.ShippingAdapterPowerRatingWatts ?? 0;
+                var connected = info.PowerRatingKnown ? $"{info.PowerRatingWatts} W" : "an unrecognised";
+                var required = shipping > 0 ? $" This machine shipped with a {shipping} W adapter." : string.Empty;
+
+                return $"The firmware reports {connected} adapter as below this machine's requirement.{required} " +
+                       "Some HP firmware reduces CPU and GPU power limits in this state, which can look like a fault " +
+                       "in OmenCore or in the GPU driver but is the platform protecting an under-rated supply. " +
+                       "If performance is lower than expected, check the adapter before anything else.";
+            }
+        }
+
+        /// <summary>True when <see cref="PowerAdapterExplanation"/> has something to show.</summary>
+        public bool HasPowerAdapterExplanation => PowerAdapterExplanation != null;
+
+        /// <summary>
+        /// Re-read the adapter state. Read-only WMI query; called when the Diagnostics tab is opened
+        /// rather than polled, because the value only changes when someone physically plugs or
+        /// unplugs something and this costs a WMI round trip.
+        /// </summary>
+        public void RefreshPowerAdapterStatus()
+        {
+            try
+            {
+                _adapterInfo = _wmiBios?.GetAdapter();
+            }
+            catch (Exception ex)
+            {
+                _logging.Debug($"Adapter status refresh failed: {ex.Message}");
+                _adapterInfo = null;
+            }
+
+            OnPropertyChanged(nameof(HasPowerAdapterInfo));
+            OnPropertyChanged(nameof(PowerAdapterSummary));
+            OnPropertyChanged(nameof(PowerAdapterRequirement));
+            OnPropertyChanged(nameof(PowerAdapterExplanation));
+            OnPropertyChanged(nameof(HasPowerAdapterExplanation));
+        }
+
         /// <summary>
         /// Monitoring diagnostics line indicating whether a model-specific CPU temperature override is active.
         /// </summary>

--- a/src/OmenCoreApp/ViewModels/MainViewModel.cs
+++ b/src/OmenCoreApp/ViewModels/MainViewModel.cs
@@ -633,7 +633,38 @@ namespace OmenCore.ViewModels
                 var connected = info.PowerRatingKnown ? $"{info.PowerRatingWatts} W" : "an unrecognised";
                 var required = shipping > 0 ? $" This machine shipped with a {shipping} W adapter." : string.Empty;
 
-                return $"The firmware reports {connected} adapter as below this machine's requirement.{required} " +
+                // Attribute the verdict to whoever actually reached it. On a barrel adapter the
+                // firmware says BelowRequirement outright and quoting it is accurate. On USB-C it
+                // says ConnectedTypeC - a description of the supply, not a complaint about it - and
+                // the under-rated judgement comes from HP's rule about the chassis rather than from
+                // the firmware. Saying "the firmware reports it as below requirement" there states
+                // something the firmware did not say, in the one panel a user opens to find out what
+                // the firmware said.
+                string verdict;
+                if (info.Status == HpWmiBios.SmartAdapterStatus.ConnectedTypeC)
+                {
+                    var supply = info.PowerRatingKnown
+                        ? $"This machine is running from a {info.PowerRatingWatts} W USB-C Power Delivery supply. "
+                        : "This machine is running from a USB-C Power Delivery supply of unreported wattage. ";
+
+                    // Two different reasons reach "under-rated" on Type-C, and they are not
+                    // interchangeable. Either the chassis advertises a USB-C design rating and this
+                    // supply came in under it, or it advertises none at all and expects a barrel
+                    // adapter - in which case no USB-C source would satisfy it, whatever it offers.
+                    var reason = info.UsbcDesignRatingWatts > 0
+                        ? $"That is below the {info.UsbcDesignRatingWatts} W this machine's USB-C input is designed for."
+                        : "This chassis expects a barrel adapter and advertises no USB-C design rating, so HP's " +
+                          "own rule treats any USB-C source as below its requirement.";
+
+                    verdict = supply + "The firmware describes it as USB-C rather than calling it " +
+                              $"under-rated. {reason}{required}";
+                }
+                else
+                {
+                    verdict = $"The firmware reports {connected} adapter as below this machine's requirement.{required}";
+                }
+
+                return verdict + " " +
                        "Some HP firmware reduces CPU and GPU power limits in this state, which can look like a fault " +
                        "in OmenCore or in the GPU driver but is the platform protecting an under-rated supply. " +
                        "If performance is lower than expected, check the adapter before anything else.";

--- a/src/OmenCoreApp/ViewModels/MainViewModel.cs
+++ b/src/OmenCoreApp/ViewModels/MainViewModel.cs
@@ -1730,7 +1730,7 @@ namespace OmenCore.ViewModels
 
             _keyboardLightingService = new KeyboardLightingService(_logging, ec, _wmiBios, _configService, _systemInfoService, _ecOperationCoordinator);
             _systemOptimizationService = systemOptimizationService ?? new SystemOptimizationService(_logging);
-            _gpuSwitchService = gpuSwitchService ?? new GpuSwitchService(_logging);
+            _gpuSwitchService = gpuSwitchService ?? new GpuSwitchService(_logging, _wmiBios);
             
             // Keyboard diagnostics (must be after _keyboardLightingService is created)
             KeyboardDiagnostics = new KeyboardDiagnosticsViewModel(_corsairDeviceService, _logitechDeviceService, _keyboardLightingService, _razerService, _logging);

--- a/src/OmenCoreApp/Views/DiagnosticsView.xaml
+++ b/src/OmenCoreApp/Views/DiagnosticsView.xaml
@@ -83,6 +83,41 @@
                 </Grid>
             </GroupBox>
 
+            <!-- Power adapter (Legacy 0x0F). Hidden entirely on boards that don't report it, rather
+                 than shown empty. Read-only: nothing here writes to the firmware. -->
+            <GroupBox Header="Power Adapter" Style="{StaticResource ModernGroupBox}" Margin="0,12,0,0"
+                      Visibility="{Binding HasPowerAdapterInfo, Converter={StaticResource BoolToVisibility}}">
+                <StackPanel Margin="8">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0">
+                            <TextBlock Text="Connected adapter" FontSize="11" Foreground="{StaticResource TextTertiaryBrush}"/>
+                            <TextBlock Text="{Binding PowerAdapterSummary}" FontSize="14" FontWeight="SemiBold"
+                                       Foreground="{StaticResource TextPrimaryBrush}" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                        </StackPanel>
+                        <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="16,0,0,0">
+                            <TextBlock Text="Shipped with" FontSize="11" Foreground="{StaticResource TextTertiaryBrush}"
+                                       HorizontalAlignment="Right"/>
+                            <TextBlock Text="{Binding PowerAdapterRequirement}" FontSize="14" FontWeight="SemiBold"
+                                       Foreground="{StaticResource TextSecondaryBrush}" HorizontalAlignment="Right" Margin="0,2,0,0"/>
+                        </StackPanel>
+                    </Grid>
+
+                    <Border Background="#2D2D1F" BorderBrush="{StaticResource WarningBrush}" BorderThickness="1"
+                            CornerRadius="6" Padding="10,8" Margin="0,12,0,0"
+                            Visibility="{Binding HasPowerAdapterExplanation, Converter={StaticResource BoolToVisibility}}">
+                        <TextBlock Text="{Binding PowerAdapterExplanation}" FontSize="11"
+                                   Foreground="{StaticResource TextSecondaryBrush}" TextWrapping="Wrap"/>
+                    </Border>
+
+                    <TextBlock Text="Read from the BIOS each time this tab is opened. This is the machine's own view of the supply attached to it, not a measurement."
+                               FontSize="11" Foreground="{StaticResource TextTertiaryBrush}" TextWrapping="Wrap" Margin="0,10,0,0"/>
+                </StackPanel>
+            </GroupBox>
+
             <!-- Model Capabilities (what this specific detected model does/doesn't support) -->
             <GroupBox Header="Model Capabilities" Style="{StaticResource ModernGroupBox}" Margin="0,12,0,0">
                 <StackPanel Margin="8">

--- a/src/OmenCoreApp/Views/DiagnosticsView.xaml.cs
+++ b/src/OmenCoreApp/Views/DiagnosticsView.xaml.cs
@@ -11,6 +11,24 @@ namespace OmenCore.Views
         public DiagnosticsView()
         {
             InitializeComponent();
+            Loaded += OnLoaded;
+        }
+
+        /// <summary>
+        /// Refresh the adapter panel when the tab is shown. Read-only WMI query, and doing it here
+        /// rather than on a timer means the cost is paid only when someone is looking at it - while
+        /// still being current, since the value changes only on a physical plug/unplug.
+        /// </summary>
+        private void OnLoaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            // Dispatched at Background priority rather than run inline: GetAdapter() is a WMI round
+            // trip, and on a board that does not implement the command it falls through to the legacy
+            // System.Management path, which has no timeout at all. Inline, that turns clicking this
+            // tab into a multi-second freeze on a machine with a degraded WMI repository. Let the tab
+            // paint first.
+            Dispatcher.InvokeAsync(
+                () => (DataContext as ViewModels.MainViewModel)?.RefreshPowerAdapterStatus(),
+                System.Windows.Threading.DispatcherPriority.Background);
         }
 
         private void OpenDiagnosticsFolder_Click(object sender, System.Windows.RoutedEventArgs e)

--- a/src/OmenCoreApp/Views/FanDiagnosticsView.xaml
+++ b/src/OmenCoreApp/Views/FanDiagnosticsView.xaml
@@ -68,9 +68,15 @@
                     Visibility="{Binding GuidedTestResult, Converter={StaticResource StringNotEmptyToVisibilityConverter}}">
                 <StackPanel>
                     <TextBlock Text="Verification Results" FontWeight="SemiBold" />
-                    <TextBlock Text="{Binding GuidedTestResult}" FontFamily="Consolas" FontSize="11" 
-                               Foreground="{StaticResource TextSecondaryBrush}" Margin="0,8,0,0"
-                               TextWrapping="Wrap"/>
+                    <!-- A read-only TextBox, not a TextBlock: WPF TextBlock text cannot be
+                         selected, so dragging across these results did nothing and the click
+                         fell through to the surrounding panel. This keeps the same flat look
+                         while letting the text be selected and copied by hand. -->
+                    <TextBox Text="{Binding GuidedTestResult, Mode=OneWay}" FontFamily="Consolas" FontSize="11"
+                             Foreground="{StaticResource TextSecondaryBrush}" Margin="0,8,0,0"
+                             TextWrapping="Wrap" IsReadOnly="True" IsReadOnlyCaretVisible="False"
+                             Background="Transparent" BorderThickness="0" Padding="0"
+                             HorizontalScrollBarVisibility="Disabled"/>
                     <Button Content="Copy Results" Command="{Binding CopyGuidedResultCommand}" 
                             Style="{StaticResource ModernButton}" Margin="0,8,0,0" 
                             Visibility="{Binding GuidedTestResult, Converter={StaticResource StringNotEmptyToVisibilityConverter}}"/>


### PR DESCRIPTION
## Where this sits

Four PRs, split so each carries its own evidence.

| | PR | Branch | Base | Scope |
|---|---|---|---|---|
| 1 | Add SmuProbe (#160) | `tooling/smu-probe` | `main` | Verification harness for the AMD SMU path. |
| 2 | Fix the AMD SMU transport (#161) | `fix/amd-smu-transport` | `main`, stacked on #160 | Makes a dead AMD backend live. Affects all AMD boards. |
| **→ 3** | **Capability profile and telemetry corrections (this PR)** | `8d87/profile-and-telemetry` | `main` | **Independent of 1 and 2 — no file overlap.** |
| 4 | Power-adapter performance control | `8d87/power-adapter-gate` | `main` | **Not yet opened** — depends on this PR, see below. |

**This PR can be reviewed and merged in any order relative to 1 and 2.** It branches off `main` and shares no files with them. It is the largest of the four but also the lowest-risk: most of it replaces proxies and unverified assumptions with real hardware reads, and it adds no EC writes.

### Why PR 4 depends on this one

On a non-330 W adapter the EC clamps this GPU from 175 W to 35 W — a 140 W loss on a supply that was measured drawing ~59 W total while clamped. The mechanism is fully traced: EC `PROH` at `0x90`, copied to `DSTA` by `_Q73`, which drives `Notify (PEGP, 0xD1..0xD5)` and hence the driver's limit.

**This PR supplies the number that makes a responsible version of that feature possible.** The `Legacy 0x0F` read added here reports the connected adapter's *real* wattage (330/280/200 W, measured exact), and `Default 0x28` gives the SKU's *required* wattage. With both halves of the comparison HP's gate makes, PR 4 can size a cap against the actual supply instead of requesting all-or-nothing 175 W.

Three things gate PR 4 beyond that:

- **Write-side EC evidence.** Port↔MMIO aliasing at `0xFE700600` is established for **reads only**, on one adapter state. Nothing may write EC RAM on that basis — and believing a byte after two agreeing states is a documented error in this investigation.
- **A shared-code change.** A hold loop needs a path that takes the `Global\Access_EC` mutex once and omits `PawnIOEcAccess.WriteByte`'s per-call `Thread.Sleep(1)`, either of which can exceed the 2 ms hold window. That file is used by every board, so it lands as its own reviewable commit.
- **Safety gating.** Out-of-spec by design, and a forced unlock was observed leaving the GPU degraded (`nvidia-smi` at 23–27 s per call) until reboot. Explicit opt-in and a rollback path.

Tracked in `docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md` §5, which this PR corrects and which `docs/8D87-EVIDENCE.md` now backs with in-repo citations.

Also not in this series: the four AMD SMU power limits that lift this board's 25 W APU clamp to ~51 W (needs #161's transport).

## What

15 commits making board `8D87` report what the hardware actually does, plus the evidence behind every claim.

Board: HP OMEN MAX 16-ak0098nr, BIOS F.07, EC 40.38, Ryzen AI 9 HX 375, RTX 5080 Laptop. Verified by the machine's owner.

## Grouped by what it fixes

**Capability and adapter awareness**
- Adapter awareness via `Legacy 0x0F` — a command class this repo had never issued. Reports the **connected adapter's real wattage** (measured exact on three physical adapters: 330/280/200 W) and HP's `SmartAdapterStatus`, including the sixth value `ConnectedTypeC` that most third-party sources omit.
- Full `Default 0x28` decode against HP's own accessors. **`IsTwoBytePL4Support` matters beyond this board** — it changes the wire format of `Default 0x29 SetPL4`.
- `Default 0x22` payload: byte 3 is a GPS temperature threshold, not a spare. This repo's `peakTemperature` naming was already right.

**Stop reporting things as done when they were not**
- A performance mode is no longer reported as applied when nothing was applied.
- A fan change is no longer reported as verified when the tachometer read zero. On this board `0x38` is refused, so no physical tachometer reached the verification path at all — which made "level matched" the only evidence checked, and incapable of failing.
- The legacy EC fan-mode readback is skipped rather than taken and discarded.

**Read real hardware instead of proxies**
- Real fan tachometers at EC `0x70` / `0x5C`, not the commanded level.
- GPU mode from `Legacy 0x52`, not from which GPU happens to be awake. A dGPU in D3 is indistinguishable from a disabled one to an adapter-activity check — that made Hybrid render as "Integrated GPU Only" with a healthy RTX 5080 enumerated.
- Battery cycle count read instead of hardcoded 0.
- V2 fan commands **probed** rather than matched on the model name, replacing the `Contains("MAX") && Contains("OMEN")` substring match already flagged in `ROADMAP_v4.0.0.md:256`. This board reports thermal policy V1 and refuses V2 outright.
- Fan chart plots RPM, not the 0–100 efficiency proxy.
- EC tachometers are retried rather than abandoned after one refused transaction.

**Profile**
- `MaxFanLevel` 100 → **60**, measured. This board's V1 levels are krpm/100, not percent, so `MaxFanLevel = 100` made `MapFanPercentToWmiLevel` an identity — a request for 50% wrote raw level 50 ≈ 5000 rpm, near maximum rather than half.
- `"L5P"` removed: no such member exists in `HpWmiBios.FanMode`, so `SetPerformanceMode("L5P")` fell through to `FanMode.Default`. Asking for L5P silently gave you Default.
- `UserVerified = true` — every board-specific field measured on hardware.
- Per-key keyboard scan widened past HP's own vendor ID. The internal keyboard is `0x0D62:0x54BF` (Darfon, HP's ODM), so the old `VendorID == 0x03F0` filter could never find it. **The PID is deliberately not added to the known-device table** — what is confirmed is the device, not that it speaks the inherited `CMD_BYTE 0x0F` command set. Per-key RGB does not work yet; this is the groundwork plus logging so the next field report names the endpoint.

**Evidence**
- `docs/8D87-VERIFICATION-CHECKLIST.md` — per field, how it was established, and what `UserVerified` does **not** cover.
- `docs/8D87-EVIDENCE.md` — cites HP's assembly and line for each static claim, and the control that makes each measurement trustworthy. Replaces links that pointed at a private local tree and were dead on GitHub.

## Two findings worth reading before touching this board

Both are in `8D87-EVIDENCE.md`:

- **A wrong offset that returns a believable number is worse than one that returns `0xFF`.** A third-party map places fan RPM at EC `0x34`/`0x35`. On this board those bytes are ASCII characters from this machine's serial number, and a `<= 80` plausibility check passes them — yielding a confident 6500 / 4800 rpm from string data.
- **`RTCD 0` is weak evidence here.** The ACPI returns `0` on its own timeout path, so an all-zero buffer at `RTCD 0` is indistinguishable from no answer. Non-zero is the trustworthy direction. Separately, `RTCD 5` means *wrong output buffer size*, not "unsupported".

## Method note on the performance-mode measurement

`Default 0x1A` writes `NPCF.MODE` and the firmware consumes `MODE & 0x0F`, so `Default` (`0x30`) and `Cool` (`0x50`) both land on nibble 0 and select the **same power profile** — measured ~102 W and ~103 W against `Performance` (`0x31`) at 175.00 W. All three return `RTCD 0`, so acceptance does not discriminate.

`Performance` was re-run as a **positive control between every pair of readings**, because `OGHP` decays within ~2 minutes and a gate-down machine reads 80 W — close enough to `MODE 0`'s ~102 W that a dropped gate reads as a real result. The first sweep produced exactly that false reading and its `Cool` row was discarded.

## Scope

Board-scoped throughout. Sibling boards `8D88`/`8DD5`/`8DD6` share this platform's firmware and **none has been measured** — `Vibrance25C1BoardIds` is a scope list for raw EC offsets, not a capability claim.

No EC writes are added. `SupportsEcPowerLimits` stays `false`.

## Testing

Builds clean. Full suite **935/935 passing, 0 failed**.
