### PR TITLE
Per-key RGB and light bar for OMEN MAX 16 (board 8D87)

### DIFF
--- a/docs/8D87-EVIDENCE.md
+++ b/docs/8D87-EVIDENCE.md
@@ -1,0 +1,373 @@
+# Board `8D87` — evidence behind the claims in this repo
+
+Several field layouts asserted in OmenCore's source — `ShippingAdapterPowerRating`, the six-value
+`SmartAdapterStatus` enum, `IsTwoBytePL4Support`, the `Default 0x22` GPS-temperature byte — cannot be
+checked by reading OmenCore. They came from **static decompilation of HP's own OMEN Gaming Hub
+binaries**, and from **live measurement** on one machine.
+
+This document is the citation for those claims, so a reviewer can locate the original without a link
+to a private tree. It is a summary of provenance, not a copy of HP's code: it names the assembly and
+line where each field is read, and states what was measured, in what units, with what control.
+
+**Scope.** Everything here is board `8D87`, one physical machine — HP OMEN MAX 16-ak0098nr, BIOS
+**F.07**, EC **40.38**, Ryzen AI 9 HX 375 (Strix Point, family `1Ah` / model `24h`), RTX 5080 Laptop
+(PCI `0x2C19`, subsystem `103C`). Nothing here should be assumed to generalise to another OMEN board
+without re-measurement. Several findings *are* corrections to other projects' register maps that were
+correct on their own hardware.
+
+---
+
+## 1. Two evidence classes, and what each is good for
+
+| Class | Method | Good for | Not evidence for |
+|---|---|---|---|
+| **Static** | Decompilation of HP's shipping assemblies. 309 assemblies, **not obfuscated** — namespaces, method names and enum members intact. | Field layout, arity, control flow, HP's own naming and thresholds. | Runtime behaviour. A field HP reads may be gated by something never reached on a given SKU. |
+| **Measured** | Live instrumentation on the machine: WMI replies, EC reads, `nvidia-smi enforced.power.limit`, Windows `\Energy Meter(*)\Power` counters. | What the hardware actually does. | Layout of anything not exercised. |
+
+Where the two disagree, static wins on **layout and naming**; measurement wins on **behaviour**. One
+such disagreement is recorded in §2.1 and resolved in favour of static.
+
+The epicentre of the static work is `HP.Omen.Core.Common` (54,462 lines decompiled) and
+`HP.Omen.Background.PerformanceControl`. Line numbers below are into those decompilations; they locate
+a claim, they are not stable identifiers across HP releases.
+
+---
+
+## 2. Static: field layouts taken from HP's own accessors
+
+### 2.1 `Default 0x28` `byte[0..1]` is the SKU's adapter wattage
+
+`HP.Omen.Core.Common.cs:34384` — HP's own accessor:
+
+- reads exactly `systemDesignData[0] | (systemDesignData[1] << 8)`
+- is named **`ShippingAdapterPowerRating`**
+- is compared against the literals **200** and **280** (`:34409`, `:34482`) — BIOS performance-mode
+  support, and TGP/PPAB enable
+
+This machine reads `0x014A` = **330**, on a laptop whose shipping adapter is 330 W.
+
+A bitwise reading of the same field as a 16-bit status-flag struct circulates and renders those
+thresholds as `>= 0x00C8` and `>= 0x0118`. Those are the decimal wattages 200 and 280. **The field is
+watts.**
+
+Consequence for this repo: with `Legacy 0x0F` (§2.2) giving the *connected* rating, OmenCore can read
+**both halves** of the comparison HP's adapter gate makes — required vs connected — rather than
+accepting a binary verdict.
+
+### 2.2 `Legacy 0x0F` is fully decoded
+
+Four-byte reply. HP's accessors, `HP.Omen.Core.Model.Device.cs:9460-9481`:
+
+| Byte | HP's accessor | Meaning |
+|---|---|---|
+| `[0]` | `GetSmartAdapterStatus` | the enum in §2.3 |
+| `[1]` bit 7 | `GetSupportBarrel` | `(data[1] & 0x80) > 0` — barrel jack supported |
+| `[2]` | `GetUsbcDesignRating` | `data[2] * 5` — USB-C **design** rating, W |
+| `[3]` | `GetPowerRating` | `data[3] * 5` — **connected adapter rating, W** |
+
+**`0xFF` on `byte[3]` is a sentinel meaning *unknown*, decoding to 0** — check it before treating a
+`0` rating as "no adapter".
+
+Measured across three physical adapters, exact each time:
+
+| Adapter | Reply | `byte[3]` × 5 |
+|---|---|---|
+| 330 W barrel | `01 C2 00 42` | **330** |
+| 280 W barrel | `02 C2 00 38` | **280** |
+| 200 W barrel | `02 C2 00 28` | **200** |
+
+### 2.3 `SmartAdapterStatus` has six values, not five
+
+`HP.Omen.Core.Common.cs:36545`:
+
+| Value | Name |
+|---|---|
+| `-1` / `0xFF` | `Error` |
+| `0` | `NotSupported` |
+| `1` | `MeetsRequirement` |
+| `2` | `BelowRequirement` |
+| `3` | `BatteryPower` |
+| `4` | `NotFunctioning` |
+| **`5`** | **`ConnectedTypeC`** |
+
+Value `5` is the one most third-party sources omit. It is **not** a fault state — it is USB-C PD
+connected, and HP gives it its own comparison logic in `IsLowWattage`
+(`HP.Omen.Core.Model.Device.cs:9484-9493`): the connected rating is compared against the USB-C
+*design* rating, instead of the binary meets/below test used for the barrel path. There is also a
+special case where barrel support is present and the USB-C design rating is 0.
+
+So `ConnectedTypeC` must not be folded into "anything that is not `MeetsRequirement`".
+
+### 2.4 `Default 0x22` byte 3 is a GPS temperature threshold
+
+`HP.Omen.Background.PerformanceControl.cs:5970` builds the payload as
+`[cTGP, ppab, dState, gps]`, and every caller passes a temperature into the fourth byte
+(`:1720`, `:1661`).
+
+OmenCore's existing `peakTemperature` naming was therefore **right**, and a "spare" reading is wrong.
+
+The value is the output of HP's `IRHandler`, a closed loop driven by the chassis **infra-red skin
+sensor**, bounded by two `PlatformSettings` values: `GpsMaxTemperature = 87` (un-throttled) and
+`GpsMinTemperature = 75` (IR-overheat response only).
+
+**Why this repo still sends 0.** A replacement with no IR loop is permanently in the un-throttled
+state. Sending the un-throttled bound `87` would assert to the firmware that the chassis is cool — a
+claim we have no sensor to justify — and byte 3 is **not** in the `0x21` readback, so the write cannot
+be verified by outcome. The decode is recorded at `HpWmiBios.HpGpsTemperatureThresholdC` and the byte
+is deliberately left at 0. See `docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md` §2.
+
+### 2.5 `Default 0x28` full decode
+
+Reply is 128 bytes, 11 non-zero here: `4A 01 3A 01 03 00 01 07 3C 00 03 00`.
+
+| Byte | Mask | HP's name | Here | Meaning |
+|---|---|---|---|---|
+| `[0..1]` | 16-bit LE | `ShippingAdapterPowerRating` | `0x014A` | **330 W** (§2.1) |
+| `[3]` | whole | `GetThermalPolicyVersion` | `0x01` | **V1** |
+| `[4]` | `0x01` | `IsSwFanControlSupport` | `0x03` | true |
+| `[4]` | `0x02` | `IsExtremeModeSupport` | | **true** |
+| `[4]` | `0x04` | `IsExtremeModeUnlock` | | **false** |
+| `[4]` | `0x08` | `IsDTBiosControl` | | false |
+| `[4]` | `0x10` | **`IsTwoBytePL4Support`** | | **false** |
+| `[5]` | whole | `PL4DefaultValue` | `0x00` | 0 |
+| `[6]` | `0x01` | `IsBiosDefinedOcSupport` | `0x01` | true |
+| `[7]` | whole | `GpuModeSwitch` | `0x07` | capability bitmask, **not** current mode |
+| `[8]` | whole | `DefaultCpuPowerLimitWithGpu` | `0x3C` | **60 W** concurrent CPU budget |
+| `[9]` | `0x0F`/`0xF0` | `LoadLineSupportLevels` / `DefaultLoadLine` | `0x00` | 0 / 0 |
+| `[10]` | `0x01`,`0x02`/`0x04`/`0x08` | `ChangeIrSensorToBoard` / `IsPchOverheatSupport` / `IsVrSensorSupport` | `0x03` | false / false / false |
+
+**`IsTwoBytePL4Support` is the entry that matters beyond this board** — it changes the wire format of
+`Default 0x29 SetPL4`. Getting it wrong is a silent write-corruption class of bug on any board where
+the bit is set.
+
+**The reply is static.** Byte-identical on the 330 W and 200 W adapters, and byte-identical in Hybrid
+and Discrete GPU modes. It describes the SKU — not the connected supply, and not the current graphics
+mode. Read the connected adapter from `Legacy 0x0F` and the GPU mode from `Legacy 0x52`.
+
+`byte[0..1] = 4A 01` also establishes the board strap **`BYID = 0`** on this machine, because the
+firmware writes those bytes only on the `BYID == Zero` branch.
+
+### 2.6 Where HP's capability data actually lives
+
+Two structural findings that bear on this repo's design, both from the static work:
+
+- **There is no EC register map anywhere in OGH.** A grep across all four decompiled roots for the EC
+  MMIO base, `EmbeddedController`, `Ec{Read,Write}`, `{Read,Write}EcRam`, `LpcACPIEC` and raw port I/O
+  returns **zero hits**. HP reaches the EC only through AML `GCxx`, and the AMD SMU through AMD's own
+  driver. A per-board table of EC offsets has no counterpart in HP's software to copy.
+- **No power decision in OGH is keyed on board ID.** The board table gates hotkeys, chassis and
+  lighting only. HP's capability source is the runtime `Default 0x28` query. This repo's per-board
+  capability model is its own invention — legitimate, but it should not be mistaken for HP's.
+
+Consequence, and it is why the board list in `ModelCapabilityDatabase.Vibrance25C1BoardIds` is scoped
+the way it is: use board ID as a **safety scope for raw EC offsets**, and prefer `0x28` for
+**capability**.
+
+### 2.7 A driver that is not a stub, and one that is
+
+- `hpomencustomcapdriver.sys` imports exactly `DbgPrintEx` and `RtlCopyUnicodeString` plus WDF loader
+  stubs — no `MmMapIoSpace`, no port I/O, no `IoCreateDevice`. It **cannot** touch the EC by
+  construction. Do not investigate it as an arming agent.
+- `HpReadHWData.sys` is the one that is not a stub. It exposes a kernel-mode WMI passthrough whose
+  validator checks the literal `SECU` tag and executes via `IoWMIExecuteMethod` on device
+  `ACPI\PNP0C14\0_0`. It also enforces a **caller-identity allowlist of eight named HP binaries** —
+  the only privilege asymmetry located between HP's writes and a third party's.
+
+---
+
+## 3. Measured: the numbers, and the controls that make them trustworthy
+
+### 3.1 Performance modes are two power profiles, not three
+
+`Default 0x1A` writes `NPCF.MODE`, and the firmware consumes **`MODE & 0x0F`**. The named mode bytes
+therefore collapse onto low nibbles. Measured in `nvidia-smi enforced.power.limit`:
+
+| Byte | Name | `& 0x0F` | `enforced` |
+|---|---|---|---|
+| `0x30` | Default | 0 | ~102 W |
+| `0x31` | Performance | 1 | **175.00 W** |
+| `0x50` | Cool | 0 | ~103 W — **same power profile as Default** |
+| `0x34` | *(unnamed)* | 4 | **175.00 W** — reachable, named by no consumer project |
+
+All of these return `RTCD 0`, **including the two that select the same profile** — so acceptance says
+nothing about which profile you got. `Cool` is a fan/thermal policy, not a power tier.
+
+**The control that makes this valid.** `OGHP` decays to 0 within ~2 minutes of OMEN userland being
+killed, and a gate-down machine reads 80.00 W while `MODE 0` reads ~102 W — close enough that a
+dropped gate mid-sweep reads as "this mode selects MODE 0". `Performance` was therefore re-run as a
+positive control between **every pair** of readings, and the run is void unless every control hits
+175 W. The first sweep attempted here produced exactly that false reading, and its `Cool` row was
+discarded.
+
+`"L5P"` is not `MODE 4` or anything else: the string has no byte anywhere in the WMI path. It was
+removed from this board's profile because `SetPerformanceMode("L5P")` fell through to
+`FanMode.Default` — asking for L5P silently gave you Default.
+
+### 3.2 Fan tachometers are `0x70` and `0x5C`
+
+Both 16-bit raw RPM in the EC state window.
+
+`0x7E`/`0x5E` are **commanded setpoints, not tachometers**, gated by the level byte `0x5B`. The
+discriminating measurement, against a full OGH "Full fan speed" ramp: `0x70`/`0x5C` climbed 0 → 4980
+rpm in step with the audible spin-up, while `0x7E`/`0x5E` read 2000/2200 throughout and then **fell to
+0/0 while the fans were still turning at 4980**. A tachometer cannot be invariant while its fan
+changes speed.
+
+This was asserted the wrong way round in an earlier draft of this work and corrected before any PR
+opened.
+
+### 3.3 `MaxFanLevel` is 60, not 100
+
+This board reports thermal policy **V1** and refuses the V2 fan commands outright — `0x37` returns
+`RTCD 6` and `0x38` returns `RTCD 4`, at every input and output buffer size tried. Fan levels
+therefore arrive through the V1 `0x2D` path in krpm/100, **not percent**.
+
+With `MaxFanLevel = 100`, `MapFanPercentToWmiLevel` became an identity: a request for 50% wrote raw
+level 50 ≈ 5000 rpm — near maximum, not half.
+
+Sampled against the EC tachometers and OGH's own readout at four points — `0`/0, `22`/2220, `47`/4680,
+`60`/6000 rpm — linear within ~1%, ceiling **60**.
+
+### 3.4 The AMD Curve Optimizer reaches the silicon
+
+Verified by outcome, not by SMU status. Three alternating pairs under sustained all-core load
+(`tools/SmuProbe --outcome`):
+
+| | Effective clock | Core power |
+|---|---|---|
+| CO 0 | 3148 MHz | 21.40 W |
+| CO −25 | 3301 MHz | 20.10 W |
+| **paired delta** | **+4.9% mean** (range +4.8…+4.9%, consistent sign in all 3 pairs) | −1.3 W |
+| sham control (CO 0 both phases) | **−0.1%** | — |
+
+More clock at less core power is the signature of a real undervolt, and the baseline returns to
+~3148 MHz every time the offset is removed.
+
+**Why it is paired.** A single before/after comparison measures thermal drift as readily as an effect:
+an earlier version of this harness reported **+4.8% and −5.3% for the same offset** on consecutive
+runs, depending only on how hot the machine started. Alternating and pairing each offset phase against
+the baseline immediately before it makes monotonic drift cancel. The sham control establishes the
+noise floor rather than assuming one.
+
+Note also that the SMU returns `Ok` for **both** MP1 `0x4C` and PSMU `0x5D` on this part, and both
+measurably work — so the message id was never the reason Curve Optimizer did nothing. The transport
+was.
+
+### 3.5 Legacy EC offsets do not port to this board, and one of them lies
+
+`0x95`, `0xBA`, `0xCE`, `0xCF` are the pre-2024 OMEN layout. This board's EC is memory-mapped at
+`0xFE700600`.
+
+The instructive one is a third-party map placing single-byte krpm fan RPM at `0x34`/`0x35`. On this
+board those two bytes are the ASCII characters `A` and `0` from the serial number `6LJCA0HTZLC9G0`,
+and a `<= 80` plausibility test passes them — yielding a confident **6500 / 4800 rpm** from string
+data.
+
+**A wrong offset that returns a believable number is worse than one that returns `0xFF`.** This is why
+raw EC offsets in this repo are board-scoped rather than shared.
+
+### 3.6 There is a mux; it is not Advanced Optimus
+
+Two different claims, and this board splits them.
+
+- **The mux is real.** In Discrete the internal panel is driven by the RTX 5080, and `Legacy 0x52`
+  reads `01`. Measured across a reboot in each direction: Hybrid → `00`, Discrete → `01`, back to
+  Hybrid → `00`. So `HasMuxSwitch = true`.
+- **Advanced Optimus is off.** That is the *dynamic* mux, moving under live ACPI control with no
+  reboot. The firmware block stays disabled through a **successful** mode switch — Smart Mux Support,
+  Acpi Control, MDM Support and Display Panel Multiplexer all read `0` in Hybrid, Discrete *and* after
+  returning to Hybrid. Routing is decided at boot. So `SupportsAdvancedOptimus = false`.
+
+`Default 0x28` byte 7 = `0x07` does **not** settle either claim: it is byte-identical in all three
+modes, so it describes the SKU family, not the current state.
+
+### 3.7 An idle dGPU is not iGPU-only mode
+
+A dGPU in D3 reports `Win32_VideoController` `Availability: 8` (Off Line) with no resolution, refresh
+rate or bit depth — indistinguishable, to an adapter-activity check, from a machine with the dGPU
+switched off in firmware. On this board that made Hybrid render as "Integrated GPU Only" with a
+healthy RTX 5080 enumerated.
+
+Read the mode from `Legacy 0x52`. The only way to make an adapter-activity check agree is to wake the
+dGPU, which spends real power to answer a question the firmware already answers.
+
+Related instrument trap: `nvidia-smi` reports `P0`/25 W at idle **because the query itself wakes the
+GPU**, then holds D0 for 120–150 s. Polling to observe D3 re-entry is what prevents it. Read
+`DEVPKEY_Device_PowerData`, which does not wake the device.
+
+---
+
+## 4. Closed questions — do not re-derive these
+
+Each was established and is closed. Recorded because the natural next step for anyone picking this up
+is to rediscover a dead end and mistake it for a lead.
+
+| Claim | Status |
+|---|---|
+| `Default 0x10` is the `OGHP` arming command | **RETRACTED.** `GC01`/`GC10`/`GC28`/`GC2B` are all 0-arg read-only methods. If a capture shows OGH sending `0x10`, that is a read. |
+| `DSTA` via `Default 0x22` is a usable lever | **NO.** `GC22`'s own tail calls `_Q73`, which overwrites `DSTA` from `PROH`. Writes snap back within a second on *either* adapter. |
+| `OGHP` has an AML writer | **NO.** Across all four decompiled tables it appears only as an `External`, a field declaration, and two `== Zero` reads. The EC owns it. |
+| `OGHP` survives a reboot | **NO.** And **the bit is not a valid readout** — it read `1` on a boot where the grants had been revoked. Test with `Default 0x21` or delivered watts. |
+| The mailbox block at `0xF5`–`0xF8` is a power lever | **NO.** It is the EC *publishing* a decision; forcing it to the 330 W values changed nothing. The SMU never reads it back. |
+| `PROH`/`DSTA` values 3/4/5 are intermediate power tiers | **NO.** They are `SmartAdapterStatus` (§2.3). There is no middle tier. |
+| A matched fan-level readback proves the fan changed speed | **NO.** It proves the firmware accepted the command. `0x38` is refused on this board, so no physical tachometer reached the old verification path at all — which made "level matched" the only evidence checked, and incapable of failing. Measured: level 28 echoed back while five consecutive samples read 0 rpm. |
+| A mode sweep can be run sequentially | **NO.** See the `OGHP` decay control in §3.1. |
+| `ZenStates-Core` can read this SMU | **NO.** No map for family `1Ah`/model `24h`. Use RyzenAdj ≥ 0.19.0, which recognises Strix Point. |
+| `GetSystemFirmwareTable(ACPI,'SSDT')` enumerates the loaded SSDTs | **NO.** It returns only the first table per signature — an enumeration loop yields 41 copies of one table. Read `HKLM:\HARDWARE\ACPI` instead: 37 distinct tables. |
+
+---
+
+## 5. Method rules these came from
+
+Four separate false positives in this work had the same shape. They are recorded as rules because the
+same shapes recur in this repo's own history.
+
+1. **Check the outcome, not the request.** A WMI command returning `RTCD 0` means the firmware
+   accepted it, not that the hardware did anything. Verify fan claims in RPM and power claims in
+   watts. On this platform `RTCD 0` is especially weak: the ACPI returns `0` on its own timeout path,
+   so an all-zero buffer at `RTCD 0` is indistinguishable from no answer. **Non-zero is the
+   trustworthy direction.**
+2. **Compare against the requested value, not the previous sample.** A write the EC has already undone
+   looks stable if you only diff consecutive polls.
+3. **Adjacency in a high-rate capture is not causation.** The `Default 0x10` claim was published and
+   retracted on exactly this error, and one grep of the static tables refuted it. **When a capture and
+   a decompiled table disagree, the table wins.**
+4. **Two agreeing snapshots are not a reproducibility filter.** One adapter-keyed byte passed that bar
+   and was still wrong. Vary the input across more than two states.
+5. **`RTCD 5` means the output buffer was the wrong size**, not "unsupported". A genuine refusal
+   persists across every buffer size tried.
+6. **Reads can be corrupted by OMEN Gaming Hub.** The EC command mailbox is a single shared buffer with
+   no locking between OS agents, and OGH polls it continuously. Repeated identical reads returned OGH's
+   replies to *its* questions until OGH was stopped. Distrust a value that changes between
+   back-to-back identical reads.
+7. **Check the instrument against a known value before believing it.** PowerShell's `-shl` preserves
+   the left operand's type, so `[byte]0x0A -shl 8` is `0`. A 16-bit EC field assembled that way
+   silently returns only its low byte — one tool reported a fan at 200 rpm while the raw window held
+   `C8 0A` = 2760. Nothing in the output looked wrong on its own.
+
+---
+
+## 6. Provenance
+
+The full lab notebooks are outside this repository — they are long (one is over 2,500 lines), they
+record method and measurement rather than conclusions, and they contain their own retractions. This
+document is the distilled citation; the source tree separates `reference/` (current truth) from
+`investigation/` (how it was established), and its notebook filenames are:
+
+| Document | Covers |
+|---|---|
+| `01-bios-f07-static.md` | static firmware analysis |
+| `02-power-gate-measurements.md` | live power measurement |
+| `03-nvpcf-tgp-mechanism.md` | the NVPCF/TGP mechanism, ACPI-decompiled |
+| `04-ogh-binaries.md` | static decompilation of HP's OMEN Gaming Hub |
+| `05-keyboard-lighting.md` | lighting topology |
+| `06-hpreadhwdata-driver.md` | `HpReadHWData.sys` |
+| `08-ec-port-aliasing.md` | ACPI EC port ↔ MMIO aliasing |
+| `09-capability-verification.md` | per-field capability verification |
+
+Two things to carry from them if this is ever reopened:
+
+- **Several findings there were corrected more than once before settling.** Prefer a distilled
+  statement over a raw section, and treat anything marked untested as untested.
+- **The port↔MMIO aliasing is established for *reads only*, on one adapter state.** Nothing may write
+  EC RAM on that basis. See `docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md` §5.1.

--- a/docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md
+++ b/docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md
@@ -199,7 +199,22 @@ Measured: 330 W → `01 C2 00 42` (`0x42` × 5 = 330). 200 W → `02 C2 00 28` (
 
 ---
 
-## 4. Tier 2 — the CPU 25 W clamp. Mostly built, plumbing is dead.
+## 4. Tier 2 — the CPU 25 W clamp. Plumbing fixed; limits implemented.
+
+> **Status, 2026-08-05.** **T2.1, T2.2 and T2.3 are done** and measured on hardware. T2.1 landed as the AMD SMU transport fix; T2.2 and T2.3 as the fast/slow/apu-slow limits and a silicon-scoped ceiling. **T2.4 stands — TDC/EDC remain untouched.** T2.5 (re-assertion) is now known to be *required*, not optional: see the box at the end of this section. T2.6's verification guidance was wrong and has been corrected below.
+>
+> Measured with `tools/SmuProbe --limits`, using an external RyzenAdj as an independent reader. Every phase pinned to its requested limit within 10 mW, and the returning phase came back exactly, so the excursion is the limit rather than drift:
+>
+> | phase | requested | read back | SMU drawing | TDC | Tctl |
+> |---|---|---|---|---|---|
+> | A stock | 45 W | 45.000 W | 44.99 W | 41.3/70 A | 66 °C |
+> | B low | 20 W | 20.000 W | 19.99 W | 21.2/70 A | 54 °C |
+> | A' stock | 45 W | 45.000 W | 45.00 W | 41.3/70 A | 68 °C |
+> | C high | **70 W** | 70.000 W | **70.00 W** | 57.5/70 A | 85 °C |
+>
+> Stock was genuinely binding — 44.99 W drawn against 45.000 W — which is what makes the upward direction answerable rather than merely unrefuted.
+
+## 4a. Tier 2 detail
 
 **Evidence:** measured end-to-end with RyzenAdj v0.19.0 on the physical machine (§7m). 25.02 W → 45.73 W → ~51 W sustained / 60.7 W peak.
 
@@ -212,9 +227,21 @@ The strongest single piece of evidence in the entire investigation is here and w
 - **T2.1 (blocker)** Fix `RyzenSmu.Initialize()`. It opens a PawnIO handle but never calls `pawnio_load`, so `ioctl_pci_read_config_dword` / `ioctl_pci_write_config_dword` have no module behind them. Compare `PawnIOEcAccess.LoadEcModule()`, which does load `LpcACPIEC`. **This is a confirmed defect, not a hypothesis** — `RyzenSmu.cs:102-104` resolves only `pawnio_open`/`pawnio_execute`/`pawnio_close`, and it is the only PawnIO consumer in the repo that skips `pawnio_load`. Gate the fix so it does not enable an untested path for every AMD board.
 - **T2.2** Add `fast-limit`, `slow-limit`, `apu-slow-limit` alongside the existing `SetStapmLimit`. Message IDs must come from RyzenAdj's Strix Point table — **do not guess them**, and do not infer them from the existing `0x14`/`0x31` stapm pair.
 - **T2.3** Raise `SetStapmLimit`'s clamp. It currently caps at 54,000 mW (`AmdUndervoltProvider.cs:302`); the measured target is 100 W with a 125 W fast limit. Pick the new ceiling deliberately and document why.
-- **T2.4** **Do not raise TDC/EDC.** With the four power limits raised the part becomes current-bound at 53.977 A against a 54.000 A limit. §7m's argument for leaving it alone is sound and should be preserved verbatim in the code comment: a power limit is self-limiting (throttle or brownout, both fixed by a reboot); a current limit governs how hard the VRM is driven, and sustained overcurrent is not self-correcting. Every write in that investigation used a value the firmware writes itself; we don't know what TDC/EDC read on the 330 W adapter.
-- **T2.5** Re-assert after power-source changes, sleep/resume, and adapter swaps — the EC recomputes everything on those transitions. Steady-state operation needs nothing.
-- **T2.6** Verify by measured APU package power, not by SMU return code. Windows exposes `\Energy Meter(Apu Power)\Power` in milliwatts (also `CPU Power`, `GPU Power`, `NPU Power`). The separate `Power Meter` counter set reads all-zero on this machine — do not use it.
+- **T2.4** **Do not raise TDC/EDC.** The risk argument is unchanged and should be preserved verbatim in the code comment: a power limit is self-limiting (throttle or brownout, both fixed by a reboot); a current limit governs how hard the VRM is driven, and sustained overcurrent is not self-correcting.
+
+> **T2.4 correction (2026-08-06).** This item said the part becomes current-bound at 53.977 A against a **54.000 A** limit, and that the 330 W reading was unknown. The limit is **not a fixed property of the part.** `TDC`/`EDC LIMIT VDD` reads **70.000 A** idle at stock — on the 330 W adapter *and* on the 280 W adapter, which is the same adapter the 54 A figure came from — so 54 A is what it read under that particular raised-limit load, not a rating. **Do not ship 54 A as a constant** (`AmdUndervoltProvider`'s old 15–54 W clamp was a symptom of treating it as one), and do not raise either number.
+- **T2.5** Re-assert after power-source changes, sleep/resume, and adapter swaps — the EC recomputes everything on those transitions. **Stronger than originally written: re-assertion is required, not just advisable.**
+
+> **T2.5 correction (2026-08-05).** "Steady-state operation needs nothing" is not what was observed. After a `--limits` run that restored all four limits to 45 W, they later read **71 / 71 / 60 / 45 W**, stable across samples. Nothing in OmenCore wrote that — every write sets all four to the same value — and the numbers are not arbitrary: **60 W is exactly this board's NVPCF `ATPP` (`0x1E0` = 480/8) and 70 W is `ACBT` (`0x230` = 560/8)**. The ACPI power path pushes its own values into the same registers.
+>
+> The limits held solidly for the whole of a sustained load and read back exactly, then were taken back once the load ended. So a user-set limit that is meant to persist needs a re-assertion loop; one call and an `Ok` status will silently drift back.
+- **T2.6** Verify by measured power, not by SMU return code. **The guidance here has been corrected — see the box below.**
+
+> **T2.6 correction (2026-08-05).** This item originally said to verify with `\Energy Meter(Apu Power)\Power`. That counter is **a different and narrower domain than the SMU's PPT, and must not be compared against a watt figure the SMU was given.** Measured on this machine at three limits: 28.82 W counter against 44.99 W SMU, 12.01 against 19.99, 43.11 against 70.00 — a consistent ~62 %. It tracks direction faithfully and absolute level not at all.
+>
+> A first pass at this measurement used the counter as its only axis and concluded the load "was not power-bound" at 27 W against a 45 W limit — while the SMU read 44.994 W drawn against 45.000 W at that same moment. That is this repo's recurring proxy-instead-of-outcome mistake, reproduced inside the harness built to avoid it.
+>
+> **Use the SMU's own `STAPM VALUE` / `PPT VALUE` as the measurement**, read over an independent transport, with the Windows counter kept as a direction-only witness. `tools/SmuProbe --limits` does exactly this.
 - **T2.7** Do not attempt to reproduce HP's mechanism. How the EC gets 25 W into the SMU is still unknown and is excluded from AML, AMD PMF, NVPCF/Dynamic Boost, Windows PPM, HP's userland, and the EC mailbox block — leaving SMM as the surviving hypothesis. It is a curiosity, not a blocker.
 
 ---
@@ -299,6 +326,94 @@ Every offset here (`0x59`, `0x90`, `0xE6`, `0xF6`/`0xF7`) came from *this* DSDT.
 - **T3.3** Stage-2 unlock: hold `PROH = 1`, fire `GC22` to run `_Q73`, release. Verify against delivered watts. Re-apply on revert.
 - **T3.4** Stage-1 arm, **only if** a fast enough transport exists: hold `OGHP` (mask `0x02`, preserving `DBST` at bit 4 — it is a read-modify-write, unlike `PROH`) from a ≤2 ms loop, fire `GC22` inside the window, release. Measured minimums: 2 ms hold, 5000 ms settle before re-read. 5 ms hold fails; 1200 ms settle fails.
 - **T3.5** Proportional TGP mode: read the connected wattage (T1.4), pick a cap the supply can plausibly sustain, apply it driver-side rather than requesting the full 175 W. This is the *responsible* version of the feature and it is only possible because `Legacy 0x0F` exposes a real number.
+
+---
+
+## 5a. Keyboard lighting — per-key, and over an open standard
+
+**Not in the original three tiers.** It turned out to be independent of the power path and far
+cheaper than expected, so it is recorded here rather than deferred.
+
+### 5a.1 This board is per-key, and the four-zone path is a decoy
+
+The capability gate HP's own software uses is **`Default 0x2B`** — class `0x00020008`, no input
+payload, 4-byte reply whose byte 0 is `NbKeyboardLightingType`. Measured **`0x03` = `RgbPerKey`
+on ten of ten reads**.
+
+The trap, and it is a good one: the four-zone colour block (`Keyboard 0x02`) **still reads back
+plausibly on a per-key board**. HP computes `ZONE_NUM` as `(uint)(type - 4) <= 1`, so type 3
+falls through to 4 zones. Reading that block alone yields four tidy RGB triples at offset 25 and
+a confident wrong answer. Gate on the topology probe first.
+
+On this chassis the four-zone commands drive the **light bar**, not the keyboard — owner-observed.
+So "four-zone returned success" was never a null result here; it was landing on a different
+lighting surface than the one being watched, which is more misleading than a refusal.
+
+### 5a.2 `Keyboard 0x01` is an accumulator, not a keyboard-type getter
+
+Widely documented as `GetKbdType`. It is not. Ten identical consecutive calls returned:
+
+```
+0x0F, 0x1F, 0x3F, 0x7F, 0xFF, then 0xFF for every call after
+```
+
+It grows until it saturates. Nothing about the hardware changed between those calls. An earlier
+note in this repo recorded "returns an 0xFF sentinel" — that was a saturated counter, not a
+sentinel. And once saturated, its bit 0 reads "lighting supported" whether or not that is true,
+so even HP's own `& 1` reading is untrustworthy here.
+
+### 5a.3 The keyboard is a standard HID LampArray — no reverse engineering needed
+
+The internal keyboard (`0D62:54BF`, "HP Gaming Keyboard II", Darfon — HP's ODM) implements
+**HID usage page `0x59`, "Lighting And Illumination"**: the standardised per-key surface that
+Windows Dynamic Lighting drives.
+
+```
+LampCount        120
+Kind             1 = Keyboard
+BoundingBox      342 x 125 x 1 mm
+MinUpdateInterval 33 ms
+per lamp         8-bit R/G/B/intensity, programmable, carries the HID usage of its key
+```
+
+Geometry is self-consistent — the numpad lamps sit at x = 279–328 mm, Tab at x = 12 mm.
+
+**This changes the cost of the feature entirely.** The plan had been to ask the GitHub #151
+reporter for HID captures and infer a vendor command set. That is no longer the critical path
+for this board: the protocol is specified, and `HidLampArray` implements it.
+
+### 5a.4 What is verified, and what cannot be
+
+The device **accepted** the control report (id 6) and range-update reports (id 5) — it took them
+without stalling, so the report layouts are structurally right.
+
+**That is not proof the keys changed colour, and no software check can be.** The LampArray spec
+has no colour readback anywhere. `tools/LightingProbe --self-test` exists for exactly this: it
+drives the keyboard in thirds (red / green / blue, so a *partial* result stays readable) and
+tells a person what they should be seeing.
+
+### 5a.5 The open question — arbitration with Windows Dynamic Lighting
+
+Dynamic Lighting is **on** on this machine (`AmbientLightingEnabled = 1`) and owns the LampArray;
+it is why `LampArray.FromIdAsync` (WinRT) times out on the keyboard interface while direct HID
+works. Three options, and they differ in what OmenCore does to a Windows feature the user may
+want running:
+
+1. WinRT `LampArray`, playing by Windows' arbitration rules.
+2. Direct HID, contending with Dynamic Lighting at ~30 Hz.
+3. Ask the user to turn Dynamic Lighting off, then direct HID.
+
+**Deliberately unresolved.** The mechanism for (2) is built because it is the one proven to work
+here; nothing is wired into the UI until the policy is chosen.
+
+### 5a.6 Work items
+
+- **T5a.1** *(done)* Topology probe `Default 0x2B`; capability detection reads it instead of assuming four-zone.
+- **T5a.2** *(done)* `HasBacklight` asks for a 128-byte reply. A 4-byte request returns **RTCD 5 = wrong output buffer size**, which the old code read as "unsupported" — reporting no backlight on a lit keyboard.
+- **T5a.3** *(done)* `HidLampArray` + `tools/LightingProbe`.
+- **T5a.4** Decide the arbitration policy (§5a.5), then wire per-key control into the UI.
+- **T5a.5** Map lamp id → key. Each lamp reports the HID usage of its key, so a usable key-name mapping is a table lookup rather than a calibration exercise. **Note the free-running response**: this keyboard's lamp-attributes reply ignores the requested id (asking 0–3 returns 41–44), so read the id the device reports.
+- **T5a.6** Settle `8D41`, the Intel sibling. It claims per-key *and* four-zone and is marked `UserVerified`, so it is somebody's real report and is left alone. One command from an owner resolves it: `LightingProbe --wmi`.
 
 ---
 

--- a/docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md
+++ b/docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md
@@ -1,6 +1,6 @@
 # Board `8D87` — OMEN MAX 16 (2025, AMD) Support Plan
 
-**Status:** planning. Nothing in this document has been implemented.
+**Status:** Tier 1 is largely **implemented** — see §8 for what has landed and what has not. Tier 2 (the AMD SMU transport) is fixed; Tier 3 (the adapter gate) is not started and is gated on evidence stated in §5.1.
 **Target board:** `8D87` — HP OMEN MAX 16-ak0098nr, Ryzen AI 9 HX 375 (family `1Ah`/model `24h`, Strix Point) + RTX 5080 Laptop (`10DE:2C19`), BIOS F.07, EC 40.38.
 **Sibling boards on the same HP platform (`Vibrance25C1`):** `8D88`, `8DD5`, `8DD6`.
 **Related existing DB entry:** `AK0003NR` (`ModelNamePattern = "max 16 ak0"`), same family, different SKU.
@@ -9,34 +9,30 @@
 
 ## 0. Where this comes from, and how much to trust it
 
-Two external investigations, both outside this repo:
+Two evidence classes, from an investigation conducted outside this repo on one physical machine:
 
-| Source | Method | Evidence class |
-|---|---|---|
-| `D:\src\omen-max-16\investigation\03-nvpcf-tgp-mechanism.md` | ACPI decompilation + **live measurement** on the physical machine | Strongest available. Firmware-derived and instrumented. |
-| `D:\src\omen-max-16\investigation\04-ogh-binaries.md` | Static decompilation of HP's own OMEN Gaming Hub binaries (309 assemblies, not obfuscated) | Strong for **arity, field layout, HP's own naming**. No evidence at all for runtime behaviour. |
+| Class | Method | Good for | Not evidence for |
+|---|---|---|---|
+| **Measured** | ACPI decompilation plus **live instrumentation** — WMI replies, EC reads, `nvidia-smi enforced.power.limit`, Windows Energy Meter counters. | What the hardware actually does. | Layout of anything not exercised. |
+| **Static** | Decompilation of HP's own OMEN Gaming Hub binaries — 309 assemblies, **not obfuscated**. | Field layout, arity, control flow, HP's own naming and thresholds. | Runtime behaviour. |
 
-Supporting documents in the same series: `01-bios-f07-static.md` (static firmware), `02-power-gate-measurements.md` (measurement), `07-setup-variable-map.md`.
+Where they conflict, **static wins on layout and naming; measurement wins on behaviour.** One such
+conflict is load-bearing here: the `Default 0x28` `byte[0..1]` field was read behaviourally as a
+status-flag struct and is, per HP's own accessor, watts.
 
 > [!IMPORTANT]
-> **Do not read either source document to answer a question of fact.** They are lab notebooks: they
-> record method and measurement — how a thing was established, on what instrument, with what numbers —
-> and they are long. `03-nvpcf-tgp-mechanism.md` alone is over 2500 lines.
+> **The distilled evidence for every claim in this document lives in
+> [`8D87-EVIDENCE.md`](8D87-EVIDENCE.md), in this repository.** It cites HP's assembly and line for
+> each static claim, and the control that makes each measurement trustworthy.
 >
-> The distilled current truth is in **`D:\src\omen-max-16\reference\`** — five short documents:
-> ``power-model.md``, ``ec-map.md``,
-> ``wmi-commands.md``,
-> ``board-8d87.md`` and
-> ``settled-negatives.md``, plus
-> ``capabilities-8d87.json`` for this plan's §3.6 database entry.
-> Cite the notebook for provenance; take facts from `reference/`.
+> The original lab notebooks are outside this repo and are deliberately not linked: they are long (one
+> is over 2,500 lines), they record method rather than conclusions, and they contain their own
+> retractions. Notebook filenames are listed in `8D87-EVIDENCE.md` §6 for provenance.
 
 **Two things to keep in mind while reading:**
 
-1. **The two sources disagree in places, and 04-ogh-binaries.md is usually the correction.** The mechanism doc's §7h concluded `0x28` bytes 0–1 were a status-flag field; 04-ogh-binaries.md §1a shows HP's own source names it `ShippingAdapterPowerRating` and compares it against 200 and 280. Where they conflict, the binary analysis wins on *layout and naming*, the mechanism doc wins on *runtime behaviour*. Both resolutions are already applied in `reference/`.
-2. **Five plausible findings on this board turned out to be false, and four failed the same way.** `PROH` at `0x8F`, `Default 0x10` as the arming command, `HPBA` as adapter-keyed, `P3TV` as a working lever, and "the exploit is a durable one-shot" were each established and then disproved — four of them because the *request* was checked instead of the *outcome*. A command that returns success is not a watt. That failure mode is directly relevant to how we implement this: see §5.2, and ``settled-negatives.md`` for the current statement of each.
-
-**This board's `UserVerified` status stays `false` for now.** The evidence above is excellent, but it comes from one machine and one investigator, not from this project's normal field-report channel. Individual items below carry their own evidence assessment.
+1. **Five plausible findings on this board turned out to be false, and four failed the same way.** `PROH` at `0x8F`, `Default 0x10` as the arming command, `HPBA` as adapter-keyed, `P3TV` as a working lever, and "the exploit is a durable one-shot" were each established and then disproved — four of them because the *request* was checked instead of the *outcome*. A command that returns success is not a watt. That failure mode is directly relevant to how we implement this: see §5.2, and [`8D87-EVIDENCE.md`](8D87-EVIDENCE.md) §4 for the current statement of each closed question.
+2. **This is one machine and one investigator**, not this project's normal field-report channel. `UserVerified` on this board's entry is now `true` because every board-specific field in it was measured on the hardware — see [`8D87-VERIFICATION-CHECKLIST.md`](8D87-VERIFICATION-CHECKLIST.md) for which claim rests on what, and what the flag does not cover. Individual items below carry their own evidence assessment.
 
 ---
 
@@ -243,8 +239,8 @@ OmenCore cannot do that:
 > [!IMPORTANT]
 > **T3.1 has now been run. The ports alias the MMIO window for reads, and the latency objection
 > below did not survive measurement.** Full method and limits:
-> ``../investigation/08-ec-port-aliasing.md``; distilled in
-> ``../reference/settled-negatives.md``.
+> the `08-ec-port-aliasing.md` notebook; distilled for this repo in
+> [`8D87-EVIDENCE.md`](8D87-EVIDENCE.md).
 
 - **T3.1 — DONE (2026-08-04).** Three runs sandwiching a PawnIO/`LpcACPIEC` port sweep between two MMIO captures, so that only bytes which held still across the whole window got a vote. **100 % / 100 % / 99.6 % agreement on judged bytes; 8 of 8 entropy-carrying anchors matched**, including both fan tachometers at 3000 rpm under deliberate CPU load and `PROH` itself. Correlation falls from 99.6 % at shift 0 to ~33 % at ±1 byte, which is what rules out coincidental resemblance rather than mere agreement. The one diverging byte was a temperature sensor that ticked mid-sweep — tracked across all three runs and explained, not waved away.
   - The warning not to accept partial agreement was honoured: §7h's withdrawn `CPUT`/`0x57` argument rested on a single static byte, and that argument is **not** what re-established this.
@@ -309,7 +305,7 @@ Every offset here (`0x59`, `0x90`, `0xE6`, `0xF6`/`0xF7`) came from *this* DSDT.
 ## 6. Explicitly do not
 
 **The full list of settled dead ends lives in one place:
-``../reference/settled-negatives.md``.** Read it before proposing
+[`8D87-EVIDENCE.md`](8D87-EVIDENCE.md) §4.** Read it before proposing
 any experiment on this board — it also records two claims that were retracted and then
 *un*-retracted, which is the layer most likely to be read wrong.
 
@@ -317,7 +313,7 @@ Specific to this repo, on top of that list:
 
 - **Do not** add EC power offsets `0xC0`–`0xC5` for this board. `SupportsEcPowerLimits` stays `false`.
 - **Do not** look for an EC register map in OGH's binaries. There is none — a grep across all four decompiled roots for `0xFE7006*`, `EmbeddedController`, `Ec{Read,Write}`, `LpcACPIEC` and raw port I/O returns zero hits. HP reaches the EC only through AML `GCxx` and the SMU only through AMD's own driver.
-- **Do not** investigate `hpomencustomcapdriver.sys`. It imports exactly `DbgPrintEx` and `RtlCopyUnicodeString` plus WDF loader stubs — no `MmMapIoSpace`, no port I/O, no `IoCreateDevice`. It is a stub and cannot touch the EC by construction. (`HpReadHWData.sys` is the one that is *not* a stub — see ``../investigation/06-hpreadhwdata-driver.md``.)
+- **Do not** investigate `hpomencustomcapdriver.sys`. It imports exactly `DbgPrintEx` and `RtlCopyUnicodeString` plus WDF loader stubs — no `MmMapIoSpace`, no port I/O, no `IoCreateDevice`. It is a stub and cannot touch the EC by construction. (`HpReadHWData.sys` is the one that is *not* a stub — see [`8D87-EVIDENCE.md`](8D87-EVIDENCE.md) §2.7.)
 - **Do not** raise TDC/EDC.
 - **Do not** reintroduce WinRing0 or inpoutx64. Note the upstream investigation's own `tools/lever/` scripts use `inpoutx64` for MMIO — **that does not port here**, and this repo removed it deliberately over Defender detections.
 
@@ -325,7 +321,7 @@ Three from the shared list are worth repeating because they are easy to re-deriv
 
 - **Do not** try to write `DSTA` directly via `GC22`. It sets `DSTA` and then calls `_Q73`, which overwrites it from `PROH`. Measured on both adapters.
 - **Do not** treat `EWDS` (mailbox `0x0E`) as a size field. Declared once, referenced by no AML, reads 0 in 1666/1666 captured events.
-- **Do not** treat `Default 0x28` as *connected* adapter state — it is byte-identical on 330 W and 200 W, and describes the SKU. But it is **not** contentless: `byte[0..1]` is `ShippingAdapterPowerRating` in watts (330 here), and `Legacy 0x0F` `byte[3] × 5` gives the connected rating. See ``../reference/wmi-commands.md``.
+- **Do not** treat `Default 0x28` as *connected* adapter state — it is byte-identical on 330 W and 200 W, and describes the SKU. But it is **not** contentless: `byte[0..1]` is `ShippingAdapterPowerRating` in watts (330 here), and `Legacy 0x0F` `byte[3] × 5` gives the connected rating. See [`8D87-EVIDENCE.md`](8D87-EVIDENCE.md) §2.1 and §2.5.
 
 ---
 
@@ -335,7 +331,7 @@ Carried forward from both documents, with our own added.
 
 **Blocking for us:**
 
-1. **Do ports `0x62`/`0x66` alias the MMIO window for *writes*, and on a second adapter state?** They do alias for **reads** — measured, three sandwiched runs; see §5.1 and ``../investigation/08-ec-port-aliasing.md``. The write direction is unproven, and nothing may write EC RAM through the ports until it is closed.
+1. **Do ports `0x62`/`0x66` alias the MMIO window for *writes*, and on a second adapter state?** They do alias for **reads** — measured, three sandwiched runs; see §5.1 and [`8D87-EVIDENCE.md`](8D87-EVIDENCE.md) §6. The write direction is unproven, and nothing may write EC RAM through the ports until it is closed.
 2. **Does the PawnIO release driver load third-party modules?** Decides Option B. **Now much less urgent** — Option A succeeded, so Option B is no longer on the critical path for either stage.
 3. **Does the `OGHP` race actually win over ports?** Feasible on the latency numbers; unproven in fact. Requires the dedicated hold path described in §5.1.
 
@@ -356,9 +352,24 @@ Carried forward from both documents, with our own added.
 
 **Phase 0 — decide the transport. ✅ DONE (2026-08-04).** T3.1 came back positive: the ports alias for reads and the transport is fast enough for *both* levers, not just `PROH`. Tier 3 exists. Two things moved as a result — Option B (custom PawnIO module) leaves the critical path, and the `OGHP` blocker is now a wrapper fix (`Thread.Sleep(1)` + per-call mutex in `PawnIOEcAccess.WriteByte`) rather than a transport dead end. The remaining gate before any EC write is confirming the aliasing holds **for writes** and on a **second adapter state**.
 
-**Phase 1 — Tier 1.** T1.4 → T1.5 → T1.6 first: adapter awareness is the highest value-per-risk item in the whole plan, it is read-only, and it makes every subsequent field report better. Then T1.8/T1.9/T1.10 (payload correctness), T1.11/T1.12 (`0x28`), T1.15/T1.16 (model DB). T1.1/T1.2/T1.3 (`MODE`) last in this phase, since they are the first real behaviour change.
+**Phase 1 — Tier 1. ✅ LARGELY DONE.** Landed: adapter awareness (`Legacy 0x0F`), the full `0x28`
+decode, the `0x22` payload correction, the model-DB entry with `UserVerified = true`, real fan
+tachometers at `0x70`/`0x5C`, a V2-capability *probe* replacing the model-name force-switch (which
+closes open question 11), the GPU mode read from `Legacy 0x52`, and the performance-mode measurement
+that removed `"L5P"`.
 
-**Phase 2 — Tier 2.** T2.1 (verify, then fix `pawnio_load`) → T2.2/T2.3 → T2.6 (verification harness) → T2.5. This is the biggest measured user-facing win (25 → 51 W CPU) and it needs no EC writes and no races.
+Not landed from Tier 1: `MODE 4` as a user-facing control (T1.2), and `OTPP` (§7.7) which remains
+untested.
+
+**Phase 2 — Tier 2. ⚠️ TRANSPORT DONE, LIMITS NOT.** T2.1 turned out to be three faults, not one: no
+`pawnio_load` call, ioctl names no bundled module exports, and a stale bundled module that rejected
+this CPU outright. All three are fixed and the transport is verified end to end — Curve Optimizer
+measures **+4.9% sustained clock at CO −25** against a ±0.1% sham control
+([`8D87-EVIDENCE.md`](8D87-EVIDENCE.md) §3.4).
+
+Still open in Tier 2: **T2.2/T2.3 — the four SMU power limits** (`stapm`, `fast`, `slow`, `apu-slow`)
+that lift the 25 W APU clamp to ~51 W. The transport they need now works; the limits themselves are
+not implemented. T2.4 stands: **do not raise TDC/EDC.**
 
 **Phase 3 — Tier 3.** Phase 0 succeeded, so this is live. T3.2 → T3.3 (Stage 2) → T3.5 (proportional). **T3.4 (Stage 1) is no longer conditional on transport speed** — 0.325 ms per transaction clears the 2 ms window — but it does depend on the dedicated hold path in §5.1, and it stays behind the safety gating in §5.2.3 regardless.
 

--- a/docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md
+++ b/docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md
@@ -1,0 +1,365 @@
+# Board `8D87` — OMEN MAX 16 (2025, AMD) Support Plan
+
+**Status:** planning. Nothing in this document has been implemented.
+**Target board:** `8D87` — HP OMEN MAX 16-ak0098nr, Ryzen AI 9 HX 375 (family `1Ah`/model `24h`, Strix Point) + RTX 5080 Laptop (`10DE:2C19`), BIOS F.07, EC 40.38.
+**Sibling boards on the same HP platform (`Vibrance25C1`):** `8D88`, `8DD5`, `8DD6`.
+**Related existing DB entry:** `AK0003NR` (`ModelNamePattern = "max 16 ak0"`), same family, different SKU.
+
+---
+
+## 0. Where this comes from, and how much to trust it
+
+Two external investigations, both outside this repo:
+
+| Source | Method | Evidence class |
+|---|---|---|
+| `D:\src\omen-max-16\investigation\03-nvpcf-tgp-mechanism.md` | ACPI decompilation + **live measurement** on the physical machine | Strongest available. Firmware-derived and instrumented. |
+| `D:\src\omen-max-16\investigation\04-ogh-binaries.md` | Static decompilation of HP's own OMEN Gaming Hub binaries (309 assemblies, not obfuscated) | Strong for **arity, field layout, HP's own naming**. No evidence at all for runtime behaviour. |
+
+Supporting documents in the same series: `01-bios-f07-static.md` (static firmware), `02-power-gate-measurements.md` (measurement), `07-setup-variable-map.md`.
+
+> [!IMPORTANT]
+> **Do not read either source document to answer a question of fact.** They are lab notebooks: they
+> record method and measurement — how a thing was established, on what instrument, with what numbers —
+> and they are long. `03-nvpcf-tgp-mechanism.md` alone is over 2500 lines.
+>
+> The distilled current truth is in **`D:\src\omen-max-16\reference\`** — five short documents:
+> ``power-model.md``, ``ec-map.md``,
+> ``wmi-commands.md``,
+> ``board-8d87.md`` and
+> ``settled-negatives.md``, plus
+> ``capabilities-8d87.json`` for this plan's §3.6 database entry.
+> Cite the notebook for provenance; take facts from `reference/`.
+
+**Two things to keep in mind while reading:**
+
+1. **The two sources disagree in places, and 04-ogh-binaries.md is usually the correction.** The mechanism doc's §7h concluded `0x28` bytes 0–1 were a status-flag field; 04-ogh-binaries.md §1a shows HP's own source names it `ShippingAdapterPowerRating` and compares it against 200 and 280. Where they conflict, the binary analysis wins on *layout and naming*, the mechanism doc wins on *runtime behaviour*. Both resolutions are already applied in `reference/`.
+2. **Five plausible findings on this board turned out to be false, and four failed the same way.** `PROH` at `0x8F`, `Default 0x10` as the arming command, `HPBA` as adapter-keyed, `P3TV` as a working lever, and "the exploit is a durable one-shot" were each established and then disproved — four of them because the *request* was checked instead of the *outcome*. A command that returns success is not a watt. That failure mode is directly relevant to how we implement this: see §5.2, and ``settled-negatives.md`` for the current statement of each.
+
+**This board's `UserVerified` status stays `false` for now.** The evidence above is excellent, but it comes from one machine and one investigator, not from this project's normal field-report channel. Individual items below carry their own evidence assessment.
+
+---
+
+## 1. The mechanism, compressed
+
+Three independent clamps. Understanding that they are independent is the whole point — earlier work in this repo and upstream conflated them.
+
+```
+Stage 1  GPU 105 W -> 175 W     OGHP  (EC 0x59 bit 1)     "OMEN Gaming Hub Present"
+Stage 2  GPU 175 W ->  35 W     PROH  (EC 0x90)           adapter verdict, on non-330 W supplies
+Stage 3  CPU  73 W ->  25 W     AMD SMU limits            adapter-keyed, entirely outside NVPCF
+```
+
+**Stage 1 — `OGHP`.** `NVPCF._DSM`'s whole body is gated on `OGHP == 1`. At boot, `_REG` sees `OGHP == 0` (no OMEN software) and zeroes `NPCF.CTGP`/`NPCF.DTGP`, revoking the configurable-TGP adder. Result: 105 W base TGP instead of 175 W (105 + `ACBT` 560/8 = 70 W adder = 175). Repaired at runtime by holding `OGHP` from a ~2 ms loop while firing `GC22` (`Default 0x22`) so the driver's `_DSM` re-read lands inside the window. The resulting `Notify` is never retracted, so the hold can be dropped immediately after. **Measured, with zero OMEN processes running.**
+
+**Stage 2 — `PROH`.** The EC classifies the adapter into `ADID` (3-bit class) and writes its verdict to `PROH` at EC `0x90`. `_Q73` copies `PROH` into `DSTA` and issues `Notify (PEGP, 0xD1..0xD5)`; the NVIDIA driver maps `0xD1` → 175 W and `0xD2` → 35 W. Holding `PROH = 1` from a ~2 ms loop and triggering `_Q73` via `GC22` took the 200 W adapter from **35 W to 175 W**. The EC reasserts `PROH` on a ~100 ms cycle, but the notify survives.
+
+**Stage 3 — the CPU.** Not reachable through `PROH`, `ADID`, `RPWR`, or anything in NVPCF. It is three ordinary AMD SMU limits (`STAPM`, `PPT FAST`, `PPT SLOW`) pinned at exactly 25.000 W, plus `PPT APU` at 45. Writing all four with RyzenAdj took the APU from **25.02 W to ~51 W sustained**, with OGH not running and **no hold thread needed** — the EC does not fight back here.
+
+**None of the three survives a reboot.** A replacement for OGH is a resident agent, not a one-shot script.
+
+---
+
+## 2. What this repo currently believes, and where it is wrong
+
+Repo-wide grep for `OGHP`, `PROH`, `NVPCF`, `CTGP`, `DTGP`, `0xFE7006`, `_Q73`, `P3TV` returns **zero hits**. None of this mechanism is known to OmenCore today.
+
+| Location | Current state | Reality on `8D87` |
+|---|---|---|
+| `ModelCapabilityDatabase.cs:928-954` | `8D87` entry, `UserVerified = false`, notes say "inferred from adjacent MAX ak/ah generation" | Now substantially characterised. See §3.5. |
+| `PowerLimitController.cs:17-25` | EC power offsets `0xC0`–`0xC5`, self-described "EXAMPLE - varies by model!" | Meaningless on this board. `SupportsEcPowerLimits` must stay `false`. |
+| `PawnIOEcAccess.cs:27-28` | EC via ACPI ports `0x62`/`0x66`, offset allowlist `0x2C`…`0xF4` | The ports **are** declared (`EC0._CRS`), and AML also reaches the EC through an MMIO alias at `0xFE700600`. The two views **are the same 256 bytes for reads** — measured, three sandwiched runs. **Writes through the ports remain unproven**, so nothing may write EC RAM that way yet. See §4 and §5.1. |
+| `HpWmiBios.cs:192` | `BuildGpuPowerPayload` returns `peakTemperature = 0x00` | Byte 3 of `0x22` is a GPS temperature threshold in °C. HP passes 87 — but only as the *most permissive* output of a closed loop it drives from the chassis IR sensor, revising it to 75 on overheat. **Deliberately left at 0**: with no IR loop, sending 87 pins the firmware in the chassis-is-cool state, and byte 3 is not in the `0x21` readback so it cannot be verified by outcome. Decode recorded at `HpGpsTemperatureThresholdC`. |
+| `HpWmiBios.cs:636-642` | `SetFanMode` sends `Default 0x1A` `{0xFF, mode, 0, 0}` — treated as fan-only | This is `GC1A`, which writes `NPCF.MODE` from **byte[1]**. It is the GPU/CPU power-profile selector, not just a fan knob. See §3.1. |
+| `RyzenSmu.cs:68-126` | `Initialize()` opens PawnIO | Never calls `pawnio_load`, so no module backs `ioctl_pci_read_config_dword` / `ioctl_pci_write_config_dword`. Every other PawnIO consumer in the repo — `PawnIOEcAccess`, `LibreHardwareMonitorImpl`, `HardwareWorker` — resolves and calls it; `RyzenSmu` is the sole exception. **The AMD SMU path is dead today**, confirmed by inspection at `RyzenSmu.cs:102-104`. |
+| `AmdUndervoltProvider.cs:300` | `SetStapmLimit` only | Three more limits are required; raising only stapm/fast/slow lands on a hard 46 W ceiling. |
+| Adapter awareness | None. Grep for "adapter" across `src/` returns Linux battery paths and one ADL delegate name. | `Legacy 0x0F` reports the connected adapter's real wattage. See §3.3. |
+| `DiagnoseCommand.cs:298-301` | Board `8D41` note: "Linux GPU TGP may stay capped near base power if hp-wmi does not send the … Dynamic Boost unlock that Windows OGH sends" | Correct symptom, now with a named cause (`OGHP`). The note can be replaced with the actual mechanism. |
+
+---
+
+## 3. Tier 1 — pure WMI. No new driver, no EC writes, no transport decision.
+
+Everything in this tier uses `HpWmiBios.SendBiosCommand` as it exists today.
+
+### 3.1 `MODE` is a power lever, and `Cool` currently costs 70 W of GPU
+
+**Evidence:** firmware (decompiled `wmi_live.dsl` + `nvpcf_live.dsl`), mechanism doc §7a/§7p. Not yet measured on this board for MODE 4.
+
+`GC1A` does `CreateByteField (Local2, One, PWMD); \_SB.NPCF.MODE = PWMD` — byte[1] of the `0x1A` payload. `NPCF` then selects a profile row on `MODE & 0x0F`. For `NVXX = 2` (this GPU):
+
+| `MODE & 0x0F` | `ACBT` → GPU adder | `ATPP` → CPU limit w/ GPU | GPU `enforced` |
+|---|---|---|---|
+| `0` | 0 → **0 W** | `0x0118` → 35 W | 105 W |
+| `1` | `0x0230` → **70 W** | `0x01E0` → 60 W | 175 W |
+| **`4`** | `0x0230` → **70 W** | `0x0320` → **100 W** | 175 W |
+
+Cross-referenced against the current `FanMode` enum (`HpWmiBios.cs:133-142`):
+
+- `Default = 0x30` → low nibble **0**
+- `Performance = 0x31` → low nibble **1**
+- `Cool = 0x50` → low nibble **0**
+
+**Consequence, and it is a live bug:** selecting **Cool** on this board sends `MODE = 0x50`, whose low nibble is 0, which revokes the entire configurable-TGP adder and drops the GPU to 105 W. That is not a fan setting, and users have no way to know.
+
+**Work items:**
+
+- **T1.1** Add a `MODE`-aware layer over the existing `0x1A` path, board-gated. Do not reuse `FanMode` for this — the coupling is the bug. Surface, at minimum, that Cool revokes the GPU adder on `Vibrance25C1` boards.
+- **T1.2** Add `MODE 4` (`0x34`) as an option. Same GPU adder as MODE 1, `ATPP` 60 → 100 W.
+  - **Caveat:** §7p measured the CPU already reaching `ATPP = 60 W` momentarily and settling at 45 W at 86 °C under a combined load. The 60 W ceiling is real and reachable but is *not* what holds the sustained figure down — so MODE 4 may buy nothing until cooling improves. Ship it as a control, not as a promised gain.
+  - Both `MODE` and `OTPP` sit inside `If ((OGHP == One))`, so neither does anything without the Stage-1 arm.
+
+### 3.2 This closes an open evidence gate already tracked in this repo
+
+`docs/ROADMAP_v4.0.0.md:349-350` records that `8D87` and `AK0003NR` are **the only two 2025 MAX boards in the database without `AllowDecoupledWmiThermalPolicyFallback = true`**, that the one-line fix was identified, and that it was deliberately withheld pending field evidence — because nobody knew what the WMI thermal-policy write actually *did* on the AMD path.
+
+We now know exactly what it does: `SetFanPerformanceModeSerialized` → `_fanController.SetPerformanceMode` → `SetFanMode` → `Default 0x1A` → `GC1A` → `NPCF.MODE`. With the flag off, `PerformanceModeService.Apply()` sends nothing at all on this board (EC limits blocked by `SupportsEcPowerLimits = false`, WMI fallback disabled), so `MODE` stays at its `Name (MODE, Zero)` initializer — low nibble 0 — and the GPU adder is never granted.
+
+That is a complete mechanical explanation for the reporter's symptom ("OGH reaches higher wattage, OmenCore doesn't touch it").
+
+- **T1.3** Set `AllowDecoupledWmiThermalPolicyFallback = true` on `8D87` and `AK0003NR`, matching their Intel siblings `8D41`/`8D42`.
+  - **Evidence class:** the mechanism is now firmware-derived rather than inferred-by-symmetry, which is a materially higher bar than the roadmap had when it deferred. It is still a hardware-behaviour change on `UserVerified = false` boards. Recommend shipping it **with** T1.4's verification so the next field report carries before/after wattage automatically, rather than shipping it blind.
+  - **Arithmetic worth checking against the field report:** the roadmap records the reporter seeing 71 W default → 105 W with OGH. MODE 1's `ATPP` is 60 W and MODE 4's is 100 W. If OGH drives MODE 4 rather than MODE 1, that fits. **Hypothesis, not a finding** — it needs one measurement to settle, and it changes which value T1.1 should send for "Performance".
+
+### 3.3 Adapter awareness — `Legacy 0x0F`
+
+**Evidence:** measured on three physical adapters (330/280/200 W), exact both times. Field layout confirmed against HP's own accessors (findings §1d). **Strongest item in this document.**
+
+`BiosCmd.Legacy` (`0x00000001`), command `0x0F`, 4-byte reply:
+
+| Byte | HP's accessor | Meaning |
+|---|---|---|
+| `[0]` | `GetSmartAdapterStatus` | `SmartAdapterStatus` enum — see below |
+| `[1]` bit 7 | `GetSupportBarrel` | barrel jack supported (`0xC2` here ⇒ true) |
+| `[2]` | `GetUsbcDesignRating` | `× 5` = USB-C **design** rating, W |
+| `[3]` | `GetPowerRating` | `× 5` = **connected adapter's rating, W**; `0xFF` means unknown ⇒ 0 |
+
+`SmartAdapterStatus`, from HP's own enum (findings §1c — note this extends OmenMon-Reborn's table, which stops at 4):
+
+`-1` Error · `0` NotSupported · `1` MeetsRequirement · `2` BelowRequirement · `3` BatteryPower · `4` NotFunctioning · **`5` ConnectedTypeC**
+
+Measured: 330 W → `01 C2 00 42` (`0x42` × 5 = 330). 200 W → `02 C2 00 28` (200). 280 W → `02 C2 00 38` (280).
+
+**Work items:**
+
+- **T1.4** Add `GetAdapter()` to `HpWmiBios` — the concrete class, **not** `IHpWmiBios`. Every consumer holds the concrete type, and a defaulted interface member would make "silently return null" the default for a future implementer, which renders as the affirmative claim *this board does not report an adapter*. Read-only, works on any board that answers the `Legacy` class. Note that this repo had **never issued the `Legacy` class for anything but `0x52`** — handle unsupported returns cleanly.
+- **T1.5** Surface it: adapter wattage + status in Diagnostics, and a clear explanation when status is `BelowRequirement`. Today a user on a 200 W adapter sees "GPU stuck at 35 W" with no explanation available anywhere in the app.
+- **T1.6** Feed it into the diagnostics export. Every future field report from a MAX-series board should carry the adapter verdict.
+- **T1.7** Handle `ConnectedTypeC` (5) separately — HP's `IsLowWattage` uses different comparison logic for it (findings §1c): `powerRating > 0 && powerRating < usbcDesignRating`, plus a barrel-support special case. Do not fold it into "not MeetsRequirement".
+
+### 3.4 `0x22` payload and arity
+
+**Evidence:** HP's own source (findings §1b), `PerformanceControl.cs:5970` and callers.
+
+- **T1.8** Byte 3 of the `0x22` payload is a **GPS temperature threshold**, not a spare. HP's `SetTgpPpabAsync` hardcodes 87 (°C). `BuildGpuPowerPayload` currently returns 0. Fix, and name it correctly.
+  - Credit where due: OmenCore's existing `peakTemperature` naming was *right* and the firmware doc's "spare" was wrong — findings §1b says so explicitly. Only the value is wrong.
+- **T1.9** `0x22` has a **second 1-byte arity** (`SetTGPAsync`, `new byte[1] { enable }`). Nothing should assume it is always 4 bytes.
+- **T1.10** `dState` is hardcoded `0x01`, which matches HP — but per §7c/§7i, `GC22` sets `DSTA` and then calls `_Q73`, which immediately overwrites it from `PROH`. `DSTA` is **not independently settable on either adapter.** Document this at the call site so nobody re-derives it.
+
+### 3.5 `0x28 SystemDesignData` is badly under-decoded
+
+**Evidence:** HP's own bitwise accessors (findings §3c). Applies to **every** board, not just this one.
+
+`QuerySystemData` reads 128 bytes and parses one (ThermalPolicy). HP's map, applied to this machine's reply `4A 01 3A 01 03 00 01 07 3C 00 03 00`:
+
+| Byte | Mask | HP's name | Here |
+|---|---|---|---|
+| `[0..1]` | 16-bit LE | `ShippingAdapterPowerRating` | **330 W** |
+| `[3]` | whole | `GetThermalPolicyVersion` | V1 |
+| `[4]` | `0x01` | `IsSwFanControlSupport` | true |
+| `[4]` | `0x02` | `IsExtremeModeSupport` | **true** |
+| `[4]` | `0x04` | `IsExtremeModeUnlock` | **false** |
+| `[4]` | `0x08` | `IsDTBiosControl` | false |
+| `[4]` | `0x10` | **`IsTwoBytePL4Support`** | **false** |
+| `[5]` | whole | `PL4DefaultValue` | 0 |
+| `[6]` | `0x01` | `IsBiosDefinedOcSupport` | true |
+| `[7]` | — | `GpuModeSwitch` | `0x07` |
+| `[8]` | whole | `DefaultCpuPowerLimitWithGpu` | **60 W** |
+| `[9]` | `0x0F`/`0xF0` | `LoadLineSupportLevels` / `DefaultLoadLine` | 0 / 0 |
+| `[10]` | `0x01`,`0x02`/`0x04`/`0x08` | `ChangeIrSensorToBoard` / `IsPchOverheatSupport` / `IsVrSensorSupport` | false / false / false |
+| `[11]` | `0x01`/`0x02` | `IsHotkeySupportFnP` / `IsHotkeySupportFnF1` | false / false (but true by board table) |
+
+**Work items:**
+
+- **T1.11** Decode the full block into a typed struct. **`IsTwoBytePL4Support` is the one that matters beyond this board** — it changes the wire format of `Default 0x29 SetPL4`. Getting it wrong is a silent write-corruption class of bug on any board where the bit is set.
+- **T1.12** Expose `ShippingAdapterPowerRating` alongside T1.4's connected wattage. Together they give the app both halves of the comparison the firmware is making — required wattage vs actual — which is what lets a replacement size a TGP against the real ratio instead of accepting HP's binary verdict.
+- **T1.13** Note `IsExtremeModeSupport = true` with `IsExtremeModeUnlock = false`. Unexplained; findings §3c calls tracing `IsExtremeModeUnlock`'s consumers the most promising unexplored lead in that section. Record, don't act.
+- **T1.14** HP caches this block at `HKCU\Software\HP\OMEN Ally\Settings\SystemDesignData` and **never invalidates it** — not even on a BIOS update (findings §0a). If we ever read that key as a convenience, treat it as a convenience only; prefer the live `0x28`.
+
+### 3.6 Model database entry
+
+- **T1.15** Update the `8D87` entry with what is now known:
+  - Thermal policy **V1** (measured — `0x28` byte 3 = `0x01`). Cross-check against `HpWmiBios`'s `Contains("MAX") && Contains("OMEN")` V2 force-switch, which `ROADMAP_v4.0.0.md:256` already flags as a broad name-substring match rather than a per-ProductId decision. **These may currently disagree on this board.**
+  - Fan tachometers at EC `0x70` (`FASP`) and `0x5C`, both 16-bit raw rpm, corroborated against
+    `Default 0x2D` at four operating points. **Not `0x7E`** — that is a commanded setpoint, a strict
+    function of the level byte at `0x5B`, and it reads 0 whenever nothing has been commanded even
+    while the fans turn. Same for `0x5E` (fan 2's setpoint, always `0x7E` + 200); there is no third
+    fan. Measured across all 28 EC captures in the research tree.
+  - **`0x9F` is `BRC0`, battery remaining capacity in mAh** — not a GPU tachometer. OmenMon-Reborn has this wrong on `8D87` and is showing its users battery charge in the GPU RPM field. Worth reporting upstream; OmenCore has not inherited the error, so this is a note, not a fix.
+  - `SupportsEcPowerLimits` stays **false**. `SupportsUndervolt` stays **false** (AMD, no Intel MSR path).
+  - `MaxModeDropChecksBeforeReapply = 1` is already present and is independently corroborated by the observed `MODE` decay.
+- **T1.16** Add the sibling board IDs `8D88`, `8DD5`, `8DD6` (HP platform `Vibrance25C1`, findings §3a) as the **safety scope** for anything in Tier 3.
+  - **But note the deeper point:** findings §3a establishes that **no power decision in OGH is keyed on board ID.** HP gates power on the runtime `0x28` capability query; the board table gates only hotkeys, chassis and lighting. This repo's per-board capability model has no counterpart in HP's own software. Use the board list to scope *raw offsets*, and prefer `0x28` for *capability*.
+
+---
+
+## 4. Tier 2 — the CPU 25 W clamp. Mostly built, plumbing is dead.
+
+**Evidence:** measured end-to-end with RyzenAdj v0.19.0 on the physical machine (§7m). 25.02 W → 45.73 W → ~51 W sustained / 60.7 W peak.
+
+The strongest single piece of evidence in the entire investigation is here and worth restating: raising `stapm` + `fast` + `slow` but **not** `apu-slow` produced a hard ceiling at ~46 W, which is exactly the untouched `PPT LIMIT APU = 45`. A cap landing precisely on the one limit left unraised is a much better check that these are the real controls than any single before/after number.
+
+**And the EC does not fight back here.** Unlike `PROH` and `OGHP`, the SMU limits were still set a minute later, and the EC's own mailbox block went on reading 25/25 while the SMU ran at 100/125 — they demonstrably disagree, and the SMU wins. No hold thread, no race.
+
+**Work items:**
+
+- **T2.1 (blocker)** Fix `RyzenSmu.Initialize()`. It opens a PawnIO handle but never calls `pawnio_load`, so `ioctl_pci_read_config_dword` / `ioctl_pci_write_config_dword` have no module behind them. Compare `PawnIOEcAccess.LoadEcModule()`, which does load `LpcACPIEC`. **This is a confirmed defect, not a hypothesis** — `RyzenSmu.cs:102-104` resolves only `pawnio_open`/`pawnio_execute`/`pawnio_close`, and it is the only PawnIO consumer in the repo that skips `pawnio_load`. Gate the fix so it does not enable an untested path for every AMD board.
+- **T2.2** Add `fast-limit`, `slow-limit`, `apu-slow-limit` alongside the existing `SetStapmLimit`. Message IDs must come from RyzenAdj's Strix Point table — **do not guess them**, and do not infer them from the existing `0x14`/`0x31` stapm pair.
+- **T2.3** Raise `SetStapmLimit`'s clamp. It currently caps at 54,000 mW (`AmdUndervoltProvider.cs:302`); the measured target is 100 W with a 125 W fast limit. Pick the new ceiling deliberately and document why.
+- **T2.4** **Do not raise TDC/EDC.** With the four power limits raised the part becomes current-bound at 53.977 A against a 54.000 A limit. §7m's argument for leaving it alone is sound and should be preserved verbatim in the code comment: a power limit is self-limiting (throttle or brownout, both fixed by a reboot); a current limit governs how hard the VRM is driven, and sustained overcurrent is not self-correcting. Every write in that investigation used a value the firmware writes itself; we don't know what TDC/EDC read on the 330 W adapter.
+- **T2.5** Re-assert after power-source changes, sleep/resume, and adapter swaps — the EC recomputes everything on those transitions. Steady-state operation needs nothing.
+- **T2.6** Verify by measured APU package power, not by SMU return code. Windows exposes `\Energy Meter(Apu Power)\Power` in milliwatts (also `CPU Power`, `GPU Power`, `NPU Power`). The separate `Power Meter` counter set reads all-zero on this machine — do not use it.
+- **T2.7** Do not attempt to reproduce HP's mechanism. How the EC gets 25 W into the SMU is still unknown and is excluded from AML, AMD PMF, NVPCF/Dynamic Boost, Windows PPM, HP's userland, and the EC mailbox block — leaving SMM as the surviving hypothesis. It is a curiosity, not a blocker.
+
+---
+
+## 5. Tier 3 — the adapter gate. Transport decided; write path still gated.
+
+This is "ungating the power adapter issue", and the mechanism is fully solved and demonstrated. **As of 2026-08-04 the transport question is also settled** (§5.1): the ports alias for reads and are fast enough for both levers. What remains gated is narrower — confirming the aliasing holds for *writes* and on a second adapter state, and building a hold path that does not inherit `PawnIOEcAccess.WriteByte`'s per-call sleep.
+
+### 5.1 The transport problem
+
+`PROH` (`0x90`) and `OGHP` (`0x59` bit 1) live in the EC's **memory-mapped** window at `0xFE700600`. The investigation wrote them with `inpoutx64` + `Marshal.WriteByte`.
+
+OmenCore cannot do that:
+
+- WinRing0/inpoutx64 were **deliberately removed** from this project over Defender's `VulnerableDriver:WinNT/Winring0` detections (`CHANGELOG.md:34, 840, 879`). Reintroducing them reverses a decision made for good reasons and would re-break every user who upgraded to escape those alerts.
+- The bundled PawnIO module is `LpcACPIEC`, which whitelists exactly ports `0x62`/`0x66` and cannot touch physical memory.
+
+**Three options, in order of preference:**
+
+**Option A — test the aliasing first. Read-only, cheap, and it decides everything.**
+
+> [!IMPORTANT]
+> **T3.1 has now been run. The ports alias the MMIO window for reads, and the latency objection
+> below did not survive measurement.** Full method and limits:
+> ``../investigation/08-ec-port-aliasing.md``; distilled in
+> ``../reference/settled-negatives.md``.
+
+- **T3.1 — DONE (2026-08-04).** Three runs sandwiching a PawnIO/`LpcACPIEC` port sweep between two MMIO captures, so that only bytes which held still across the whole window got a vote. **100 % / 100 % / 99.6 % agreement on judged bytes; 8 of 8 entropy-carrying anchors matched**, including both fan tachometers at 3000 rpm under deliberate CPU load and `PROH` itself. Correlation falls from 99.6 % at shift 0 to ~33 % at ±1 byte, which is what rules out coincidental resemblance rather than mere agreement. The one diverging byte was a temperature sensor that ticked mid-sweep — tracked across all three runs and explained, not waved away.
+  - The warning not to accept partial agreement was honoured: §7h's withdrawn `CPUT`/`0x57` argument rested on a single static byte, and that argument is **not** what re-established this.
+  - The port path here is byte-for-byte the one `PawnIOEcAccess.ReadByte` uses, so this is a result about the shipping code path.
+  - **Reads only, one adapter state (330 W).** Writes through the ports remain unproven, and the anchors should be re-checked on the 200 W supply — where `PROH` → 2 and `P3TV` → 185 — before this is more than provisional. Two agreeing states is the `HPBA` error.
+
+`PROH` and `OGHP` are therefore addressable through the module OmenCore **already ships**, and Stage 2 costs an allowlist entry plus a hold thread.
+
+**The caveat that was expected to be decisive, and what measurement did to it.** The plan predicted the port protocol would be far slower than an MMIO store, making `OGHP` unreachable. Measured over 200 samples: PawnIO's bare ioctl round trip is **~6 µs**, and a full EC read transaction is **0.325 ms median** (p95 1.86 ms, max 4.03 ms).
+
+| Target | Reassert cadence | Predicted | **Measured** |
+|---|---|---|---|
+| `PROH` | ~100 ms | Plausible | **~300 transactions per cycle.** Comfortable. |
+| `OGHP` | EC clears it on 98 % of 2 ms cycles | Very unlikely | **~6 transactions per window.** Feasible. |
+
+**So the transport is not the barrier — `PawnIOEcAccess` is.** `WriteByte` (`PawnIOEcAccess.cs:530-533`) ends every write with `Thread.Sleep(1)` and acquires the `Global\Access_EC` mutex per call. `Thread.Sleep(1)` yields the rest of a scheduler quantum — commonly 1–15 ms — which alone can exceed the entire `OGHP` hold window. A hold loop needs a dedicated path that takes the mutex once for its duration and omits the per-write sleep. **That is an application-layer fix, not a transport limitation**, and it is the single most consequential thing this test changed.
+
+Two operational notes for any hold loop: port reads time out on 1–3 % of offsets at randomly varying addresses, so retry rather than single-shot; and the `OGHP` p95 of 1.86 ms means a minority of iterations overrun 2 ms — tolerable, since the MMIO race already loses ~98 % of cycles and is won by repetition, but it means the loop is measured by `enforced ≥ 170 W` and never by iteration count.
+
+**Option B — a custom PawnIO module** exposing that one physical page, allowlisted to the two offsets. Technically the right answer. Friction is module signing: official PawnIO modules are signed by the project author. **Needs verifying** whether the release driver loads third-party modules, or whether upstreaming an `HpOmenEcMmio` module is the realistic path.
+
+**Option C — accept Stage 1 as out of scope in-app**, and keep `OGHP` arming as a documented external step (the investigation's `Invoke-OmenArm.ps1`). Least satisfying, but honest, and it still leaves Stage 2 and Tier 2 fully in-app if Option A succeeds.
+
+### 5.2 Design rules that apply regardless of transport
+
+These come from the investigation's own retractions. They invert how parts of this codebase currently work.
+
+**5.2.1 — Verify by outcome, never by readback of what we wrote.**
+`GC22` returns `RTCD = 0` whether or not the driver was listening. §7o records the exact failure: a textbook-clean `GC22` with `CTGP = 1`, `DTGP = 1`, `RTCD = 0` — and `enforced` still at 80 W, because the driver's `_DSM` re-read landed on one of the EC's zeros. The tool reported that as `GRANTS RESTORED`. It now requires `enforced ≥ 170 W`.
+
+That was the **fourth** wrong-reference false positive in that investigation, after `P3TV`, the `STABLE` bug, and the retracted `Default 0x10` arming command. The recurring error is checking the request instead of the outcome.
+
+`HpWmiBios.VerifyGpuPowerReadback` (`HpWmiBios.cs:986-1006`) is precisely this pattern. It is fine for what it currently does, but **must not** be the verification for anything in this tier. Verification means delivered watts, via NVAPI (`NvapiService` already exists) or `nvidia-smi`.
+
+**5.2.2 — This is a resident agent, not a one-shot.**
+- No stage survives a reboot. `_REG` zeroes the grants ~2 s into boot, before any userland exists.
+- Stage 2's 175 W **reverts spontaneously while idle** — `_Q73` re-runs on EC events and power-state transitions, re-deriving the limit from whatever `PROH` then reads. An earlier revision of the doc concluded from a single 20 s observation that the unlock was durable; that was retracted.
+- Stage 3 survives steady state but not a power-source change.
+
+So: a supervised re-applier with hooks on adapter change, resume, and a slow watchdog. Not a button.
+
+**5.2.3 — Safety gating is not optional here.**
+Forcing 175 W on a 200 W supply is out-of-spec by design. §7j observed the GPU entering a degraded state after a forced unlock — `nvidia-smi` at 23–27 s per call, FurMark unable to render — which **persisted after the manipulation stopped** and cleared only on reboot, on a machine with a history of `nvlddmkm` power-IRP BSODs. The GPU-under-load comparison at forced `PROH = 1` is therefore **unmeasured**, not merely unfavourable.
+
+Requirements: explicit opt-in with the risk stated plainly; adapter wattage from T1.4 so the feature can offer a **proportional** cap against the real supply rather than all-or-nothing 175 W; and a rollback path.
+
+**5.2.4 — Board scoping.**
+Every offset here (`0x59`, `0x90`, `0xE6`, `0xF6`/`0xF7`) came from *this* DSDT. Gate on `8D87` + `8D88`/`8DD5`/`8DD6`, never generally. This is the same class of error as `PowerLimitController`'s `0xC0`–`0xC5` and OmenMon-Reborn's `0x9F`.
+
+**5.2.5 — EC access discipline.**
+`PawnIOEcAccess` already has the `Global\Access_EC` mutex. OmenMon-Reborn additionally uses a graduated spin → yield → sleep backoff (added after relentless polling was implicated in ACPI-timeout BIOS panic shutdowns, their issue #88) and a torn-read guard requiring two consecutive identical 16-bit reads (their issue #86). A hold loop running at tens of Hz makes both of those relevant to us for the first time.
+
+### 5.3 Work items (conditional on T3.1)
+
+- **T3.2** MMIO or port-based access to the two offsets, single-purpose and allowlisted. Follow the investigation's pattern: `Write-EcProh.ps1` writes `0x90` **only** — the offset is not a parameter. Fan control (`MFAN` at `0x4A`), thermal trip points and battery charge parameters share the same 256-byte window.
+- **T3.3** Stage-2 unlock: hold `PROH = 1`, fire `GC22` to run `_Q73`, release. Verify against delivered watts. Re-apply on revert.
+- **T3.4** Stage-1 arm, **only if** a fast enough transport exists: hold `OGHP` (mask `0x02`, preserving `DBST` at bit 4 — it is a read-modify-write, unlike `PROH`) from a ≤2 ms loop, fire `GC22` inside the window, release. Measured minimums: 2 ms hold, 5000 ms settle before re-read. 5 ms hold fails; 1200 ms settle fails.
+- **T3.5** Proportional TGP mode: read the connected wattage (T1.4), pick a cap the supply can plausibly sustain, apply it driver-side rather than requesting the full 175 W. This is the *responsible* version of the feature and it is only possible because `Legacy 0x0F` exposes a real number.
+
+---
+
+## 6. Explicitly do not
+
+**The full list of settled dead ends lives in one place:
+``../reference/settled-negatives.md``.** Read it before proposing
+any experiment on this board — it also records two claims that were retracted and then
+*un*-retracted, which is the layer most likely to be read wrong.
+
+Specific to this repo, on top of that list:
+
+- **Do not** add EC power offsets `0xC0`–`0xC5` for this board. `SupportsEcPowerLimits` stays `false`.
+- **Do not** look for an EC register map in OGH's binaries. There is none — a grep across all four decompiled roots for `0xFE7006*`, `EmbeddedController`, `Ec{Read,Write}`, `LpcACPIEC` and raw port I/O returns zero hits. HP reaches the EC only through AML `GCxx` and the SMU only through AMD's own driver.
+- **Do not** investigate `hpomencustomcapdriver.sys`. It imports exactly `DbgPrintEx` and `RtlCopyUnicodeString` plus WDF loader stubs — no `MmMapIoSpace`, no port I/O, no `IoCreateDevice`. It is a stub and cannot touch the EC by construction. (`HpReadHWData.sys` is the one that is *not* a stub — see ``../investigation/06-hpreadhwdata-driver.md``.)
+- **Do not** raise TDC/EDC.
+- **Do not** reintroduce WinRing0 or inpoutx64. Note the upstream investigation's own `tools/lever/` scripts use `inpoutx64` for MMIO — **that does not port here**, and this repo removed it deliberately over Defender detections.
+
+Three from the shared list are worth repeating because they are easy to re-derive from the code:
+
+- **Do not** try to write `DSTA` directly via `GC22`. It sets `DSTA` and then calls `_Q73`, which overwrites it from `PROH`. Measured on both adapters.
+- **Do not** treat `EWDS` (mailbox `0x0E`) as a size field. Declared once, referenced by no AML, reads 0 in 1666/1666 captured events.
+- **Do not** treat `Default 0x28` as *connected* adapter state — it is byte-identical on 330 W and 200 W, and describes the SKU. But it is **not** contentless: `byte[0..1]` is `ShippingAdapterPowerRating` in watts (330 here), and `Legacy 0x0F` `byte[3] × 5` gives the connected rating. See ``../reference/wmi-commands.md``.
+
+---
+
+## 7. Open questions
+
+Carried forward from both documents, with our own added.
+
+**Blocking for us:**
+
+1. **Do ports `0x62`/`0x66` alias the MMIO window for *writes*, and on a second adapter state?** They do alias for **reads** — measured, three sandwiched runs; see §5.1 and ``../investigation/08-ec-port-aliasing.md``. The write direction is unproven, and nothing may write EC RAM through the ports until it is closed.
+2. **Does the PawnIO release driver load third-party modules?** Decides Option B. **Now much less urgent** — Option A succeeded, so Option B is no longer on the critical path for either stage.
+3. **Does the `OGHP` race actually win over ports?** Feasible on the latency numbers; unproven in fact. Requires the dedicated hold path described in §5.1.
+
+**Carried from the investigation, unresolved:**
+
+4. **How does OGH set `OGHP` durably?** OGH's arm stays up until the app is killed; ours is cleared on 98% of 2 ms cycles. The EC treats OGH's arm as authoritative and ours as noise. Not a blocker (a momentary hold suffices) but it is the one OGH behaviour that cannot be reproduced, only worked around. Every `GCxx` command OGH has been observed to send is a 0-arg read, so passive mailbox capture is the wrong instrument.
+5. **What transports the EC's 25 W decision into the SMU?** SMM is the surviving hypothesis. Not needed — the SMU limits are directly writable.
+6. **Why does `GC22`-zeroing give 80 W while `_REG`-zeroing gives 105 W?** Both set `CTGP = DTGP = 0`. 105 W is explained (base TGP, adder absent); 80 W is not. Suggests the historical 80 W baseline was never the clean "grants revoked" state it was taken for.
+7. **`OTPP`** — a one-shot arbitrary override of `ATPP`, consumed on use, writable in the same SSDT scope as `MODE`/`CTGP`/`DTGP`. Finest-grained lever found. Untested.
+8. **PPAB values above 1** — OmenCore's `Extended3`/`Extended4` pass `ppab = 2`/`3`, documented as "+25 W or more (RTX 5080+)". Unverified on this board, and there is no headroom to expose them while `enforced` already equals `power.max_limit`.
+9. **Why is NVPCF variant A selected?** Eight `Nvd*` SSDTs ship; something picks one. If it is a setup variable, that is a directly writable lever.
+10. **`STS0` at EC `0xBB`** — the one surviving unexplained adapter-keyed byte, and suspect by association after `HPBA` was retracted.
+11. **The V2 fan-command force-switch.** `HpWmiBios` switches this board to V2 fan commands via a `Contains("MAX") && Contains("OMEN")` name-substring match, but `0x28` byte 3 reports thermal policy **V1**. `ROADMAP_v4.0.0.md:256` already flags the substring match as a problem. Do these disagree on `8D87`?
+
+---
+
+## 8. Suggested sequencing
+
+**Phase 0 — decide the transport. ✅ DONE (2026-08-04).** T3.1 came back positive: the ports alias for reads and the transport is fast enough for *both* levers, not just `PROH`. Tier 3 exists. Two things moved as a result — Option B (custom PawnIO module) leaves the critical path, and the `OGHP` blocker is now a wrapper fix (`Thread.Sleep(1)` + per-call mutex in `PawnIOEcAccess.WriteByte`) rather than a transport dead end. The remaining gate before any EC write is confirming the aliasing holds **for writes** and on a **second adapter state**.
+
+**Phase 1 — Tier 1.** T1.4 → T1.5 → T1.6 first: adapter awareness is the highest value-per-risk item in the whole plan, it is read-only, and it makes every subsequent field report better. Then T1.8/T1.9/T1.10 (payload correctness), T1.11/T1.12 (`0x28`), T1.15/T1.16 (model DB). T1.1/T1.2/T1.3 (`MODE`) last in this phase, since they are the first real behaviour change.
+
+**Phase 2 — Tier 2.** T2.1 (verify, then fix `pawnio_load`) → T2.2/T2.3 → T2.6 (verification harness) → T2.5. This is the biggest measured user-facing win (25 → 51 W CPU) and it needs no EC writes and no races.
+
+**Phase 3 — Tier 3.** Phase 0 succeeded, so this is live. T3.2 → T3.3 (Stage 2) → T3.5 (proportional). **T3.4 (Stage 1) is no longer conditional on transport speed** — 0.325 ms per transaction clears the 2 ms window — but it does depend on the dedicated hold path in §5.1, and it stays behind the safety gating in §5.2.3 regardless.
+
+Phases 1 and 2 are independent and can run in parallel. Phase 3 benefits from T1.4 and is now gated on write-side confirmation rather than on Phase 0.

--- a/docs/8D87-VERIFICATION-CHECKLIST.md
+++ b/docs/8D87-VERIFICATION-CHECKLIST.md
@@ -1,0 +1,128 @@
+# Board 8D87 — what is verified, and what is not
+
+`ModelCapabilities.UserVerified` is a single flag over a profile with ~20 fields. On board `8D87`
+every board-specific claim in the entry has now been confirmed on real hardware, so the flag is
+**true**.
+
+It did not start that way. This document was written while fan curves and performance modes were
+still inherited from the adjacent MAX generation, and it recorded the flag as `false` on the rule
+below that the flag is all-or-nothing. Those rows have since been measured — see
+[Was not verified, now is](#was-not-verified-now-is) — and the flag was flipped in the same commit
+that measured the last of them.
+
+This document says exactly which claim rests on what, so the next person does not have to re-derive
+it, and so that the flag is a decision with a checklist behind it rather than a guess.
+
+## Verified on hardware
+
+Board `8D87`, HP OMEN MAX 16-ak0098nr, BIOS **F.07**, EC **40.38**, by the machine's owner,
+2026-08-01..05. Method was ACPI decompilation plus live measurement, cross-checked against three
+physical power adapters, the EC tachometers and OMEN Gaming Hub's own readout.
+
+| Field | How it was established |
+|---|---|
+| `SupportsEcPowerLimits = false` | The EC mailbox power block at `0xF5`–`0xF8` was forced to its high-power values with no effect on delivered watts — it is a mirror the SMU never reads back. |
+| `SupportsFanControlEc = false` | The EC is memory-mapped at `0xFE700600`, not at the legacy port offsets. The legacy register map does not apply. |
+| `SupportsUndervolt = false` | AMD Ryzen AI part; the Intel MSR undervolt path does not exist here. |
+| `MaxModeDropChecksBeforeReapply = 1` | Corroborated by the observed performance-mode decay on this machine. |
+| `Family`, `ModelYear`, `ProductId` | Firmware identification. |
+| Thermal policy | `Default 0x28` byte 3 reads `0x01` (V1). The app drives this board as V2 via a model-name force-switch; the diagnostics export prints both and flags the disagreement. See the caveat below. |
+| `FanZoneCount = 2` | `Default 0x10` returns 2, and two EC tachometers track independently. |
+| **`MaxFanLevel = 60`** | Measured, was 100. `0x2D` sampled against the EC tachometers and OGH's readout at four points — `0`/0, `22`/2220, `47`/4680, `60`/6000 rpm — linear within ~1 %. |
+| `SupportsRpmReadback = true` | Same four samples; the V1 `0x2D` level tracks the tachometers at every point. |
+| **`HasPerKeyRgb = true`** | Topology probe — class `0x00020008`, command `0x2B`, null input, 4-byte return — returns `0x03` = `RgbPerKey`, stable across repeated reads. |
+| `HasKeyboardBacklight = true` | Same probe: a lighting type is reported and it is neither `None` nor `Normal`. |
+| **`HasFourZoneRgb = false`** | Was defaulted `true`. HP's own `FourZoneHelper.IsSupported` returns false for lighting type 3, so the four-zone path does not drive a per-key keyboard. |
+| `HasMuxSwitch = true` | Inherited, now **measured** by switching modes and rebooting. In Discrete the internal panel is driven by the dGPU. See below. |
+| **`SupportsAdvancedOptimus = false`** | Was inherited `true`. There *is* a mux, but it is routed at boot — the Smart Mux block stays disabled through a working switch. See below. |
+
+### There is a mux; it is not Advanced Optimus
+
+These are two different claims and this board splits them. BIOS setup offers **Hybrid / Discrete /
+UMA**, taking effect on reboot; OMEN Gaming Hub exposes the same selector. Captured in Hybrid, in
+Discrete, and again after returning to Hybrid.
+
+| Reading | Hybrid | Discrete | Restored |
+|---|---|---|---|
+| `Legacy 0x52` | `00 00 00 00` | **`01 00 00 00`** | `00 00 00 00` |
+| `AMD_PBS_SETUP 0x05` Primary Video Adaptor | 1 = IGD | **2 = PEG** | 1 = IGD |
+| Internal panel driven by | Radeon 890M | **RTX 5080** | Radeon 890M |
+| `nvidia-smi display_active` | Disabled | **Enabled** | Disabled |
+| Smart Mux block (`0xB6`/`0xC7`/`0xC8`/`0xCA`) | all 0 | **all 0** | all 0 |
+
+**`HasMuxSwitch = true`** because the internal panel changes which GPU drives it — in Discrete the
+sole display is the built-in `CMN1652` at its native 2560×1600, attached to the RTX 5080, with the
+Radeon reporting no active mode. Reversible: the restored capture matches the baseline on every WMI
+and `AMD_PBS_SETUP` field.
+
+**`SupportsAdvancedOptimus = false`** because Advanced Optimus means the mux moves under **live ACPI
+control, without a reboot**, and the entire Smart Mux block reads zero in all three states. It stays
+off through a switch that demonstrably works, so the routing decision is taken at boot by firmware
+and there is no runtime control surface.
+
+`Default 0x28` byte 7 = `0x07` ("graphics switching supported") is a **capability bitmask, not the
+current mode** — byte-identical in all three states, so it describes the SKU family. Read the mode
+from `Legacy 0x52`.
+
+`Legacy 0x52` is genuine state rather than an ACPI timeout: a field that only ever returns zero
+cannot return `0x01`. The size-gate control agrees — `Default 0x28` returns code `5` at the 4-byte
+output size while `0x52` returns `0`, so the gate is live and `0x52`'s declared reply really is four
+bytes.
+
+No byte in the EC state window at `0xFE700600` tracks the mode; the 25 bytes that differ across the
+three captures are fan and thermal values, and none returns to its Hybrid value.
+
+Fan tachometers are at EC `0x70` (fan 1) and `0x5C` (fan 2). **`0x7E` is not a reliable second
+tachometer** — it reads 0 at every manual fan setting while that fan is spinning, and under auto it
+shadowed fan 1. `0x9F` is battery remaining capacity in mAh, **not** a GPU tachometer — a mistake
+other projects have made on this board. OmenCore has never carried it.
+
+### Caveat: this board is V1 and is driven as V2
+
+`Default 0x28` byte 3 reports thermal policy **V1**, and the firmware **rejects the V2 fan
+commands** — `0x37` returns `RTCD 6` and `0x38` returns `RTCD 4`, at every input and output buffer
+size. Fan levels reach the app only because `GetFanLevel()` falls back to the V1 command `0x2D`.
+
+That fallback is correct and works. But the model-name force-switch to V2 (`HpWmiBios.cs:858-866`)
+also drives `MaxFanLevel = 100` (`:931-935`), which is wrong here because V1 levels are krpm/100.
+This entry now sets `MaxFanLevel = 60` explicitly, and the model override returns from
+`DetectMaxFanLevel` **before** the V2 branch, so the correct value is what takes effect. The
+underlying force-switch logic is untouched and still affects any OMEN MAX board without an entry.
+
+## Was not verified, now is
+
+These three rows were the reason this document originally kept `UserVerified = false`. All three
+have since been measured on the hardware.
+
+| Field | Then | Now |
+|---|---|---|
+| `PerformanceModes` | inherited, included `"L5P"` | Measured in **delivered watts**, not return codes, with the `OGHP` gate armed: `Default 0x30` → ~102 W, `Performance 0x31` → 175.00 W, `Cool 0x50` → ~103 W. `SetFanMode` writes `NPCF.MODE` and the firmware consumes `(MODE & 0x0F)`, so Default and Cool both select nibble 0 and deliver the same power profile — Cool differs as *fan* policy, not as a power tier. All three bytes return `RTCD 0`, including the two that select the same profile, so acceptance was never the evidence. **`"L5P"` removed:** there is no such member in `HpWmiBios.FanMode`, so `SetPerformanceMode("L5P")` fell through to `FanMode.Default` — asking for L5P silently gave you Default. |
+| `SupportsFanCurves = true` | inherited | Verified by RPM readback against the EC tachometers, not by return code. |
+| `SupportsIndependentFanCurves = false` | inherited | Confirmed impossible on this board, so the `false` is now a measurement rather than a default. |
+
+Method note worth keeping: `Performance` was re-run as a **positive control between every pair of
+readings**, because a decayed `OGHP` gate reads 80.00 W and would otherwise masquerade as MODE 0.
+Without that control the Default/Cool result would have been indistinguishable from a gate that had
+simply lapsed mid-measurement.
+
+## Rules for this entry
+
+- **Verify by outcome.** A WMI command returning success does not mean the hardware did anything.
+  For fan claims that means RPM readback; for power claims, watts. On this platform `RTCD == 0` is
+  especially weak evidence — the ACPI returns `0` on its own timeout path.
+- **Reads can be corrupted by OMEN Gaming Hub.** The EC command mailbox is a single shared buffer
+  with no locking between OS agents, and OGH polls it continuously. During this verification,
+  repeated identical reads returned OGH's replies to *its* questions until OGH was stopped. Prefer
+  the EC tachometers (direct MMIO) for fan cross-checks, and distrust a value that changes between
+  back-to-back identical reads.
+- **`RTCD = 5` means the output buffer was the wrong size,** not "unsupported". A genuine rejection
+  persists across every buffer size.
+- **The flag is all-or-nothing.** It was flipped only once every board-specific row was measured. If
+  a future field is added to this entry by inheritance rather than measurement, `UserVerified` goes
+  back to `false` until it is checked. If the flag ever gains per-field granularity, revisit this.
+- **What `UserVerified = true` does not claim.** It covers the board-specific fields in this entry.
+  Fields that are platform-generic and untested here — `SupportsNetworkBoost`, and anything driven by
+  a subsystem this board routes elsewhere — are not evidence-backed by the flag.
+- **Do not widen to sibling boards.** `8D88`, `8DD5` and `8DD6` share this platform's firmware but
+  none of them has been measured. See `ModelCapabilityDatabase.Vibrance25C1BoardIds`, which is a
+  scope list for raw EC offsets and explicitly not a capability claim.

--- a/src/OmenCoreApp.Tests/Hardware/EcFanTachometerTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/EcFanTachometerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -35,6 +36,46 @@ namespace OmenCoreApp.Tests.Hardware
             {
                 ReadAddresses.Add(address);
                 return _bytes.TryGetValue(address, out var b) ? b : (byte)0x00;
+            }
+
+            public void WriteByte(ushort address, byte value) { }
+            public void Dispose() { }
+        }
+
+        /// <summary>
+        /// EC stub driven by a script of per-tick outcomes: a null entry throws the way a busy
+        /// ACPI EC port pair does, a tuple serves that fan pair. The last entry repeats once the
+        /// script runs out, so "fails once then works" and "never works" are both expressible.
+        /// </summary>
+        private sealed class ScriptedEcAccess : IEcAccess
+        {
+            private readonly Queue<(int fan1, int fan2)?> _script;
+            private (int fan1, int fan2)? _current;
+
+            public ScriptedEcAccess(params (int fan1, int fan2)?[] ticks)
+                => _script = new Queue<(int fan1, int fan2)?>(ticks);
+
+            public List<ushort> ReadAddresses { get; } = new();
+            public bool IsAvailable => true;
+            public bool Initialize(string devicePath) => true;
+
+            public byte ReadByte(ushort address)
+            {
+                ReadAddresses.Add(address);
+
+                // A tick begins at the first tachometer's low byte.
+                if (address == 0x70 && _script.Count > 0)
+                {
+                    _current = _script.Dequeue();
+                }
+
+                if (_current is null)
+                {
+                    throw new TimeoutException("EC output buffer not full");
+                }
+
+                var rpm = address is 0x70 or 0x71 ? _current.Value.fan1 : _current.Value.fan2;
+                return address is 0x71 or 0x5D ? (byte)(rpm >> 8) : (byte)(rpm & 0xFF);
             }
 
             public void WriteByte(ushort address, byte value) { }
@@ -200,6 +241,79 @@ namespace OmenCoreApp.Tests.Hardware
 
             ec.ReadAddresses.Should().BeEmpty();
             fans[0].SpeedRpm.Should().Be(2000);
+        }
+
+        [Fact]
+        public void OneFailedTransaction_DoesNotDisableTheTachometerForTheSession()
+        {
+            // Measured on 8D87: the app logged a single "EC output buffer not full" 39 seconds
+            // after start and, because the first failure was treated as permanent, spent the
+            // next eight minutes on the fan-level estimate - including a full verification run,
+            // which then scored six passes on evidence that was the commanded level echoed back.
+            // The port pair is shared with the firmware's own traffic; one refusal is contention.
+            var ec = new ScriptedEcAccess(null, (2760, 2220));
+
+            using var controller = CreateController(ec, new ushort[] { 0x70, 0x5C });
+
+            var duringFailure = Read(controller);
+            duringFailure[0].RpmSource.Should().Be(RpmSource.Estimated, "the tick itself has no reading");
+
+            var afterRecovery = Read(controller);
+            afterRecovery[0].SpeedRpm.Should().Be(2760);
+            afterRecovery[0].RpmSource.Should().Be(RpmSource.EcDirect, "the next tick must try again");
+        }
+
+        [Fact]
+        public void SustainedFailures_StopHammeringTheEc()
+        {
+            // The other half of the trade: retrying every tick forever would amplify exactly the
+            // contention that caused the failure. After a short run of failures it backs off, so
+            // an EC that genuinely will not answer costs almost no traffic.
+            var ec = new ScriptedEcAccess(null, null, null, null, null);
+
+            using var controller = CreateController(ec, new ushort[] { 0x70, 0x5C });
+
+            for (var tick = 0; tick < 8; tick++)
+            {
+                Read(controller);
+            }
+
+            ec.ReadAddresses.Count.Should().BeLessThan(8, "the backoff must actually stop the traffic");
+            ec.ReadAddresses.Should().OnlyContain(a => a == 0x70, "a tick that throws never reaches the second byte");
+        }
+
+        [Fact]
+        public void OneImplausibleReading_IsDiscardedAsATornRead_NotAsWrongOffsets()
+        {
+            // A tachometer is two separate byte transactions, so a single absurd pair can be a
+            // read torn across an EC update. Writing the offsets off on the strength of one is
+            // the same over-reaction as giving up after one timeout.
+            var ec = new ScriptedEcAccess((65535, 65535), (2760, 2220));
+
+            using var controller = CreateController(ec, new ushort[] { 0x70, 0x5C });
+
+            Read(controller)[0].RpmSource.Should().Be(RpmSource.Estimated);
+            Read(controller)[0].SpeedRpm.Should().Be(2760, "one bad pair is not proof the offsets are wrong");
+        }
+
+        [Fact]
+        public void RepeatedImplausibleReadings_WriteOffTheOffsetsForGood()
+        {
+            // A run of them is proof. Offsets pointed at something that is not a tachometer -
+            // 0x34/0x35 on this board's neighbours land in an ASCII serial number - must be
+            // abandoned rather than retried, because they will read "fine" forever.
+            var ec = new ScriptedEcAccess((65535, 65535), (65535, 65535), (65535, 65535), (2760, 2220));
+
+            using var controller = CreateController(ec, new ushort[] { 0x70, 0x5C });
+
+            for (var tick = 0; tick < 3; tick++)
+            {
+                Read(controller);
+            }
+
+            var afterGivingUp = Read(controller);
+            afterGivingUp[0].SpeedRpm.Should().Be(2000, "the offsets are written off; this is the level estimate");
+            afterGivingUp[0].RpmSource.Should().Be(RpmSource.Estimated);
         }
 
         [Fact]

--- a/src/OmenCoreApp.Tests/Hardware/EcFanTachometerTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/EcFanTachometerTests.cs
@@ -1,0 +1,216 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using OmenCore.Hardware;
+using OmenCore.Models;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Hardware
+{
+    /// <summary>
+    /// Board 8D87 reported 0 RPM in the UI while its fans turned at 2760. The V2 command
+    /// GetFanRpmDirect (0x38) is refused there, leaving GetFanLevel x 100 as the only RPM
+    /// source - and that is the *commanded* level echoed back, which reads 0 under BIOS
+    /// automatic control because nothing has been commanded.
+    ///
+    /// These pin the EC tachometer path that fixes it: that it is preferred over the level
+    /// estimate rather than used only as a last resort, that it decodes 16-bit little-endian,
+    /// that a genuine zero survives as a zero, and that a model without configured offsets
+    /// behaves exactly as before.
+    /// </summary>
+    public class EcFanTachometerTests
+    {
+        /// <summary>EC stub serving a fixed byte map; records every address read.</summary>
+        private sealed class MapEcAccess : IEcAccess
+        {
+            private readonly Dictionary<ushort, byte> _bytes;
+
+            public MapEcAccess(Dictionary<ushort, byte> bytes) => _bytes = bytes;
+
+            public List<ushort> ReadAddresses { get; } = new();
+            public bool IsAvailable { get; init; } = true;
+            public bool Initialize(string devicePath) => true;
+
+            public byte ReadByte(ushort address)
+            {
+                ReadAddresses.Add(address);
+                return _bytes.TryGetValue(address, out var b) ? b : (byte)0x00;
+            }
+
+            public void WriteByte(ushort address, byte value) { }
+            public void Dispose() { }
+        }
+
+        /// <summary>
+        /// V1 board: GetFanRpmDirect refused, GetFanLevel answers. Mirrors 8D87, where the
+        /// level is the thing that must NOT win over a tachometer.
+        /// </summary>
+        private sealed class V1FanLevelBios : IHpWmiBios
+        {
+            public (byte fan1, byte fan2)? Level { get; init; } = (20, 22);
+
+            public bool IsAvailable => true;
+            public string Status => "fake V1";
+            public HpWmiBios.ThermalPolicyVersion ThermalPolicy => HpWmiBios.ThermalPolicyVersion.V1;
+            public int FanCount => 2;
+            public int MaxFanLevel => 60;
+
+            // The board this models refuses 0x38 outright - that refusal is the whole reason
+            // the level estimate was ever load-bearing.
+            public (int fan1Rpm, int fan2Rpm)? GetFanRpmDirect() => null;
+            public (byte fan1, byte fan2)? GetFanLevel() => Level;
+
+            public bool SetFanMax(bool enabled) => true;
+            public bool SetFanLevel(byte fan1, byte fan2) => true;
+            public bool SetFanMode(HpWmiBios.FanMode mode) => true;
+
+            public double? GetTemperature() => 50;
+            public double? GetGpuTemperature() => 50;
+            public void ExtendFanCountdown() { }
+
+            public (bool customTgp, bool ppab, int dState)? GetGpuPower() => null;
+            public bool SetGpuPower(HpWmiBios.GpuPowerLevel level) => true;
+            public HpWmiBios.GpuMode? GetGpuMode() => null;
+
+            public void Dispose() { }
+        }
+
+        private static WmiFanController CreateController(
+            IEcAccess? ecAccess,
+            ushort[]? offsets,
+            IHpWmiBios? bios = null)
+            => new(
+                hwMonitor: null,
+                logging: null,
+                injectedWmiBios: bios ?? new V1FanLevelBios(),
+                ecAccess: ecAccess,
+                ecFanTachometerOffsets: offsets);
+
+        private static List<FanTelemetry> Read(WmiFanController controller)
+            => controller.ReadFanSpeeds().ToList();
+
+        [Fact]
+        public void Tachometers_AreReadAs16BitLittleEndian()
+        {
+            // 0x70/0x71 = C8 0A -> 2760; 0x5C/0x5D = AC 08 -> 2220. Taking only the low byte
+            // would give 200 and 172 - the exact failure a sibling probe script hit.
+            var ec = new MapEcAccess(new Dictionary<ushort, byte>
+            {
+                [0x70] = 0xC8, [0x71] = 0x0A,
+                [0x5C] = 0xAC, [0x5D] = 0x08
+            });
+
+            using var controller = CreateController(ec, new ushort[] { 0x70, 0x5C });
+            var fans = Read(controller);
+
+            fans.Should().HaveCount(2);
+            fans[0].SpeedRpm.Should().Be(2760);
+            fans[1].SpeedRpm.Should().Be(2220);
+        }
+
+        [Fact]
+        public void Tachometer_BeatsTheFanLevelEstimate()
+        {
+            // The level says 20 -> 2000 RPM. The tachometer says 2760. Preferring the level
+            // would replace a measurement with an echo of the last command.
+            var ec = new MapEcAccess(new Dictionary<ushort, byte>
+            {
+                [0x70] = 0xC8, [0x71] = 0x0A,
+                [0x5C] = 0xC8, [0x5D] = 0x0A
+            });
+
+            using var controller = CreateController(
+                ec, new ushort[] { 0x70, 0x5C }, new V1FanLevelBios { Level = (20, 20) });
+
+            var fans = Read(controller);
+
+            fans[0].SpeedRpm.Should().Be(2760, "the physical tachometer must win over level x 100");
+            fans[0].SpeedRpm.Should().NotBe(2000, "2000 is the commanded level echoed back, not a measurement");
+            fans[0].RpmSource.Should().Be(RpmSource.EcDirect);
+        }
+
+        [Fact]
+        public void StoppedFans_ReportZero_RatherThanFallingBackToTheLevel()
+        {
+            // The whole point of having a tachometer: when it says the fans are stopped, that
+            // is the answer, even though the firmware still remembers a non-zero level. Falling
+            // through to the level here would resurrect exactly the reading that made a fan
+            // change verifiable against its own request.
+            var ec = new MapEcAccess(new Dictionary<ushort, byte>
+            {
+                [0x70] = 0x00, [0x71] = 0x00,
+                [0x5C] = 0x00, [0x5D] = 0x00
+            });
+
+            using var controller = CreateController(
+                ec, new ushort[] { 0x70, 0x5C }, new V1FanLevelBios { Level = (35, 35) });
+
+            var fans = Read(controller);
+
+            fans[0].SpeedRpm.Should().Be(0);
+            fans[0].RpmSource.Should().Be(RpmSource.EcDirect, "a measured zero is still a measurement");
+            fans[0].SpeedRpm.Should().NotBe(3500, "3500 would be the level estimate leaking back in");
+        }
+
+        [Fact]
+        public void ImplausibleReading_IsRejected_AndFallsBackToWmi()
+        {
+            // A mis-aimed offset usually reads as something absurd rather than as an error.
+            // 0xFFFF is 65535 RPM; publishing it would be worse than falling back.
+            var ec = new MapEcAccess(new Dictionary<ushort, byte>
+            {
+                [0x70] = 0xFF, [0x71] = 0xFF,
+                [0x5C] = 0xFF, [0x5D] = 0xFF
+            });
+
+            using var controller = CreateController(
+                ec, new ushort[] { 0x70, 0x5C }, new V1FanLevelBios { Level = (20, 22) });
+
+            var fans = Read(controller);
+
+            fans[0].SpeedRpm.Should().Be(2000, "rejecting the EC read must fall back to the level estimate");
+            fans[0].RpmSource.Should().Be(RpmSource.Estimated, "and must be labelled as the estimate it is");
+        }
+
+        [Fact]
+        public void ModelWithoutConfiguredOffsets_TouchesTheEcNotAtAll()
+        {
+            // Every board that has not had its tachometers located must behave exactly as
+            // before - no new EC transactions on the monitoring cadence.
+            var ec = new MapEcAccess(new Dictionary<ushort, byte>
+            {
+                [0x70] = 0xC8, [0x71] = 0x0A
+            });
+
+            using var controller = CreateController(ec, offsets: null);
+            var fans = Read(controller);
+
+            ec.ReadAddresses.Should().NotContain(0x70);
+            fans[0].SpeedRpm.Should().Be(2000, "unchanged: the WMI fan-level estimate");
+            fans[0].RpmSource.Should().Be(RpmSource.Estimated);
+        }
+
+        [Fact]
+        public void UnavailableEcAccess_FallsBackWithoutThrowing()
+        {
+            var ec = new MapEcAccess(new Dictionary<ushort, byte>()) { IsAvailable = false };
+
+            using var controller = CreateController(ec, new ushort[] { 0x70, 0x5C });
+            var fans = Read(controller);
+
+            ec.ReadAddresses.Should().BeEmpty();
+            fans[0].SpeedRpm.Should().Be(2000);
+        }
+
+        [Fact]
+        public void TachometerOffsets_AreIndependentOfEcFanControlSupport()
+        {
+            // 8D87 has SupportsFanControlEc = false and readable tachometers. The two must not
+            // be coupled: one gates writes, the other is a read.
+            var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
+
+            caps.SupportsFanControlEc.Should().BeFalse();
+            caps.EcFanTachometerOffsets.Should().Equal(new ushort[] { 0x70, 0x5C });
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Hardware/HidLampArrayReportTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/HidLampArrayReportTests.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using OmenCore.Hardware;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Hardware
+{
+    /// <summary>
+    /// Pins the HID LampArray report byte layouts.
+    ///
+    /// These are worth testing precisely because getting them wrong does not fail loudly. A
+    /// misplaced offset produces a report the device accepts and acts on - it just lights the
+    /// wrong lamp, or the right lamp in the wrong colour. There is no colour readback in the
+    /// LampArray spec to catch it with, so the byte layout is the last place it can be checked
+    /// automatically.
+    ///
+    /// Layouts are from the HID Lighting And Illumination usage page (0x59). The 51-byte
+    /// LampMultiUpdateReport size is corroborated by hardware: both LampArrays on the board this
+    /// was written against report exactly 51-byte feature reports.
+    /// </summary>
+    public class HidLampArrayReportTests
+    {
+        private const int ReportLength = 51;
+
+        [Fact]
+        public void RangeUpdate_PlacesEveryFieldWhereTheSpecSaysIt()
+        {
+            var report = HidLampArray.BuildRangeUpdateReport(ReportLength, 0x0102, 0x0304, 10, 20, 30, 40);
+
+            report[0].Should().Be(5, "LampRangeUpdateReport is report id 5");
+            report[1].Should().Be(0x01, "LampUpdateComplete must be set or the device waits for more");
+            report[2].Should().Be(0x02, "LampIdStart is little-endian u16");
+            report[3].Should().Be(0x01);
+            report[4].Should().Be(0x04, "LampIdEnd is little-endian u16");
+            report[5].Should().Be(0x03);
+            report[6].Should().Be(10);
+            report[7].Should().Be(20);
+            report[8].Should().Be(30);
+            report[9].Should().Be(40, "intensity is the fourth channel, after RGB");
+        }
+
+        [Fact]
+        public void MultiUpdate_ChannelsStartAfterAllEightIdSlots()
+        {
+            // The trap this guards. The id and channel arrays are both sized for eight lamps
+            // whether or not all eight are used, so a partial batch must still leave the unused id
+            // slots in place. Packing channels immediately after the ids in use would shift every
+            // channel forward and misalign the whole batch.
+            var lamps = new List<HidLampArray.LampColor>
+            {
+                new(0x1111, 1, 2, 3, 4),
+                new(0x2222, 5, 6, 7, 8)
+            };
+
+            var report = HidLampArray.BuildMultiUpdateReport(ReportLength, lamps, 0, 2, isLastBatch: true);
+
+            report[0].Should().Be(4, "LampMultiUpdateReport is report id 4");
+            report[1].Should().Be(2, "LampCount");
+            report[2].Should().Be(0x01, "LampUpdateComplete on the final batch");
+
+            // Ids at 3, packed u16.
+            report[3].Should().Be(0x11);
+            report[4].Should().Be(0x11);
+            report[5].Should().Be(0x22);
+            report[6].Should().Be(0x22);
+
+            // Unused id slots stay zero rather than being overwritten by channel data.
+            for (int i = 7; i < 19; i++) report[i].Should().Be(0, $"id slot byte {i} is unused");
+
+            // Channels at 3 + 8*2 = 19, regardless of how few lamps are in this batch.
+            report[19].Should().Be(1);
+            report[20].Should().Be(2);
+            report[21].Should().Be(3);
+            report[22].Should().Be(4);
+            report[23].Should().Be(5);
+            report[24].Should().Be(6);
+            report[25].Should().Be(7);
+            report[26].Should().Be(8);
+        }
+
+        [Fact]
+        public void MultiUpdate_FullBatchFillsTheReportExactly()
+        {
+            // Eight lamps is the most one report holds, and it should reach byte 50 of 51 - which
+            // is why the 51-byte feature report length seen on real hardware is corroboration
+            // rather than coincidence.
+            var lamps = new List<HidLampArray.LampColor>();
+            for (ushort i = 0; i < 8; i++) lamps.Add(new HidLampArray.LampColor(i, 255, 255, 255, 255));
+
+            var report = HidLampArray.BuildMultiUpdateReport(ReportLength, lamps, 0, 8, isLastBatch: true);
+
+            report[50].Should().Be(255, "the eighth lamp's intensity is the final byte");
+            report[19 + (8 * 4) - 1].Should().Be(255);
+        }
+
+        [Fact]
+        public void MultiUpdate_OnlyTheFinalBatchIsFlaggedComplete()
+        {
+            // A non-final batch flagged complete makes the device apply a partial frame, which
+            // tears visibly across a large update.
+            var lamps = new List<HidLampArray.LampColor>();
+            for (ushort i = 0; i < 16; i++) lamps.Add(new HidLampArray.LampColor(i, 1, 1, 1));
+
+            var first = HidLampArray.BuildMultiUpdateReport(ReportLength, lamps, 0, 8, isLastBatch: false);
+            var last = HidLampArray.BuildMultiUpdateReport(ReportLength, lamps, 8, 8, isLastBatch: true);
+
+            first[2].Should().Be(0x00);
+            last[2].Should().Be(0x01);
+        }
+
+        [Fact]
+        public void MultiUpdate_ReadsFromTheGivenOffset()
+        {
+            var lamps = new List<HidLampArray.LampColor>
+            {
+                new(0x0001, 11, 11, 11),
+                new(0x0002, 22, 22, 22),
+                new(0x0003, 33, 33, 33)
+            };
+
+            var report = HidLampArray.BuildMultiUpdateReport(ReportLength, lamps, offset: 2, count: 1, isLastBatch: true);
+
+            report[3].Should().Be(0x03, "the batch starts at the requested offset, not at zero");
+            report[19].Should().Be(33);
+        }
+
+        [Fact]
+        public void LampIds_AreLittleEndian()
+        {
+            var lamps = new List<HidLampArray.LampColor> { new(0x00FF, 0, 0, 0) };
+            var report = HidLampArray.BuildMultiUpdateReport(ReportLength, lamps, 0, 1, true);
+
+            report[3].Should().Be(0xFF, "low byte first");
+            report[4].Should().Be(0x00);
+        }
+
+        [Fact]
+        public void Intensity_DefaultsToFull()
+        {
+            // A default of 0 would make every colour set through the convenience constructor
+            // invisible, which looks exactly like the write not working.
+            var lamp = new HidLampArray.LampColor(0, 255, 0, 0);
+            lamp.Intensity.Should().Be(255);
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Hardware/HpWmiBiosAdapterDecodeTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/HpWmiBiosAdapterDecodeTests.cs
@@ -1,0 +1,181 @@
+using FluentAssertions;
+using OmenCore.Hardware;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Hardware
+{
+    /// <summary>
+    /// Decode tests for the <c>Legacy 0x0F</c> adapter reply.
+    ///
+    /// The three 4-byte payloads used here are real captures from an OMEN MAX 16 (board 8D87,
+    /// BIOS F.07) taken with three physical adapters plugged into the same machine. They are the
+    /// reason this decode can be trusted: the wattage byte was checked against the printed rating on
+    /// three different supplies, not inferred from one.
+    /// </summary>
+    public class HpWmiBiosAdapterDecodeTests
+    {
+        [Fact]
+        public void DecodeAdapterData_Decodes_330W_Adapter_Capture()
+        {
+            // Measured: 330 W supply. 0x42 * 5 = 330.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x01, 0xC2, 0x00, 0x42 });
+
+            decoded.Should().NotBeNull();
+            decoded!.Value.Status.Should().Be(HpWmiBios.SmartAdapterStatus.MeetsRequirement);
+            decoded.Value.PowerRatingWatts.Should().Be(330);
+            decoded.Value.PowerRatingKnown.Should().BeTrue();
+            decoded.Value.UsbcDesignRatingWatts.Should().Be(0);
+            decoded.Value.SupportsBarrelConnector.Should().BeTrue();
+            decoded.Value.IsLowWattage.Should().BeFalse();
+        }
+
+        [Fact]
+        public void DecodeAdapterData_Decodes_280W_Adapter_Capture()
+        {
+            // Measured: 280 W supply. 0x38 * 5 = 280, and the firmware calls it below requirement.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x02, 0xC2, 0x00, 0x38 });
+
+            decoded.Should().NotBeNull();
+            decoded!.Value.Status.Should().Be(HpWmiBios.SmartAdapterStatus.BelowRequirement);
+            decoded.Value.PowerRatingWatts.Should().Be(280);
+            decoded.Value.IsLowWattage.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DecodeAdapterData_Decodes_200W_Adapter_Capture()
+        {
+            // Measured: 200 W supply. 0x28 * 5 = 200.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x02, 0xC2, 0x00, 0x28 });
+
+            decoded.Should().NotBeNull();
+            decoded!.Value.PowerRatingWatts.Should().Be(200);
+            decoded.Value.Status.Should().Be(HpWmiBios.SmartAdapterStatus.BelowRequirement);
+            decoded.Value.IsLowWattage.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DecodeAdapterData_Treats_0xFF_As_Unknown_Not_1275W()
+        {
+            // 0xFF is HP's "unknown" sentinel. Decoding it arithmetically would report 1275 W and
+            // make an unidentified supply look like the best-equipped machine in the field reports.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x01, 0xC2, 0x00, 0xFF });
+
+            decoded.Should().NotBeNull();
+            decoded!.Value.PowerRatingKnown.Should().BeFalse();
+            decoded.Value.PowerRatingWatts.Should().Be(0);
+        }
+
+        [Fact]
+        public void DecodeAdapterData_Reads_BarrelSupport_From_Bit7_Only()
+        {
+            // 0xC2 has bit 7 set; 0x42 is the same byte without it. Nothing else in byte 1 matters.
+            HpWmiBios.DecodeAdapterData(new byte[] { 0x01, 0xC2, 0x00, 0x42 })!
+                .Value.SupportsBarrelConnector.Should().BeTrue();
+
+            HpWmiBios.DecodeAdapterData(new byte[] { 0x01, 0x42, 0x00, 0x42 })!
+                .Value.SupportsBarrelConnector.Should().BeFalse();
+        }
+
+        [Fact]
+        public void DecodeAdapterData_Returns_Null_For_Short_Or_Missing_Payload()
+        {
+            HpWmiBios.DecodeAdapterData(null).Should().BeNull();
+            HpWmiBios.DecodeAdapterData(new byte[] { 0x01, 0xC2, 0x00 }).Should().BeNull();
+        }
+
+        // ── IsLowWattage: HP's own comparison, including the Type-C branch most tables miss ──
+
+        [Fact]
+        public void IsLowWattage_TypeC_Compares_Against_UsbcDesignRating_Not_The_Status()
+        {
+            // 100 W PD supply on a chassis designed for 140 W: under-rated, even though the status
+            // byte is ConnectedTypeC rather than BelowRequirement. Folding value 5 into
+            // "anything that isn't MeetsRequirement" would get the right answer here by accident and
+            // the wrong one in the next test.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x05, 0x00, 0x1C, 0x14 });
+
+            decoded!.Value.Status.Should().Be(HpWmiBios.SmartAdapterStatus.ConnectedTypeC);
+            decoded.Value.UsbcDesignRatingWatts.Should().Be(140);
+            decoded.Value.PowerRatingWatts.Should().Be(100);
+            decoded.Value.IsLowWattage.Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsLowWattage_TypeC_At_Design_Rating_Is_Not_Low_Wattage()
+        {
+            // 140 W PD on a 140 W design: adequate. This is the case a naive
+            // "status != MeetsRequirement" test gets wrong - it would warn the user about a supply
+            // that is exactly what the chassis was designed for.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x05, 0x00, 0x1C, 0x1C });
+
+            decoded!.Value.IsLowWattage.Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsLowWattage_TypeC_With_Barrel_Support_And_Zero_Design_Rating_Is_Low_Wattage()
+        {
+            // HP's special case: a barrel-capable chassis reporting no USB-C design rating is
+            // treated as under-rated on PD regardless of what the supply claims.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x05, 0x80, 0x00, 0x42 });
+
+            decoded!.Value.SupportsBarrelConnector.Should().BeTrue();
+            decoded.Value.UsbcDesignRatingWatts.Should().Be(0);
+            decoded.Value.IsLowWattage.Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsLowWattage_TypeC_Without_Barrel_Support_And_Zero_Design_Rating_Is_Not_Low_Wattage()
+        {
+            // Same zero design rating, no barrel jack: the special case does not apply, and the
+            // primary comparison (0 < 0) is false.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0x05, 0x00, 0x00, 0x42 });
+
+            decoded!.Value.IsLowWattage.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(0x02)] // BelowRequirement
+        [InlineData(0x03)] // BatteryPower
+        [InlineData(0x04)] // NotFunctioning
+        public void IsLowWattage_NonTypeC_Is_Anything_Other_Than_MeetsRequirement(byte status)
+        {
+            HpWmiBios.DecodeAdapterData(new byte[] { status, 0xC2, 0x00, 0x42 })!
+                .Value.IsLowWattage.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(0x00)] // NotSupported
+        [InlineData(0xFF)] // Error
+        public void NoVerdict_Statuses_Are_Not_Reported_As_Low_Wattage(byte status)
+        {
+            // HP evaluates its low-wattage rule only after a successful query. Feeding a non-answer
+            // through the "anything that isn't MeetsRequirement" branch turns "no verdict" into "bad
+            // adapter" - and a board that replies with zeroes would then be told, confidently and on
+            // screen, to go and check a power supply that is probably fine.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { status, 0x00, 0x00, 0x00 });
+
+            decoded!.Value.HasVerdict.Should().BeFalse();
+            decoded.Value.IsLowWattage.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Status_0xFF_Decodes_To_Error_Not_255()
+        {
+            // The enum is sbyte-backed for this reason. With the default int backing, a 0xFF wire
+            // byte produced 255, which fell through every switch to render as the literal "255" in
+            // the UI and the diagnostics export.
+            var decoded = HpWmiBios.DecodeAdapterData(new byte[] { 0xFF, 0xC2, 0x00, 0x42 });
+
+            decoded!.Value.Status.Should().Be(HpWmiBios.SmartAdapterStatus.Error);
+        }
+
+        [Fact]
+        public void SmartAdapterStatus_Includes_ConnectedTypeC()
+        {
+            // Guards the sixth value. Tables sourced from third-party projects commonly stop at 4,
+            // which silently reclassifies a USB-C PD machine as a fault state.
+            ((int)HpWmiBios.SmartAdapterStatus.ConnectedTypeC).Should().Be(5);
+            ((int)HpWmiBios.SmartAdapterStatus.Error).Should().Be(-1);
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Hardware/HpWmiBiosEnumDecodeTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/HpWmiBiosEnumDecodeTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using OmenCore.Hardware;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Hardware
+{
+    /// <summary>
+    /// Decode tests for the two BIOS replies that are cast to an enum: <c>Keyboard 0x01</c> keyboard
+    /// type and <c>Legacy 0x52</c> GPU mode.
+    ///
+    /// These exist because casting a wire byte straight to an enum silently manufactures values the
+    /// enum never declared. The repo has already been bitten by that shape once - SmartAdapterStatus
+    /// was int-backed, so a 0xFF byte decoded to 255 rather than Error and rendered as the literal
+    /// "255" in the UI. The 0xFF keyboard payload below is a real capture from board 8D87.
+    /// </summary>
+    public class HpWmiBiosEnumDecodeTests
+    {
+        // ---- keyboard type -------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(0x00, HpWmiBios.KbdType.Standard)]
+        [InlineData(0x01, HpWmiBios.KbdType.WithNumPad)]
+        [InlineData(0x02, HpWmiBios.KbdType.TenKeyLess)]
+        [InlineData(0x03, HpWmiBios.KbdType.PerKeyRgb)]
+        public void DecodeKeyboardType_Accepts_Every_Declared_Value(byte wire, HpWmiBios.KbdType expected)
+        {
+            HpWmiBios.DecodeKeyboardType(new byte[] { wire, 0, 0, 0 }).Should().Be(expected);
+        }
+
+        [Fact]
+        public void DecodeKeyboardType_Rejects_The_0xFF_Reply_Measured_On_Board_8D87()
+        {
+            // Measured on an OMEN MAX 16 (8D87, BIOS F.07): this board does not answer Keyboard 0x01
+            // and returns 0xFF. Before validation that became (KbdType)255 - not a member, but not a
+            // failure either, so callers had no way to tell it apart from a real answer.
+            HpWmiBios.DecodeKeyboardType(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF })
+                .Should().BeNull("0xFF is not a KbdType and must not be manufactured into one");
+        }
+
+        [Theory]
+        [InlineData(0x04)]
+        [InlineData(0x7F)]
+        [InlineData(0xFE)]
+        public void DecodeKeyboardType_Rejects_Anything_Outside_The_Declared_Range(byte wire)
+        {
+            HpWmiBios.DecodeKeyboardType(new byte[] { wire, 0, 0, 0 }).Should().BeNull();
+        }
+
+        [Fact]
+        public void DecodeKeyboardType_Handles_Missing_And_Empty_Replies()
+        {
+            HpWmiBios.DecodeKeyboardType(null).Should().BeNull();
+            HpWmiBios.DecodeKeyboardType(new byte[0]).Should().BeNull();
+        }
+
+        // ---- GPU mode ------------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(0x00, HpWmiBios.GpuMode.Hybrid)]
+        [InlineData(0x01, HpWmiBios.GpuMode.Discrete)]
+        [InlineData(0x02, HpWmiBios.GpuMode.Optimus)]
+        public void DecodeGpuMode_Accepts_Every_Declared_Value(byte wire, HpWmiBios.GpuMode expected)
+        {
+            HpWmiBios.DecodeGpuMode(new byte[] { wire, 0, 0, 0 }).Should().Be(expected);
+        }
+
+        [Fact]
+        public void DecodeGpuMode_Decodes_The_Hybrid_Reply_Measured_On_Board_8D87()
+        {
+            // Measured: 00 00 00 00 with return code 0. Worth pinning as a decode, but note that on
+            // this transport an all-zero reply is also what an ACPI timeout produces, so the value
+            // being Hybrid is not on its own evidence that a MUX exists to be in hybrid.
+            HpWmiBios.DecodeGpuMode(new byte[] { 0x00, 0x00, 0x00, 0x00 })
+                .Should().Be(HpWmiBios.GpuMode.Hybrid);
+        }
+
+        [Theory]
+        [InlineData(0x03)]
+        [InlineData(0x04)]
+        [InlineData(0xFF)]
+        public void DecodeGpuMode_Rejects_Anything_Outside_The_Declared_Range(byte wire)
+        {
+            HpWmiBios.DecodeGpuMode(new byte[] { wire, 0, 0, 0 })
+                .Should().BeNull("GpuMode declares only 0x00-0x02");
+        }
+
+        [Fact]
+        public void DecodeGpuMode_Handles_Missing_And_Empty_Replies()
+        {
+            HpWmiBios.DecodeGpuMode(null).Should().BeNull();
+            HpWmiBios.DecodeGpuMode(new byte[0]).Should().BeNull();
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Hardware/HpWmiBiosSystemDesignDataTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/HpWmiBiosSystemDesignDataTests.cs
@@ -1,0 +1,156 @@
+using FluentAssertions;
+using OmenCore.Hardware;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Hardware
+{
+    /// <summary>
+    /// Decode tests for HP's <c>SystemDesignData</c> block (<c>Default 0x28</c>).
+    ///
+    /// The reply used throughout is a real capture from board 8D87 (BIOS F.07). The command returns
+    /// 128 bytes and OmenCore historically read exactly one of them.
+    /// </summary>
+    public class HpWmiBiosSystemDesignDataTests
+    {
+        /// <summary>
+        /// Measured 0x28 reply, padded to the 128 bytes the firmware actually returns.
+        /// 4A 01 = 330 W shipping adapter, 3A = unused, 01 = thermal policy V1, 03 = SW fan control
+        /// + extreme mode support, 00 = PL4 default, 01 = BIOS OC support, 07 = GPU mode switch,
+        /// 3C = 60 W CPU budget with GPU, 00 = load lines, 03 00 = sensor/hotkey bits.
+        /// </summary>
+        private static byte[] Board8D87Reply()
+        {
+            var reply = new byte[128];
+            byte[] head = { 0x4A, 0x01, 0x3A, 0x01, 0x03, 0x00, 0x01, 0x07, 0x3C, 0x00, 0x03, 0x00 };
+            head.CopyTo(reply, 0);
+            return reply;
+        }
+
+        [Fact]
+        public void DecodeSystemDesignData_Decodes_Board8D87_Capture()
+        {
+            var decoded = HpWmiBios.DecodeSystemDesignData(Board8D87Reply());
+
+            decoded.Should().NotBeNull();
+            var design = decoded!.Value;
+
+            design.ShippingAdapterPowerRatingWatts.Should().Be(330);
+            design.ThermalPolicyVersion.Should().Be(HpWmiBios.ThermalPolicyVersion.V1);
+            design.IsSwFanControlSupport.Should().BeTrue();
+            design.IsExtremeModeSupport.Should().BeTrue();
+            design.IsExtremeModeUnlock.Should().BeFalse();
+            design.IsDTBiosControl.Should().BeFalse();
+            design.IsTwoBytePL4Support.Should().BeFalse();
+            design.PL4DefaultValue.Should().Be(0);
+            design.IsBiosDefinedOcSupport.Should().BeTrue();
+            design.GpuModeSwitch.Should().Be(0x07);
+            design.DefaultCpuPowerLimitWithGpuWatts.Should().Be(60);
+            design.LoadLineSupportLevels.Should().Be(0);
+            design.DefaultLoadLine.Should().Be(0);
+
+            // Byte 10 is 0x03 and byte 11 is 0x00 on this board. These five were omitted from an
+            // earlier version of this test, which is exactly where a decode bug hid: reading
+            // ChangeIrSensorToBoard as bit 0 alone returned true here, where HP's two-bit rule
+            // (bit 0 clear AND bit 1 set) returns false. Assert them against the unmodified capture.
+            design.ChangeIrSensorToBoard.Should().BeFalse();
+            design.IsPchOverheatSupport.Should().BeFalse();
+            design.IsVrSensorSupport.Should().BeFalse();
+            design.IsHotkeySupportFnP.Should().BeFalse();
+            design.IsHotkeySupportFnF1.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(0x00, false)] // both clear
+        [InlineData(0x01, false)] // bit 0 set   -> excluded by the "bit 0 clear" half
+        [InlineData(0x02, true)]  // bit 1 only  -> the only pattern that qualifies
+        [InlineData(0x03, false)] // both set    -> this board; the case a bit-0-only read gets wrong
+        public void ChangeIrSensorToBoard_RequiresBit0Clear_AndBit1Set(byte byte10, bool expected)
+        {
+            var reply = Board8D87Reply();
+            reply[10] = byte10;
+
+            HpWmiBios.DecodeSystemDesignData(reply)!
+                .Value.ChangeIrSensorToBoard.Should().Be(expected);
+        }
+
+        [Fact]
+        public void ShippingAdapterPowerRating_Is_LittleEndian_Watts_Not_A_Flag_Field()
+        {
+            // 0x014A = 330. This field was once read as a 16-bit flag field whose decimal value
+            // happened to be 330; HP's own accessor compares it numerically against 200 and 280,
+            // which settles it as watts.
+            HpWmiBios.DecodeSystemDesignData(Board8D87Reply())!
+                .Value.ShippingAdapterPowerRatingWatts.Should().Be(330);
+
+            var twoHundredEighty = Board8D87Reply();
+            twoHundredEighty[0] = 0x18;
+            twoHundredEighty[1] = 0x01; // 0x0118 = 280
+            HpWmiBios.DecodeSystemDesignData(twoHundredEighty)!
+                .Value.ShippingAdapterPowerRatingWatts.Should().Be(280);
+        }
+
+        [Fact]
+        public void IsTwoBytePL4Support_Reads_Byte4_Bit4()
+        {
+            // This bit changes the wire format of Default 0x29 SetPL4 from one byte to two. Nothing
+            // issues 0x29 today; the bit is decoded so that whatever does can branch on it rather
+            // than assume a width. It is not board-specific - any board may set it.
+            var reply = Board8D87Reply();
+            reply[4] |= 0x10;
+
+            var design = HpWmiBios.DecodeSystemDesignData(reply)!.Value;
+            design.IsTwoBytePL4Support.Should().BeTrue();
+
+            // and the neighbouring bits in the same byte are unaffected
+            design.IsSwFanControlSupport.Should().BeTrue();
+            design.IsExtremeModeSupport.Should().BeTrue();
+            design.IsExtremeModeUnlock.Should().BeFalse();
+            design.IsDTBiosControl.Should().BeFalse();
+        }
+
+        [Fact]
+        public void LoadLine_Splits_Byte9_Into_Nibbles()
+        {
+            var reply = Board8D87Reply();
+            reply[9] = 0x34; // low nibble = supported levels, high nibble = default
+
+            var design = HpWmiBios.DecodeSystemDesignData(reply)!.Value;
+            design.LoadLineSupportLevels.Should().Be(4);
+            design.DefaultLoadLine.Should().Be(3);
+        }
+
+        [Fact]
+        public void DecodeSystemDesignData_Reads_Sensor_And_Hotkey_Bits()
+        {
+            var reply = Board8D87Reply();
+            reply[10] = 0x0E; // bit 1 IR sensor (bit 0 clear), bit 2 PCH overheat, bit 3 VR sensor
+            reply[11] = 0x03; // bit 0 Fn+P, bit 1 Fn+F1
+
+            var design = HpWmiBios.DecodeSystemDesignData(reply)!.Value;
+            design.ChangeIrSensorToBoard.Should().BeTrue();
+            design.IsPchOverheatSupport.Should().BeTrue();
+            design.IsVrSensorSupport.Should().BeTrue();
+            design.IsHotkeySupportFnP.Should().BeTrue();
+            design.IsHotkeySupportFnF1.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DecodeSystemDesignData_Returns_Null_When_Reply_Is_Too_Short()
+        {
+            // The existing thermal-policy read only needed 9 bytes. Firmware that answers with fewer
+            // than the 12 HP's accessors cover must not be decoded past what it sent.
+            HpWmiBios.DecodeSystemDesignData(null).Should().BeNull();
+            HpWmiBios.DecodeSystemDesignData(new byte[11]).Should().BeNull();
+            HpWmiBios.DecodeSystemDesignData(new byte[12]).Should().NotBeNull();
+        }
+
+        [Fact]
+        public void DecodeSystemDesignData_Keeps_Only_The_First_12_Bytes_Of_Raw_Data()
+        {
+            var design = HpWmiBios.DecodeSystemDesignData(Board8D87Reply())!.Value;
+
+            design.RawData.Should().HaveCount(12);
+            design.RawData.Should().Equal(0x4A, 0x01, 0x3A, 0x01, 0x03, 0x00, 0x01, 0x07, 0x3C, 0x00, 0x03, 0x00);
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Hardware/KeyboardLightingTopologyTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/KeyboardLightingTopologyTests.cs
@@ -1,0 +1,147 @@
+using System;
+using FluentAssertions;
+using OmenCore.Hardware;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Hardware
+{
+    /// <summary>
+    /// Pins the keyboard lighting topology decode and how it maps onto capability flags.
+    ///
+    /// The behaviour these guard was measured on board 8D87 (OMEN MAX 16, 2025 AMD): the topology
+    /// probe (Default 0x2B) returns a stable 0x03 = RgbPerKey, while the command usually called
+    /// "GetKbdType" (Keyboard 0x01) returns a byte that grows on every identical call and
+    /// saturates at 0xFF. The point of these tests is that a per-key board must never come out of
+    /// detection claiming four-zone lighting.
+    /// </summary>
+    public class KeyboardLightingTopologyTests
+    {
+        [Theory]
+        [InlineData(0xFF, HpWmiBios.KeyboardLightingType.None)]        // -1 as a signed byte
+        [InlineData(0x00, HpWmiBios.KeyboardLightingType.Normal)]
+        [InlineData(0x01, HpWmiBios.KeyboardLightingType.FourZoneWithNumpad)]
+        [InlineData(0x02, HpWmiBios.KeyboardLightingType.FourZoneWithoutNumpad)]
+        [InlineData(0x03, HpWmiBios.KeyboardLightingType.RgbPerKey)]
+        [InlineData(0x04, HpWmiBios.KeyboardLightingType.OneZoneWithNumpad)]
+        [InlineData(0x05, HpWmiBios.KeyboardLightingType.OneZoneWithoutNumpad)]
+        public void LightingType_CoversHpsEnumeration(byte raw, HpWmiBios.KeyboardLightingType expected)
+        {
+            ((HpWmiBios.KeyboardLightingType)(sbyte)raw).Should().Be(expected);
+        }
+
+        [Fact]
+        public void LightingType_None_IsMinusOne_NotTwoFiftyFive()
+        {
+            // The probe returns a single byte and None is -1, so it arrives as 0xFF. Decoding it
+            // unsigned would land on 255, which is not a declared value, and the board would be
+            // reported as "unknown topology" rather than "no keyboard lighting".
+            ((int)HpWmiBios.KeyboardLightingType.None).Should().Be(-1);
+            ((HpWmiBios.KeyboardLightingType)unchecked((sbyte)0xFF)).Should().Be(HpWmiBios.KeyboardLightingType.None);
+        }
+
+        [Fact]
+        public void MapLightingTypeToKbdType_OnlyClaimsPerKey()
+        {
+            // KbdType describes key LAYOUT, the topology describes LIGHTING. Only per-key has an
+            // honest counterpart; a four-zone keyboard could have any layout, so claiming one
+            // would be inventing an answer the probe never gave.
+            HpWmiBios.MapLightingTypeToKbdType(HpWmiBios.KeyboardLightingType.RgbPerKey)
+                .Should().Be(HpWmiBios.KbdType.PerKeyRgb);
+
+            foreach (HpWmiBios.KeyboardLightingType t in Enum.GetValues<HpWmiBios.KeyboardLightingType>())
+            {
+                if (t == HpWmiBios.KeyboardLightingType.RgbPerKey) continue;
+                HpWmiBios.MapLightingTypeToKbdType(t).Should().BeNull(
+                    $"{t} says nothing about the key layout");
+            }
+        }
+
+        [Fact]
+        public void MapLightingTypeToKbdType_NoAnswerStaysNoAnswer()
+        {
+            HpWmiBios.MapLightingTypeToKbdType(null).Should().BeNull();
+        }
+
+        [Fact]
+        public void DecodeKeyboardType_RejectsTheAccumulatorValues()
+        {
+            // The exact byte sequence measured from ten identical Keyboard 0x01 calls on 8D87.
+            // Every one of them must be rejected: they are not keyboard types, and the older code
+            // cast this byte straight to the enum.
+            foreach (byte raw in new byte[] { 0x0D, 0x0F, 0x1F, 0x3F, 0x7F, 0xFF })
+            {
+                HpWmiBios.DecodeKeyboardType(new[] { raw })
+                    .Should().BeNull($"0x{raw:X2} is accumulator residue, not a KbdType");
+            }
+        }
+
+        [Fact]
+        public void DecodeKeyboardType_StillAcceptsRealValues()
+        {
+            // Boards where Keyboard 0x01 does answer must keep working.
+            HpWmiBios.DecodeKeyboardType(new byte[] { 0x00 }).Should().Be(HpWmiBios.KbdType.Standard);
+            HpWmiBios.DecodeKeyboardType(new byte[] { 0x03 }).Should().Be(HpWmiBios.KbdType.PerKeyRgb);
+        }
+
+        [Fact]
+        public void Board8D87_IsPerKeyAndNotFourZone()
+        {
+            var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
+
+            caps.HasPerKeyRgb.Should().BeTrue("the topology probe returns RgbPerKey on this board");
+            caps.HasFourZoneRgb.Should().BeFalse(
+                "HP's own four-zone gate returns false for lighting type 3, and on this chassis " +
+                "the four-zone commands drive the light bar instead of the keyboard");
+            caps.HasKeyboardBacklight.Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Boards known to claim both, which this test deliberately does not fail on.
+        ///
+        /// 8D41 is the Intel sibling of 8D87 - same OMEN MAX 16 2025 chassis, Intel Core Ultra
+        /// instead of Ryzen AI - and it is marked UserVerified, so the entry is somebody's real
+        /// report rather than a guess. On 8D87 the same-looking pair turned out to mean "per-key
+        /// keyboard plus a four-zone LIGHT BAR", and 8D41 very likely has that same arrangement.
+        /// But "very likely" is not what UserVerified means, and nobody here has an 8D41 to run
+        /// the topology probe on, so its flags are left exactly as its owner reported them.
+        ///
+        /// Settling it needs one command from an 8D41 owner: tools/LightingProbe --wmi. If the
+        /// topology reads RgbPerKey, HasFourZoneRgb should become false and HasLightBar true,
+        /// and this entry should come off the list.
+        /// </summary>
+        private static readonly string[] UnsettledDualClaimBoards = { "8D41" };
+
+        [Fact]
+        public void NoModelClaimsBothPerKeyAndFourZoneKeyboardRgb()
+        {
+            // They are different command surfaces. A board claiming both offers the user a zone
+            // control that writes somewhere its keyboard does not listen - which is worse than no
+            // control, because it reports success.
+            foreach (var model in ModelCapabilityDatabase.GetAllModels())
+            {
+                if (!model.HasPerKeyRgb) continue;
+                if (Array.Exists(UnsettledDualClaimBoards,
+                                 id => string.Equals(id, model.ProductId, StringComparison.OrdinalIgnoreCase)))
+                {
+                    continue;
+                }
+
+                model.HasFourZoneRgb.Should().BeFalse(
+                    $"{model.ProductId} ({model.ModelName}) claims per-key AND four-zone keyboard RGB");
+            }
+        }
+
+        [Fact]
+        public void TheDualClaimExclusionListStaysHonest()
+        {
+            // If someone fixes one of these entries, the exclusion has to go with it - otherwise
+            // the list quietly becomes a place where new violations can hide.
+            foreach (string id in UnsettledDualClaimBoards)
+            {
+                var model = ModelCapabilityDatabase.GetCapabilities(id);
+                (model.HasPerKeyRgb && model.HasFourZoneRgb).Should().BeTrue(
+                    $"{id} no longer claims both, so it should be removed from UnsettledDualClaimBoards");
+            }
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Hardware/ModelCapabilityDatabase8D87Tests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/ModelCapabilityDatabase8D87Tests.cs
@@ -16,10 +16,10 @@ namespace OmenCoreApp.Tests.Hardware
             var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
 
             caps.ProductId.Should().Be("8D87");
-            // Not flipped: fan curves and performance modes are still inherited because confirming
-            // them needs writes, and UserVerified is all-or-nothing so it must report the weakest
-            // claim in the entry. See docs/8D87-VERIFICATION-CHECKLIST.md for exactly what remains.
-            caps.UserVerified.Should().BeFalse();
+            // Flipped once the last inherited field - the named performance modes - was measured in
+            // delivered watts rather than return codes. Every board-specific claim in the entry is
+            // now owner-verified on the hardware.
+            caps.UserVerified.Should().BeTrue();
 
             // The EC on this board is memory-mapped and does not follow the legacy offset layout, so
             // neither EC fan control nor EC power-limit writes may be attempted on it. The power-limit
@@ -28,11 +28,43 @@ namespace OmenCoreApp.Tests.Hardware
             caps.SupportsFanControlEc.Should().BeFalse();
             caps.SupportsEcPowerLimits.Should().BeFalse();
 
-            // AMD Ryzen AI part: the Intel MSR undervolt path does not apply.
-            caps.SupportsUndervolt.Should().BeFalse();
+            // True: this part undervolts via AMD Curve Optimizer, owner-confirmed. The field
+            // describes the hardware, not whether OmenCore's SMU backend can drive it today -
+            // ShowUndervolt already ANDs this with UndervoltRuntimeReady, so backend gaps surface
+            // as AmdUndervoltProvider's RuntimeBlockReason rather than as a false capability claim.
+            // RyzenControl's exclusion is (family 0x1A && model >= 0x40); this part is family 0x1A
+            // model 0x24, below that bound, so Curve Optimizer is not ruled out here either.
+            caps.SupportsUndervolt.Should().BeTrue();
+
+            // Intel thermal-control-circuit knob; there is no such register on a Ryzen AI 9 HX 375.
+            caps.SupportsTccOffset.Should().BeFalse();
+
+            // Default 0x28 byte 4 = 0x03: ExtremeMode is SUPPORTED (bit 1) but ExtremeModeUnlock
+            // (bit 2) is CLEAR, so the effective capability is false. Guards against a later reader
+            // seeing "ExtremeMode supported" in the capability block and flipping this.
+            caps.SupportsOverboost.Should().BeFalse();
 
             // Independently corroborated by the observed performance-mode decay on this machine.
             caps.MaxModeDropChecksBeforeReapply.Should().Be(1);
+        }
+
+        [Fact]
+        public void Board8D87_PerformanceModes_Are_The_Three_The_Wmi_Path_Can_Actually_Send()
+        {
+            var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
+
+            // "L5P" was inherited from the adjacent AK0003NR entry and is NOT sendable: there is no
+            // L5P member in HpWmiBios.FanMode at all, so SetPerformanceMode can never produce it.
+            // The name resolves only inside OghServiceProxy.ThermalPolicy, a different transport.
+            caps.PerformanceModes.Should().Equal("Default", "Performance", "Cool");
+            caps.PerformanceModes.Should().NotContain("L5P");
+
+            // Measured in delivered watts on the hardware: SetFanMode writes NPCF.MODE and the
+            // firmware consumes (MODE & 0x0F), so Default (0x30) and Cool (0x50) both select
+            // nibble 0 and delivered ~102 W, while Performance (0x31) selects nibble 1 and pinned
+            // enforced.power.limit at 175 W. All three return RTCD 0, so the return code never
+            // distinguished them - Cool differs as fan policy, not as a power tier.
+            caps.SupportsPerformanceModes.Should().BeTrue();
         }
 
         [Fact]
@@ -68,6 +100,13 @@ namespace OmenCoreApp.Tests.Hardware
             var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
 
             caps.HasPerKeyRgb.Should().BeTrue();
+
+            // The four-zone flag gates the four-zone KEYBOARD path, which HP's own
+            // FourZoneHelper.IsSupported refuses for lighting type 3. The four-zone commands are
+            // not inert on this chassis though - owner-observed, they drive the LIGHT BAR and leave
+            // the keyboard alone, which is why "four-zone succeeded" was never evidence here.
+            caps.HasFourZoneRgb.Should().BeFalse();
+            caps.HasLightBar.Should().BeTrue();
             caps.HasKeyboardBacklight.Should().BeTrue();
             caps.HasFourZoneRgb.Should().BeFalse("HP gates the four-zone path off for lighting type 3");
         }

--- a/src/OmenCoreApp.Tests/Hardware/ModelCapabilityDatabase8D87Tests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/ModelCapabilityDatabase8D87Tests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+using OmenCore.Hardware;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Hardware
+{
+    /// <summary>
+    /// Pins the board 8D87 profile (OMEN MAX 16, 2025 AMD) to what was measured on the hardware,
+    /// and pins the Vibrance25C1 platform list that bounds any raw EC offset derived from it.
+    /// </summary>
+    public class ModelCapabilityDatabase8D87Tests
+    {
+        [Fact]
+        public void Board8D87_Profile_Matches_What_Was_Measured_On_Hardware()
+        {
+            var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
+
+            caps.ProductId.Should().Be("8D87");
+            // Not flipped: fan curves and performance modes are still inherited because confirming
+            // them needs writes, and UserVerified is all-or-nothing so it must report the weakest
+            // claim in the entry. See docs/8D87-VERIFICATION-CHECKLIST.md for exactly what remains.
+            caps.UserVerified.Should().BeFalse();
+
+            // The EC on this board is memory-mapped and does not follow the legacy offset layout, so
+            // neither EC fan control nor EC power-limit writes may be attempted on it. The power-limit
+            // flag is not merely unconfirmed here - forcing that block was measured to change nothing,
+            // because it is a mirror the SMU never reads back.
+            caps.SupportsFanControlEc.Should().BeFalse();
+            caps.SupportsEcPowerLimits.Should().BeFalse();
+
+            // AMD Ryzen AI part: the Intel MSR undervolt path does not apply.
+            caps.SupportsUndervolt.Should().BeFalse();
+
+            // Independently corroborated by the observed performance-mode decay on this machine.
+            caps.MaxModeDropChecksBeforeReapply.Should().Be(1);
+        }
+
+        [Fact]
+        public void Board8D87_MaxFanLevel_Is_The_Measured_V1_Ceiling_Not_The_V2_Percentage()
+        {
+            // Regression guard, and the same defect class as
+            // GetCapabilities_8C77_Wf1xxx_UsesExactV1WmiProfileNotV2Mismatch.
+            //
+            // This board reports thermal policy V1 and rejects the V2 fan commands outright (0x37 ->
+            // RTCD 6, 0x38 -> RTCD 4, at every input and output buffer size). Levels therefore come
+            // from the V1 0x2D fallback in krpm/100. MapFanPercentToWmiLevel scales a requested
+            // percent by MaxFanLevel, so leaving this at 100 makes it an identity and a request for
+            // 50% writes raw level 50 - about 5000 rpm on hardware whose ceiling is 6000.
+            //
+            // 60 is measured: 0x2D against the EC tachometers and OGH's own readout at four points,
+            // 0/0, 22/2220, 47/4680 and 60/6000, linear within ~1%.
+            var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
+
+            caps.MaxFanLevel.Should().Be(60);
+            caps.MaxFanLevel.Should().NotBe(100, "V1 levels are krpm/100, not a percentage");
+            caps.FanZoneCount.Should().Be(2);
+            caps.SupportsRpmReadback.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Board8D87_Is_PerKey_Rgb_And_Therefore_Not_FourZone()
+        {
+            // The keyboard topology probe - class 0x00020008, command 0x2B, null input, 4-byte
+            // return - reads 0x03 = NbKeyboardLightingType.RgbPerKey, stable across repeated reads.
+            // HP's own FourZoneHelper.IsSupported returns false for type 3, so the four-zone path
+            // does not drive this keyboard. HasFourZoneRgb defaults to true on ModelCapabilities,
+            // so it must be set explicitly here or the entry claims both at once.
+            var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
+
+            caps.HasPerKeyRgb.Should().BeTrue();
+            caps.HasKeyboardBacklight.Should().BeTrue();
+            caps.HasFourZoneRgb.Should().BeFalse("HP gates the four-zone path off for lighting type 3");
+        }
+
+        [Fact]
+        public void Board8D87_Has_A_Mux_But_Not_Advanced_Optimus()
+        {
+            // These two flags are different claims and this board splits them, so they are pinned
+            // together - setting either from the other is the mistake this test exists to catch.
+            //
+            // HasMuxSwitch: measured by switching BIOS setup from Hybrid to Discrete and back, with
+            // a reboot each way. In Discrete the sole display is the internal panel (CMN1652) at its
+            // native 2560x1600 driven by the RTX 5080, the Radeon reports no active mode, and
+            // nvidia-smi reports display_active = Enabled. Legacy 0x52 byte 0 moves 0x00 -> 0x01 and
+            // back. The panel changes which GPU drives it, which is what the flag claims.
+            //
+            // SupportsAdvancedOptimus: false, and inherited true. Advanced Optimus is the *dynamic*
+            // form - the mux moves under live ACPI control, no reboot. The AMD_PBS_SETUP Smart Mux
+            // block (0xB6 Support, 0xC7 Acpi Control, 0xC8 Display Panel Multiplexer, 0xCA MDM
+            // Support Level) reads 0 in Hybrid, in Discrete, and again after returning to Hybrid.
+            // It stays off through a switch that demonstrably works, so routing is decided at boot.
+            var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
+
+            caps.HasMuxSwitch.Should().BeTrue(
+                "in Discrete the internal panel is driven by the dGPU and Legacy 0x52 reads 0x01");
+            caps.SupportsAdvancedOptimus.Should().BeFalse(
+                "the Smart Mux block stays Disabled through a working mode switch, so there is no runtime control surface");
+        }
+
+        [Fact]
+        public void Board8D87_Does_Not_Opt_Into_The_Decoupled_Thermal_Policy_Fallback()
+        {
+            // Deliberate: that flag changes fan/thermal behaviour and is gated on field confirmation
+            // of the behaviour itself, which this board has not had. Read-only identification work
+            // does not license it.
+            ModelCapabilityDatabase.GetCapabilities("8D87")
+                .AllowDecoupledWmiThermalPolicyFallback.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Vibrance25C1_Platform_List_Covers_The_MAX_Sibling_Boards()
+        {
+            ModelCapabilityDatabase.Vibrance25C1BoardIds.Should()
+                .BeEquivalentTo(new[] { "8D87", "8D88", "8DD5", "8DD6" });
+
+            ModelCapabilityDatabase.IsVibrance25C1Board("8D87").Should().BeTrue();
+            ModelCapabilityDatabase.IsVibrance25C1Board("8d88").Should().BeTrue("board IDs are matched case-insensitively");
+            ModelCapabilityDatabase.IsVibrance25C1Board("8A44").Should().BeFalse();
+            ModelCapabilityDatabase.IsVibrance25C1Board(null).Should().BeFalse();
+            ModelCapabilityDatabase.IsVibrance25C1Board("").Should().BeFalse();
+        }
+
+        [Fact]
+        public void Vibrance25C1_Siblings_Are_Not_Given_Invented_Capability_Profiles()
+        {
+            // The list is a scope boundary for raw offsets, not a claim about these boards. Only 8D87
+            // has been measured; adding database entries for the others would assert fan, RGB and MUX
+            // behaviour nobody has confirmed. If a real owner of one of them submits a profile, this
+            // test is the thing to update - deliberately, not incidentally.
+            foreach (var boardId in new[] { "8D88", "8DD5", "8DD6" })
+            {
+                ModelCapabilityDatabase.GetCapabilities(boardId).ProductId
+                    .Should().NotBe(boardId, $"no measured profile exists for {boardId}");
+            }
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Hardware/ModelCapabilityDatabaseTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/ModelCapabilityDatabaseTests.cs
@@ -33,7 +33,10 @@ namespace OmenCoreApp.Tests.Hardware
         [InlineData("8A25", OmenModelFamily.Victus)]
         [InlineData("8C58", OmenModelFamily.Transcend)]
         [InlineData("8E41", OmenModelFamily.Transcend)]
-        [InlineData("8D87", OmenModelFamily.OMEN2024Plus)]
+        // 8D87 is deliberately NOT in this list: the shared assertion below pins newly added
+        // entries as UserVerified = false, and 8D87 is now fully owner-verified. Its ProductId,
+        // Family and UserVerified are covered by GetCapabilities_8D87_OmenMaxAk0xxx_* below and by
+        // ModelCapabilityDatabase8D87Tests, so nothing is lost by removing the row.
         [InlineData("8574", OmenModelFamily.Legacy)]
         [InlineData("8600", OmenModelFamily.Legacy)]
         [InlineData("8787", OmenModelFamily.Legacy)]
@@ -97,8 +100,8 @@ namespace OmenCoreApp.Tests.Hardware
             caps.MaxModeDropChecksBeforeReapply.Should().Be(1,
                 "8D87 field chat reports fans become disobedient after a while, so MAX-series Max hold should reassert on first low telemetry sample");
             caps.HasPerKeyRgb.Should().BeTrue();
-            caps.UserVerified.Should().BeFalse(
-                "power and thermal fields are owner-verified but the keyboard/RGB and fan-range fields are not, and the flag is all-or-nothing");
+            caps.UserVerified.Should().BeTrue(
+                "every board-specific claim in the entry is now owner-verified on the hardware, the last of them being the performance modes measured in delivered watts");
         }
 
         [Fact]

--- a/src/OmenCoreApp.Tests/Hardware/ModelCapabilityDatabaseTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/ModelCapabilityDatabaseTests.cs
@@ -97,7 +97,8 @@ namespace OmenCoreApp.Tests.Hardware
             caps.MaxModeDropChecksBeforeReapply.Should().Be(1,
                 "8D87 field chat reports fans become disobedient after a while, so MAX-series Max hold should reassert on first low telemetry sample");
             caps.HasPerKeyRgb.Should().BeTrue();
-            caps.UserVerified.Should().BeFalse();
+            caps.UserVerified.Should().BeFalse(
+                "power and thermal fields are owner-verified but the keyboard/RGB and fan-range fields are not, and the flag is all-or-nothing");
         }
 
         [Fact]

--- a/src/OmenCoreApp.Tests/Hardware/WmiV2VerificationTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/WmiV2VerificationTests.cs
@@ -835,6 +835,52 @@ namespace OmenCoreApp.Tests.Hardware
         }
 
         [Fact]
+        public void SetPerformanceMode_WhenReadbackNonStrict_DoesNotReadTheLegacyFanModeOffsetAtAll()
+        {
+            // The mismatch was already ignored, but only after three reads of EC 0x95 and two 40 ms
+            // sleeps, then a WARN pair - per fan-mode change. On a board where that offset does not
+            // hold the fan mode (8D87's EC is memory-mapped; 0x95 reads 0x02 where 0x30 is expected)
+            // the answer could not be used either way, so issuing the transaction was pure cost and
+            // the WARN was noise about a non-event.
+            var fake = new ModeCaptureFakeWmiBios();
+            var ec = new FanModeReadbackEcAccess(0x30);
+            var controller = new WmiFanController(
+                null,
+                null,
+                0,
+                injectedWmiBios: fake,
+                ecAccess: ec,
+                strictFanModeReadback: false);
+
+            controller.SetPerformanceMode("Performance").Should().BeTrue();
+
+            ec.ReadAddresses.Should().NotContain((ushort)0x95,
+                "a profile that cannot act on the readback should not spend an EC transaction taking it");
+        }
+
+        [Fact]
+        public void SetPerformanceMode_WhenReadbackStrict_StillReadsTheFanModeOffset()
+        {
+            // Guard on the other side: the skip must be scoped to non-strict profiles. Boards where
+            // the readback IS authoritative must keep taking it, or the confirmation above becomes
+            // unreachable and SetPerformanceMode would project unverified modes as applied.
+            var fake = new ModeCaptureFakeWmiBios();
+            var ec = new FanModeReadbackEcAccess(0x31);
+            var controller = new WmiFanController(
+                null,
+                null,
+                0,
+                injectedWmiBios: fake,
+                ecAccess: ec,
+                strictFanModeReadback: true);
+
+            controller.SetPerformanceMode("Performance").Should().BeTrue();
+
+            ec.ReadAddresses.Should().Contain((ushort)0x95,
+                "strict profiles depend on this readback to confirm the mode actually took");
+        }
+
+        [Fact]
         public void ApplyPreset_V1AutoHandoff_ClearsManualFloorAfterTransitionKick()
         {
             var fake = new V1AutoHandoffFakeWmiBios();
@@ -902,9 +948,18 @@ namespace OmenCoreApp.Tests.Hardware
                 _fanMode = fanMode;
             }
 
+            /// <summary>Addresses read through this stub, in order.</summary>
+            public System.Collections.Generic.List<ushort> ReadAddresses { get; } = new();
+
             public bool IsAvailable => true;
             public bool Initialize(string devicePath) => true;
-            public byte ReadByte(ushort address) => address == 0x95 ? _fanMode : (byte)0x00;
+
+            public byte ReadByte(ushort address)
+            {
+                ReadAddresses.Add(address);
+                return address == 0x95 ? _fanMode : (byte)0x00;
+            }
+
             public void WriteByte(ushort address, byte value) { }
             public void Dispose() { }
         }

--- a/src/OmenCoreApp.Tests/Hardware/WmiV2VerificationTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/WmiV2VerificationTests.cs
@@ -730,6 +730,31 @@ namespace OmenCoreApp.Tests.Hardware
         }
 
         [Theory]
+        [InlineData(HpWmiBios.GpuPowerLevel.Minimum)]
+        [InlineData(HpWmiBios.GpuPowerLevel.Medium)]
+        [InlineData(HpWmiBios.GpuPowerLevel.Maximum)]
+        [InlineData(HpWmiBios.GpuPowerLevel.Extended3)]
+        [InlineData(HpWmiBios.GpuPowerLevel.Extended4)]
+        public void BuildGpuPowerPayload_KeepsDStateAndGpsTemperatureBytesFixed(HpWmiBios.GpuPowerLevel level)
+        {
+            var payload = HpWmiBios.BuildGpuPowerPayload(level);
+
+            // dState: hardcoded to 1 to match HP, and not a knob - MAX-series firmware overwrites
+            // the ACPI field this sets from the EC's adapter verdict during the same call.
+            payload.dState.Should().Be(0x01);
+
+            // Byte 3 is a GPS temperature threshold in °C, not a spare - the output of HP's IRHandler
+            // loop. HP emits 87 only while the chassis IR sensor reads cool, and revises it down to
+            // 75 on overheat. This app has no such loop, so sending 87 would pin the firmware in the
+            // most permissive state permanently rather than reproduce HP's behaviour - and the 0x21
+            // readback cannot observe byte 3, so it could not be verified by outcome either.
+            //
+            // Held at 0 until someone measures. This assertion exists so that a future change is
+            // deliberate rather than discovered in a field report.
+            payload.peakTemperature.Should().Be(0x00);
+        }
+
+        [Theory]
         [InlineData(HpWmiBios.GpuPowerLevel.Minimum, false, 0, true)]
         [InlineData(HpWmiBios.GpuPowerLevel.Medium, true, 0, true)]
         [InlineData(HpWmiBios.GpuPowerLevel.Maximum, true, 1, true)]

--- a/src/OmenCoreApp.Tests/Services/BatteryInfoProviderTests.cs
+++ b/src/OmenCoreApp.Tests/Services/BatteryInfoProviderTests.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+using OmenCore.Services;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Services
+{
+    /// <summary>
+    /// The dashboard displayed a hardcoded 0 battery cycles on a machine whose battery reports
+    /// 14. The reading itself needs real WMI, so what is pinned here is the part that made the
+    /// old code wrong independently of any hardware: treating "unknown" and "zero" as the same
+    /// value. A new battery legitimately reads 0 cycles.
+    /// </summary>
+    public class BatteryInfoProviderTests
+    {
+        [Fact]
+        public void HealthPercent_IsFullChargeOverDesign()
+        {
+            // The measured values from the board that prompted this: 79416 of 83029 mWh.
+            var info = new BatteryInfoProvider.BatteryInfo
+            {
+                DesignedCapacityMilliwattHours = 83029,
+                FullChargedCapacityMilliwattHours = 79416
+            };
+
+            info.HealthPercent.Should().BeApproximately(95.65, 0.01);
+        }
+
+        [Theory]
+        [InlineData(null, 79416)]
+        [InlineData(83029, null)]
+        [InlineData(null, null)]
+        public void HealthPercent_IsUnknown_WhenEitherCapacityIsMissing(int? design, int? full)
+        {
+            var info = new BatteryInfoProvider.BatteryInfo
+            {
+                DesignedCapacityMilliwattHours = design,
+                FullChargedCapacityMilliwattHours = full
+            };
+
+            info.HealthPercent.Should().BeNull("half a ratio is not a health figure");
+        }
+
+        [Fact]
+        public void HealthPercent_IsUnknown_RatherThanInfinite_WhenDesignCapacityIsZero()
+        {
+            var info = new BatteryInfoProvider.BatteryInfo
+            {
+                DesignedCapacityMilliwattHours = 0,
+                FullChargedCapacityMilliwattHours = 79416
+            };
+
+            info.HealthPercent.Should().BeNull();
+        }
+
+        [Fact]
+        public void HealthPercent_IsNotClampedTo100()
+        {
+            // A pack reporting slightly over design is real and common. Trimming it to 100
+            // would hide a miscalibrated gauge behind a perfect-looking number.
+            var info = new BatteryInfoProvider.BatteryInfo
+            {
+                DesignedCapacityMilliwattHours = 80000,
+                FullChargedCapacityMilliwattHours = 82000
+            };
+
+            info.HealthPercent.Should().BeApproximately(102.5, 0.01);
+        }
+
+        [Fact]
+        public void ZeroCycles_IsAValue_NotAnAbsentReading()
+        {
+            // The distinction the old code collapsed: a brand-new battery reads 0, and that is
+            // not the same as a controller that declines to answer.
+            var newBattery = new BatteryInfoProvider.BatteryInfo { CycleCount = 0 };
+            var noReading = new BatteryInfoProvider.BatteryInfo { CycleCount = null };
+
+            newBattery.CycleCount.Should().Be(0);
+            newBattery.CycleCount.Should().NotBeNull();
+            noReading.CycleCount.Should().BeNull();
+        }
+
+        [Fact]
+        public void Get_DoesNotThrow_WhateverTheMachineReports()
+        {
+            // Runs against real WMI. The assertion is only that an unreadable counter is an
+            // expected outcome rather than an exception - this is called on every UI tick and
+            // on hardware with no battery at all.
+            var act = () => BatteryInfoProvider.Get();
+
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Services/FanChartUnitsTests.cs
+++ b/src/OmenCoreApp.Tests/Services/FanChartUnitsTests.cs
@@ -1,0 +1,88 @@
+using System.Reflection;
+using FluentAssertions;
+using OmenCore.Hardware;
+using OmenCore.Models;
+using OmenCore.Services;
+using OmenCore.Services.Diagnostics;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Services
+{
+    // Reported on board 8D87: the dashboard "Fan Speeds" card read 28 while the fans were turning
+    // at roughly 2800 RPM. The series was plotting HardwareMetrics.FanEfficiency - a 0-100 proxy
+    // computed as avgRpm/50 - under an axis that GetLabelForChartType labels "RPM", so every reading
+    // was understated by ~50x. These tests pin the axis label and the plotted value to the same
+    // unit, in both directions, so the two cannot drift apart again.
+    public class FanChartUnitsTests
+    {
+        private sealed class StubBridge : IHardwareMonitorBridge
+        {
+            public string MonitoringSource => "StubBridge";
+            public System.Threading.Tasks.Task<MonitoringSample> ReadSampleAsync(System.Threading.CancellationToken token)
+                => System.Threading.Tasks.Task.FromResult(new MonitoringSample());
+            public System.Threading.Tasks.Task<bool> TryRestartAsync() => System.Threading.Tasks.Task.FromResult(true);
+        }
+
+        private static HardwareMonitoringService CreateService()
+        {
+            var logging = new LoggingService();
+            logging.Initialize();
+            return new HardwareMonitoringService(
+                new StubBridge(), logging, new MonitoringPreferences(), new ResumeRecoveryDiagnosticsService());
+        }
+
+        private static object? Invoke(HardwareMonitoringService svc, string name, params object[] args)
+        {
+            var method = typeof(HardwareMonitoringService).GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic);
+            method.Should().NotBeNull($"{name} is the method under test");
+            return method!.Invoke(svc, args);
+        }
+
+        [Fact]
+        public void FanSpeedsChart_PlotsRpm_NotTheZeroToHundredProxy()
+        {
+            using var svc = CreateService();
+
+            var metrics = new HardwareMetrics
+            {
+                FanRpmAverage = 2800,
+                FanEfficiency = 56 // the proxy for the same reading: 2800 / 50
+            };
+
+            var value = (double)Invoke(svc, "GetValueForChartType", metrics, ChartType.FanSpeeds)!;
+
+            value.Should().Be(2800, "the axis is labelled RPM, so the series must carry RPM");
+            value.Should().NotBe(56, "plotting the 0-100 proxy under an RPM axis is what rendered 2800 RPM as 28");
+        }
+
+        [Fact]
+        public void FanSpeedsChart_LabelAndValue_AgreeOnTheUnit()
+        {
+            using var svc = CreateService();
+
+            var label = (string)Invoke(svc, "GetLabelForChartType", ChartType.FanSpeeds)!;
+            label.Should().Be("RPM");
+
+            // A mid-range fan speed must land in RPM's order of magnitude, not a percentage's.
+            var metrics = new HardwareMetrics { FanRpmAverage = 3200, FanEfficiency = 64 };
+            var value = (double)Invoke(svc, "GetValueForChartType", metrics, ChartType.FanSpeeds)!;
+
+            value.Should().BeGreaterThan(100,
+                "a real fan speed exceeds any percentage scale; a value under 100 here means the proxy leaked back in");
+        }
+
+        [Fact]
+        public void FanSpeedsChart_ReportsZero_WhenNoFanTelemetryIsAvailable()
+        {
+            // Distinct from the defect above: zero must stay zero rather than become a floor or an
+            // estimate. On boards with no usable tachometer this is the honest reading, and the
+            // dashboard should not invent motion it cannot measure.
+            using var svc = CreateService();
+
+            var value = (double)Invoke(svc, "GetValueForChartType",
+                new HardwareMetrics { FanRpmAverage = 0, FanEfficiency = 0 }, ChartType.FanSpeeds)!;
+
+            value.Should().Be(0);
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Services/FanVerificationServiceTests.cs
+++ b/src/OmenCoreApp.Tests/Services/FanVerificationServiceTests.cs
@@ -80,6 +80,124 @@ namespace OmenCoreApp.Tests.Services
                 "a matched firmware level should not be reported as a Poor/near-failed result solely because the generic expected RPM curve was too aggressive");
         }
 
+        [Fact]
+        public void VerifyAppliedState_Fails_WhenAPhysicalSourceReportsZeroRpm_AtALowTarget()
+        {
+            // Board 8D87, from the owner's log: 50% requested, level 28 echoed back by firmware,
+            // five consecutive RPM samples of 0 from a WmiBios source. The old code accepted level
+            // evidence unconditionally below 40% and reported "✓ verified ... score 5/100 Failed" -
+            // a pass and its own failing score on one line. A non-zero request answered by a flat
+            // zero from a physical source is a contradiction at ANY percentage.
+            var logging = new LoggingService();
+            logging.Initialize();
+            var service = new FanVerificationService(wmiBios: null, fanService: null, logging);
+
+            var result = new FanApplyResult
+            {
+                RequestedPercent = 30,
+                ExpectedRpm = 1800,
+                ActualRpmAfter = 0,
+                RpmSource = OmenCore.Models.RpmSource.WmiBios,
+                ExpectedLevel = 17,
+                ActualLevelAfter = 17,
+                LevelReadbackMatched = true,
+                WmiCallSucceeded = true
+            };
+
+            var method = typeof(FanVerificationService).GetMethod("VerifyAppliedState", BindingFlags.Instance | BindingFlags.NonPublic);
+            method.Should().NotBeNull();
+
+            var verified = (bool)method!.Invoke(service, new object[] { result })!;
+            verified.Should().BeFalse("a physical RPM source reading zero contradicts a non-zero fan request, whatever the level readback says");
+        }
+
+        [Fact]
+        public void VerifyAppliedState_StillPasses_WhenRpmIsMerelyEstimated_AndLevelMatches()
+        {
+            // The guard above must not break the legitimate case it sits next to: on a V1 board the
+            // GetFanLevel value is surfaced as an Estimated RPM, which is not independent evidence
+            // either way. Level-only confirmation stays acceptable there - only a *physical* source
+            // contradicting the request is treated as disqualifying.
+            var logging = new LoggingService();
+            logging.Initialize();
+            var service = new FanVerificationService(wmiBios: null, fanService: null, logging);
+
+            var result = new FanApplyResult
+            {
+                RequestedPercent = 30,
+                ExpectedRpm = 1800,
+                ActualRpmAfter = 0,
+                RpmSource = OmenCore.Models.RpmSource.Estimated,
+                ExpectedLevel = 17,
+                ActualLevelAfter = 17,
+                LevelReadbackMatched = true,
+                WmiCallSucceeded = true
+            };
+
+            var method = typeof(FanVerificationService).GetMethod("VerifyAppliedState", BindingFlags.Instance | BindingFlags.NonPublic);
+            method.Should().NotBeNull();
+
+            var verified = (bool)method!.Invoke(service, new object[] { result })!;
+            verified.Should().BeTrue("an estimated RPM is not a physical measurement, so it cannot contradict the level readback");
+        }
+
+        [Fact]
+        public void DescribeVerificationPass_DoesNotClaimTheFanMoved_OnLevelOnlyEvidence()
+        {
+            // The log line is the deliverable here: level-only evidence proves the firmware accepted
+            // the command, not that the fan turned. It must not read identically to a tachometer-
+            // corroborated pass, and it must not quote an RPM accuracy score it did not measure.
+            var result = new FanApplyResult
+            {
+                RequestedPercent = 30,
+                ExpectedRpm = 1800,
+                ActualRpmAfter = 0,
+                RpmSource = OmenCore.Models.RpmSource.Estimated,
+                ExpectedLevel = 17,
+                ActualLevelAfter = 17,
+                LevelReadbackMatched = true,
+                WmiCallSucceeded = true,
+                VerificationPassed = true,
+                VerificationEvidence = "Level"
+            };
+
+            var method = typeof(FanVerificationService).GetMethod("DescribeVerificationPass", BindingFlags.Static | BindingFlags.NonPublic);
+            method.Should().NotBeNull();
+
+            var text = (string)method!.Invoke(null, new object[] { 0, result })!;
+            text.Should().Contain("Fan motion NOT confirmed");
+            text.Should().NotContain("verified:", "that wording is reserved for a pass a tachometer corroborated");
+            text.Should().NotContain("/100", "the RPM accuracy score is meaningless on the level-only path");
+        }
+
+        [Fact]
+        public void DescribeVerificationPass_ReportsTheScore_WhenRpmCorroboratedThePass()
+        {
+            var result = new FanApplyResult
+            {
+                RequestedPercent = 60,
+                ExpectedRpm = 3600,
+                ActualRpmAfter = 3500,
+                RpmSource = OmenCore.Models.RpmSource.WmiBios,
+                ExpectedLevel = 33,
+                ActualLevelAfter = 33,
+                LevelReadbackMatched = true,
+                WmiCallSucceeded = true,
+                VerificationPassed = true,
+                VerificationEvidence = "RPM+Level",
+                RpmStandardDeviation = 20,
+                ActualRpmBefore = 1200
+            };
+
+            var method = typeof(FanVerificationService).GetMethod("DescribeVerificationPass", BindingFlags.Static | BindingFlags.NonPublic);
+            method.Should().NotBeNull();
+
+            var text = (string)method!.Invoke(null, new object[] { 0, result })!;
+            text.Should().Contain("verified:");
+            text.Should().Contain("/100");
+            text.Should().NotContain("NOT confirmed");
+        }
+
         [Theory]
         [InlineData(0, 0, true)]
         [InlineData(0, 2, true)]

--- a/src/OmenCoreApp.Tests/Services/GpuSwitchServiceModeMappingTests.cs
+++ b/src/OmenCoreApp.Tests/Services/GpuSwitchServiceModeMappingTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using OmenCore.Hardware;
+using OmenCore.Models;
+using OmenCore.Services;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Services
+{
+    /// <summary>
+    /// The firmware-to-UI GPU mode mapping used by <c>GpuSwitchService.DetectCurrentMode</c>.
+    ///
+    /// Mode detection used to be inferred entirely from which adapter was painting a display, which
+    /// gets the answer wrong on any healthy Optimus laptop: RTD3 idles the dGPU into D3, so
+    /// <c>Win32_VideoController</c> reports it Off Line with no resolution, and Hybrid was reported as
+    /// Integrated. These tests cover the mapping half - the part that can be exercised without a WMI
+    /// round trip or a live display topology.
+    /// </summary>
+    public class GpuSwitchServiceModeMappingTests
+    {
+        [Fact]
+        public void Discrete_Maps_To_Discrete()
+        {
+            GpuSwitchService.MapFirmwareGpuMode(HpWmiBios.GpuMode.Discrete)
+                .Should().Be(GpuSwitchMode.Discrete);
+        }
+
+        [Fact]
+        public void Hybrid_Maps_To_Hybrid()
+        {
+            GpuSwitchService.MapFirmwareGpuMode(HpWmiBios.GpuMode.Hybrid)
+                .Should().Be(GpuSwitchMode.Hybrid);
+        }
+
+        [Fact]
+        public void Optimus_Maps_To_Hybrid_Because_The_Ui_Has_No_Separate_Member()
+        {
+            // Optimus is a hybrid arrangement with dGPU-direct routing available. GpuSwitchMode
+            // declares only Integrated/Discrete/Hybrid, and Hybrid is what the UI means by it.
+            GpuSwitchService.MapFirmwareGpuMode(HpWmiBios.GpuMode.Optimus)
+                .Should().Be(GpuSwitchMode.Hybrid);
+        }
+
+        [Fact]
+        public void An_Undeclared_Firmware_Value_Maps_To_Null_Rather_Than_Guessing()
+        {
+            // A machine routed to iGPU-only - the BIOS calls it UMA on board 8D87 - is a state
+            // HpWmiBios.GpuMode does not declare, and no capture has pinned what Legacy 0x52 reads
+            // there. Null hands the question back to adapter inference, which is at its most reliable
+            // in exactly that case: a machine with no usable dGPU really does have one active adapter.
+            GpuSwitchService.MapFirmwareGpuMode((HpWmiBios.GpuMode)0x7F)
+                .Should().BeNull("an unmapped firmware byte must not be forced into a UI mode");
+        }
+
+        [Fact]
+        public void Never_Maps_Any_Firmware_Value_To_Integrated()
+        {
+            // The firmware enum has no iGPU-only member, so nothing it reports should produce
+            // Integrated. This pins the specific defect: Integrated was being concluded from a
+            // sleeping dGPU, never from anything the firmware actually said.
+            foreach (var mode in new[]
+                     {
+                         HpWmiBios.GpuMode.Hybrid,
+                         HpWmiBios.GpuMode.Discrete,
+                         HpWmiBios.GpuMode.Optimus
+                     })
+            {
+                GpuSwitchService.MapFirmwareGpuMode(mode)
+                    .Should().NotBe(GpuSwitchMode.Integrated,
+                        $"{mode} is not an iGPU-only state");
+            }
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/Services/HotkeyAndMonitoringTests.cs
+++ b/src/OmenCoreApp.Tests/Services/HotkeyAndMonitoringTests.cs
@@ -547,7 +547,20 @@ namespace OmenCoreApp.Tests.Services
             var batteryHistory = (await svc.GetHistoricalDataAsync(ChartType.BatteryHealth, TimeSpan.FromMinutes(5))).ToList();
 
             metrics.BatteryChargePercentage.Should().Be(68);
-            metrics.BatteryHealthPercentage.Should().Be(-1, "charge percent is not a battery health estimate");
+
+            // The regression this guards is health being filled in from charge. It used to be
+            // asserted as exactly -1, which only held while health was hardcoded to that; now that
+            // UpdateDashboardMetrics reads real capacities, -1 means "this machine has no battery
+            // or does not report capacity". So the assertion passed on CI and failed on any laptop
+            // with a battery - the machines this application exists for.
+            //
+            // Assert what the test is named for instead: health must not be the charge value, and
+            // must be either the unknown sentinel or a plausible percentage.
+            metrics.BatteryHealthPercentage.Should().NotBe(68, "charge percent is not a battery health estimate");
+            (metrics.BatteryHealthPercentage == -1 ||
+             (metrics.BatteryHealthPercentage > 0 && metrics.BatteryHealthPercentage <= 100))
+                .Should().BeTrue("health is either unknown (-1) or a real percentage");
+
             alerts.Should().NotContain(alert => alert.Title == "Battery Health Warning");
             batteryHistory.Should().ContainSingle(point => point.Value == 68);
         }

--- a/src/OmenCoreApp.Tests/Services/KeyboardModelDatabaseTests.cs
+++ b/src/OmenCoreApp.Tests/Services/KeyboardModelDatabaseTests.cs
@@ -102,7 +102,13 @@ namespace OmenCoreApp.Tests.Services
             cfg!.ModelName.Should().Contain("OMEN MAX 16");
             cfg.PreferredMethod.Should().Be(KeyboardMethod.HidPerKey);
             cfg.KeyboardType.Should().Be(KeyboardType.PerKeyRgb);
-            cfg.UserVerified.Should().BeFalse();
+
+            // Was BeFalse. This board is now owner-verified on hardware: the keyboard is Darfon
+            // 0d62:54bf, driven over mi_04 for static per-key colour and mi_03 for the twelve
+            // device effects, all confirmed by eye. UserVerified is a claim about evidence, and
+            // the evidence changed - so the assertion follows it rather than pinning the entry to
+            // what was known when the test was written.
+            cfg.UserVerified.Should().BeTrue();
         }
 
         [Fact]

--- a/src/OmenCoreApp.Tests/Services/PerformanceModeNoOpReportingTests.cs
+++ b/src/OmenCoreApp.Tests/Services/PerformanceModeNoOpReportingTests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using OmenCore.Hardware;
+using OmenCore.Models;
+using OmenCore.Services;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Services
+{
+    /// <summary>
+    /// Pins the case where applying a performance mode changes nothing about the hardware.
+    ///
+    /// On board 8D87 all three effect paths decline: direct EC power-limit writes are disabled for the
+    /// model (that EC block is a mirror the SMU never reads back), the decoupled WMI thermal-policy
+    /// fallback is not permitted for it, and fan policy is decoupled from performance mode by default.
+    /// The mode switch therefore changes only the Windows power plan - which is a legitimate outcome,
+    /// but was being reported as an unqualified "applied successfully".
+    ///
+    /// These tests assert on the apply trace rather than on log text, so they pin the state the
+    /// summary line is derived from without coupling to its wording.
+    /// </summary>
+    public class PerformanceModeNoOpReportingTests
+    {
+        private sealed class NullFanController : IFanController
+        {
+            public bool IsAvailable => false;
+            public string Status => "null";
+            public string Backend => "null";
+            public bool ApplyPreset(FanPreset preset) => false;
+            public bool ApplyCustomCurve(IEnumerable<FanCurvePoint> curve) => false;
+            public bool SetFanSpeed(int percent) => false;
+            public bool SetFanSpeeds(int cpu, int gpu) => false;
+            public bool SetMaxFanSpeed(bool enabled) => false;
+            public bool SetPerformanceMode(string modeName) => false;
+            public bool RestoreAutoControl() => false;
+            public IEnumerable<FanTelemetry> ReadFanSpeeds() => new[] { new FanTelemetry() };
+            public bool ApplyMaxCooling() => true;
+            public void ApplyAutoMode() { }
+            public void ApplyQuietMode() { }
+            public bool ResetEcToDefaults() => false;
+            public bool ApplyThrottlingMitigation() => false;
+            public bool VerifyMaxApplied(out string details) { details = ""; return false; }
+            public void Dispose() { }
+        }
+
+        private static PerformanceModeService BuildService(ModelCapabilities? caps)
+        {
+            var log = new LoggingService();
+            return new PerformanceModeService(new NullFanController(), new PowerPlanService(log), null, log,
+                modelCapabilities: caps);
+        }
+
+        [Fact]
+        public void Board8D87_AppliesNoHardwareEffect_AndTheTraceSaysSo()
+        {
+            var caps = ModelCapabilityDatabase.GetCapabilities("8D87");
+            caps.Should().NotBeNull();
+
+            var service = BuildService(caps);
+            service.LinkFanToPerformanceMode = false;
+
+            service.Apply(new PerformanceMode
+            {
+                Name = "Quiet",
+                CpuPowerLimitWatts = 35,
+                GpuPowerLimitWatts = 60
+            });
+
+            var trace = service.GetApplyTraceSnapshot().Should().ContainSingle().Subject;
+
+            trace.EffectiveModeName.Should().Be("Quiet");
+            trace.EcPowerLimitApplied.Should().BeFalse("SupportsEcPowerLimits is false for this board");
+            trace.WmiPolicyFallbackApplied.Should().BeFalse(
+                "AllowDecoupledWmiThermalPolicyFallback is false for this board, so the fallback the " +
+                "skip message advertises does not actually run");
+            trace.FanPolicyAction.Should().Be("Unchanged",
+                "LinkFanToPerformanceMode defaults off, so fan policy is untouched");
+        }
+
+        [Fact]
+        public void Board8D87_DoesNotClaimTheWmiFallbackWasEvenAttempted()
+        {
+            // The skip message says "using WMI thermal policy fallback when available". On this board
+            // it is not available, and the distinction matters: attempted-and-failed is a hardware
+            // problem worth chasing, never-attempted is a capability flag worth knowing about.
+            var service = BuildService(ModelCapabilityDatabase.GetCapabilities("8D87"));
+            service.LinkFanToPerformanceMode = false;
+
+            service.Apply(new PerformanceMode { Name = "Quiet", CpuPowerLimitWatts = 35, GpuPowerLimitWatts = 60 });
+
+            var trace = service.GetApplyTraceSnapshot().Should().ContainSingle().Subject;
+            trace.WmiPolicyFallbackAttempted.Should().BeFalse();
+            trace.AllowWmiThermalPolicyFallback.Should().BeFalse();
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/ViewModels/KeyboardMapGroupingTests.cs
+++ b/src/OmenCoreApp.Tests/ViewModels/KeyboardMapGroupingTests.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+using System.Linq;
+using OmenCore.Hardware;
+using OmenCore.ViewModels;
+using Xunit;
+
+namespace OmenCoreApp.Tests.ViewModels
+{
+    /// <summary>
+    /// Collecting reported LAMPS into physical KEYS.
+    ///
+    /// The device reports lamps and a wide key carries several - Space has five on board 8D87,
+    /// both Shifts have three. Their centres sit closer together than one key is wide, so treating
+    /// each lamp as its own cap draws overlapping squares and the modifier columns look crushed.
+    ///
+    /// Every case here is taken from the real 8D87 lamp map, because the interesting failures are
+    /// all about spacing that a made-up fixture would not reproduce.
+    /// </summary>
+    public class KeyboardMapGroupingTests
+    {
+        private static HidLampArray.LampInfo Lamp(ushort id, uint xMm, uint yMm, byte usage) =>
+            new(id, xMm * 1000, yMm * 1000, 0, usage);
+
+        [Fact]
+        public void Adjacent_lamps_sharing_a_usage_become_one_key()
+        {
+            // Left Shift on 8D87: three lamps at x = 12, 23 and 30 mm, all usage 0xE1.
+            var map = new List<HidLampArray.LampInfo>
+            {
+                Lamp(80, 12, 81, 0xE1),
+                Lamp(81, 23, 81, 0xE1),
+                Lamp(82, 30, 81, 0xE1),
+            };
+
+            var keys = KeyboardMapViewModel.GroupLampsIntoKeys(map);
+
+            Assert.Single(keys);
+            Assert.Equal(3, keys[0].Count);
+        }
+
+        [Fact]
+        public void Neighbouring_letters_stay_separate_keys()
+        {
+            var map = new List<HidLampArray.LampInfo>
+            {
+                Lamp(83, 52, 81, 0x1D), // Z
+                Lamp(84, 71, 81, 0x1B), // X
+                Lamp(85, 89, 81, 0x06), // C
+            };
+
+            var keys = KeyboardMapViewModel.GroupLampsIntoKeys(map);
+
+            Assert.Equal(3, keys.Count);
+            Assert.All(keys, k => Assert.Single(k));
+        }
+
+        [Fact]
+        public void The_same_usage_in_different_rows_is_two_keys()
+        {
+            // Keypad Enter appears twice on this keyboard, one row apart. Grouping on usage alone
+            // would merge them into a single key spanning the gap.
+            var map = new List<HidLampArray.LampInfo>
+            {
+                Lamp(99, 328, 81, 0x58),
+                Lamp(119, 328, 99, 0x58),
+            };
+
+            var keys = KeyboardMapViewModel.GroupLampsIntoKeys(map);
+
+            Assert.Equal(2, keys.Count);
+        }
+
+        [Fact]
+        public void The_same_usage_far_apart_in_one_row_is_two_keys()
+        {
+            // Both Shifts share usage 0xE1 in some reports. They are at opposite ends of the row,
+            // so adjacency is what keeps them apart.
+            var map = new List<HidLampArray.LampInfo>
+            {
+                Lamp(80, 12, 81, 0xE1),
+                Lamp(93, 239, 81, 0xE1),
+            };
+
+            var keys = KeyboardMapViewModel.GroupLampsIntoKeys(map);
+
+            Assert.Equal(2, keys.Count);
+        }
+
+        [Fact]
+        public void Unbound_lamps_are_never_merged_with_each_other()
+        {
+            // Usage 0 means "no key reported". That is not evidence two lamps belong together, and
+            // on this board each is separately addressable under decorative trim.
+            var map = new List<HidLampArray.LampInfo>
+            {
+                Lamp(10, 100, 20, 0x00),
+                Lamp(11, 108, 20, 0x00),
+            };
+
+            var keys = KeyboardMapViewModel.GroupLampsIntoKeys(map);
+
+            Assert.Equal(2, keys.Count);
+        }
+
+        [Fact]
+        public void Every_lamp_survives_grouping_exactly_once()
+        {
+            // The property that matters for correctness: grouping must not drop or duplicate a
+            // lamp, or the apply path silently misses keys.
+            var map = new List<HidLampArray.LampInfo>
+            {
+                Lamp(0, 12, 81, 0xE1), Lamp(1, 23, 81, 0xE1), Lamp(2, 30, 81, 0xE1),
+                Lamp(3, 52, 81, 0x1D), Lamp(4, 71, 81, 0x1B),
+                Lamp(5, 91, 99, 0x2C), Lamp(6, 106, 99, 0x2C), Lamp(7, 126, 99, 0x2C),
+                Lamp(8, 200, 99, 0x00),
+            };
+
+            var keys = KeyboardMapViewModel.GroupLampsIntoKeys(map);
+
+            var flattened = keys.SelectMany(k => k).Select(l => l.LampId).OrderBy(id => id).ToList();
+            Assert.Equal(map.Select(l => l.LampId).OrderBy(id => id), flattened);
+        }
+
+        [Fact]
+        public void Space_becomes_one_wide_key_rather_than_five()
+        {
+            // Five lamps at 91, 106, 126, 146 and 161 mm - gaps of 15 to 20 mm, right at the limit
+            // that separates "one wide cap" from "two keys".
+            var map = new List<HidLampArray.LampInfo>
+            {
+                Lamp(105, 91, 99, 0x2C),
+                Lamp(106, 106, 99, 0x2C),
+                Lamp(107, 126, 99, 0x2C),
+                Lamp(108, 146, 99, 0x2C),
+                Lamp(109, 161, 99, 0x2C),
+            };
+
+            var keys = KeyboardMapViewModel.GroupLampsIntoKeys(map);
+
+            Assert.Single(keys);
+            Assert.Equal(5, keys[0].Count);
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/ViewModels/KeyboardMapGroupingTests.cs
+++ b/src/OmenCoreApp.Tests/ViewModels/KeyboardMapGroupingTests.cs
@@ -140,5 +140,49 @@ namespace OmenCoreApp.Tests.ViewModels
             Assert.Single(keys);
             Assert.Equal(5, keys[0].Count);
         }
+
+        // ── Splitting a cap into its LEDs ──────────────────────────────────────────
+        //
+        // The layout-driven editor draws one cell per LED inside the key's own rectangle, so which
+        // way a cap divides decides where the user clicks. Rectangles below are the real ones from
+        // HP's Dojo/Global table.
+
+        [Fact]
+        public void Two_leds_stack_even_on_a_cap_wider_than_it_is_tall()
+        {
+            // Esc is 26 x 19 - wider than tall - and its two LEDs are one under the legend and one
+            // below it. Splitting on aspect ratio would draw them side by side, and that is wrong
+            // for every key on the top and number rows.
+            Assert.False(KeyboardMapViewModel.SplitsHorizontally(2, 26, 19));
+            Assert.False(KeyboardMapViewModel.SplitsHorizontally(2, 25, 25));   // Key1
+        }
+
+        [Fact]
+        public void A_long_cap_divides_along_its_length()
+        {
+            Assert.True(KeyboardMapViewModel.SplitsHorizontally(5, 137, 25));   // Space, five across
+            Assert.True(KeyboardMapViewModel.SplitsHorizontally(7, 52, 25));    // Left Shift
+            Assert.True(KeyboardMapViewModel.SplitsHorizontally(4, 31, 25));    // Tab
+            Assert.True(KeyboardMapViewModel.SplitsHorizontally(3, 49, 25));    // Num 0
+        }
+
+        [Fact]
+        public void A_tall_cap_divides_down_it()
+        {
+            // The numpad's Plus and Enter are 23 x 54, two rows high with four LEDs down them.
+            Assert.False(KeyboardMapViewModel.SplitsHorizontally(4, 23, 54));
+            Assert.False(KeyboardMapViewModel.SplitsHorizontally(4, 23, 55));
+        }
+
+        [Fact]
+        public void Hp_key_names_shorten_to_what_is_printed_on_the_cap()
+        {
+            Assert.Equal("[", KeyboardMapViewModel.ShortName("KeyBracketsL"));
+            Assert.Equal("Space", KeyboardMapViewModel.ShortName("KeySpace"));
+            Assert.Equal("↑", KeyboardMapViewModel.ShortName("KeyArrUP"));
+
+            // HP's table spells it "KeyCopliot". The key is Copilot.
+            Assert.Equal("Copilot", KeyboardMapViewModel.ShortName("KeyCopliot"));
+        }
     }
 }

--- a/src/OmenCoreApp.Tests/ViewModels/KeyboardMapSelectionTests.cs
+++ b/src/OmenCoreApp.Tests/ViewModels/KeyboardMapSelectionTests.cs
@@ -1,0 +1,152 @@
+using System.Linq;
+using OmenCore.ViewModels;
+using Xunit;
+
+namespace OmenCoreApp.Tests.ViewModels
+{
+    /// <summary>
+    /// Rubber-band selection maths.
+    ///
+    /// Worth testing precisely because it cannot fail loudly: an off-by-one in a bounds check does
+    /// not throw, it selects the key next to the one the user dragged over, and the only symptom is
+    /// the wrong key lighting up on a keyboard nobody can read back.
+    ///
+    /// The view-model is exercised with no keyboard service, which is the supported way to construct
+    /// it - a machine with no per-key backend gets an empty map and hides the editor.
+    /// </summary>
+    public class KeyboardMapSelectionTests
+    {
+        /// <summary>Three keys in a row, 100 wide, at x = 0, 200 and 400.</summary>
+        private static KeyboardMapViewModel ThreeKeysInARow()
+        {
+            var vm = new KeyboardMapViewModel(null, new OmenCore.Services.LoggingService());
+
+            for (int i = 0; i < 3; i++)
+            {
+                vm.Keys.Add(new KeyLampViewModel
+                {
+                    LampIds = new ushort[] { (ushort)i },
+                    Label = i.ToString(),
+                    X = i * 200,
+                    Y = 0,
+                    Width = 100,
+                    Height = 100
+                });
+            }
+
+            return vm;
+        }
+
+        [Fact]
+        public void Band_across_all_three_selects_all_three()
+        {
+            var vm = ThreeKeysInARow();
+
+            vm.SelectWithin(-10, -10, 510, 110, additive: false);
+
+            Assert.Equal(3, vm.SelectedCount);
+        }
+
+        [Fact]
+        public void Band_over_the_first_key_only_leaves_the_others_alone()
+        {
+            var vm = ThreeKeysInARow();
+
+            vm.SelectWithin(10, 10, 90, 90, additive: false);
+
+            Assert.True(vm.Keys[0].IsSelected);
+            Assert.False(vm.Keys[1].IsSelected);
+            Assert.False(vm.Keys[2].IsSelected);
+        }
+
+        [Fact]
+        public void A_band_that_merely_clips_a_key_still_catches_it()
+        {
+            var vm = ThreeKeysInARow();
+
+            // Ends one pixel inside the second key. Selecting only keys wholly enclosed is the
+            // behaviour users read as "the drag missed some".
+            vm.SelectWithin(0, 0, 201, 50, additive: false);
+
+            Assert.True(vm.Keys[0].IsSelected);
+            Assert.True(vm.Keys[1].IsSelected);
+            Assert.False(vm.Keys[2].IsSelected);
+        }
+
+        [Fact]
+        public void A_band_touching_nothing_deselects_when_not_additive()
+        {
+            var vm = ThreeKeysInARow();
+            vm.SelectWithin(-10, -10, 510, 110, additive: false);
+
+            vm.SelectWithin(120, 0, 180, 50, additive: false); // the gap between keys 0 and 1
+
+            Assert.Equal(0, vm.SelectedCount);
+        }
+
+        [Fact]
+        public void Additive_bands_accumulate_across_separate_regions()
+        {
+            var vm = ThreeKeysInARow();
+
+            vm.SelectWithin(10, 10, 90, 90, additive: false);   // first key
+            vm.SelectWithin(410, 10, 490, 90, additive: true);  // third key, holding a modifier
+
+            Assert.True(vm.Keys[0].IsSelected);
+            Assert.False(vm.Keys[1].IsSelected);
+            Assert.True(vm.Keys[2].IsSelected);
+        }
+
+        [Fact]
+        public void A_band_dragged_up_and_left_selects_the_same_keys_as_down_and_right()
+        {
+            var downRight = ThreeKeysInARow();
+            var upLeft = ThreeKeysInARow();
+
+            downRight.SelectWithin(10, 10, 290, 90, additive: false);
+            upLeft.SelectWithin(290, 90, 10, 10, additive: false);
+
+            Assert.Equal(
+                downRight.Keys.Select(k => k.IsSelected),
+                upLeft.Keys.Select(k => k.IsSelected));
+        }
+
+        [Fact]
+        public void Toggling_a_key_selects_then_deselects_it()
+        {
+            var vm = ThreeKeysInARow();
+
+            vm.ToggleKey(vm.Keys[1]);
+            Assert.True(vm.Keys[1].IsSelected);
+            Assert.Equal(1, vm.SelectedCount);
+
+            vm.ToggleKey(vm.Keys[1]);
+            Assert.False(vm.Keys[1].IsSelected);
+            Assert.Equal(0, vm.SelectedCount);
+        }
+
+        [Fact]
+        public void No_keyboard_service_means_no_map_and_a_hidden_editor()
+        {
+            var vm = new KeyboardMapViewModel(null, new OmenCore.Services.LoggingService());
+
+            Assert.False(vm.IsAvailable);
+            Assert.Empty(vm.Keys);
+        }
+
+        [Theory]
+        [InlineData(0x04, "A")]
+        [InlineData(0x1D, "Z")]
+        [InlineData(0x1E, "1")]
+        [InlineData(0x27, "0")]
+        [InlineData(0x29, "Esc")]
+        [InlineData(0x2C, "Space")]
+        [InlineData(0x3A, "F1")]
+        [InlineData(0x45, "F12")]
+        [InlineData(0xE1, "Shift")]
+        public void Key_usages_map_to_readable_names(byte usage, string expected)
+        {
+            Assert.Equal(expected, KeyboardMapViewModel.KeyName(usage));
+        }
+    }
+}

--- a/src/OmenCoreApp.Tests/ViewModels/LightingViewModelTests.cs
+++ b/src/OmenCoreApp.Tests/ViewModels/LightingViewModelTests.cs
@@ -100,6 +100,124 @@ namespace OmenCoreApp.Tests.ViewModels
             vm.RgbSurfaceObservationStatusText.Should().Contain("Light bar changed");
         }
 
+        // The reactive lighting toggles shipped inert twice over: the view-model was constructed
+        // with no monitoring service, so nothing was subscribed, and even wired up the first paint
+        // waited for a poll tick that may be 30 s out. Both look identical from the UI — the toggle
+        // moves and no light changes — so these two tests pin the observable behaviour rather than
+        // the wiring.
+        [Fact]
+        public async Task EnablingTemperatureResponsiveLighting_PaintsImmediately()
+        {
+            var (vm, provider, monitoring, tempDir) = CreateReactiveLightingVm();
+            try
+            {
+                AddSample(monitoring, cpuTempC: 40, gpuTempC: 40);
+
+                vm.TemperatureResponsiveLightingEnabled = true;
+                await Task.Delay(250);
+
+                // 40 °C is below both medium thresholds, so the low-temperature colour.
+                provider.LastEffect.Should().Be($"color:{vm.TempLowColorHex}");
+            }
+            finally
+            {
+                vm.Cleanup();
+                monitoring.Dispose();
+                Cleanup(tempDir);
+            }
+        }
+
+        [Fact]
+        public async Task EnablingTemperatureResponsiveLighting_WithNoSampleYet_DoesNotThrow()
+        {
+            var (vm, provider, monitoring, tempDir) = CreateReactiveLightingVm();
+            try
+            {
+                // No sample has arrived, which is the state during startup.
+                vm.TemperatureResponsiveLightingEnabled = true;
+                await Task.Delay(150);
+
+                provider.LastEffect.Should().BeNull();
+            }
+            finally
+            {
+                vm.Cleanup();
+                monitoring.Dispose();
+                Cleanup(tempDir);
+            }
+        }
+
+        private static (LightingViewModel vm, TestRgbProvider provider,
+                        HardwareMonitoringService monitoring, string tempDir) CreateReactiveLightingVm()
+        {
+            Environment.SetEnvironmentVariable("OMENCORE_DISABLE_FILE_LOG", "1");
+            var tempDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "OmenCoreTests", Guid.NewGuid().ToString());
+            System.IO.Directory.CreateDirectory(tempDir);
+            Environment.SetEnvironmentVariable("OMENCORE_CONFIG_DIR", tempDir);
+
+            var logging = new LoggingService { Level = LogLevel.Info };
+            var monitoring = new HardwareMonitoringService(
+                new ReactiveLightingBridgeStub(),
+                logging,
+                new OmenCore.Models.MonitoringPreferences(),
+                new OmenCore.Services.Diagnostics.ResumeRecoveryDiagnosticsService());
+
+            var rgbManager = new RgbManager();
+            var provider = new TestRgbProvider();
+            rgbManager.RegisterProvider(provider);
+
+            var vm = new LightingViewModel(
+                null, null, logging,
+                keyboardLightingService: null,
+                configService: new ConfigurationService(),
+                razerService: null,
+                rgbManager: rgbManager,
+                hardwareMonitoringService: monitoring);
+
+            return (vm, provider, monitoring, tempDir);
+        }
+
+        /// <summary>
+        /// Push a sample into the service's history without starting its poll loop. The paint on
+        /// enable reads Samples.LastOrDefault(), so that is the only state the test needs.
+        /// </summary>
+        private static void AddSample(HardwareMonitoringService monitoring, double cpuTempC, double gpuTempC)
+        {
+            var field = typeof(HardwareMonitoringService)
+                .GetField("_samples", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            field.Should().NotBeNull();
+
+            var samples = (System.Collections.ObjectModel.ObservableCollection<OmenCore.Models.MonitoringSample>)field!.GetValue(monitoring)!;
+            samples.Add(new OmenCore.Models.MonitoringSample
+            {
+                CpuTemperatureC = cpuTempC,
+                GpuTemperatureC = gpuTempC
+            });
+        }
+
+        private static void Cleanup(string tempDir)
+        {
+            Environment.SetEnvironmentVariable("OMENCORE_CONFIG_DIR", null);
+            try
+            {
+                if (System.IO.Directory.Exists(tempDir)) System.IO.Directory.Delete(tempDir, true);
+            }
+            catch { }
+        }
+
+        private sealed class ReactiveLightingBridgeStub : OmenCore.Hardware.IHardwareMonitorBridge
+        {
+            public string MonitoringSource => "ReactiveLightingStub";
+
+            public Task<OmenCore.Models.MonitoringSample> ReadSampleAsync(System.Threading.CancellationToken token)
+            {
+                token.ThrowIfCancellationRequested();
+                return Task.FromResult(new OmenCore.Models.MonitoringSample());
+            }
+
+            public Task<bool> TryRestartAsync() => Task.FromResult(true);
+        }
+
         private class TestRgbProvider : IRgbProvider
         {
             public string ProviderName => "TestProvider";

--- a/src/OmenCoreApp/App.xaml.cs
+++ b/src/OmenCoreApp/App.xaml.cs
@@ -955,7 +955,7 @@ namespace OmenCore
             services.AddSingleton(_ => new BiosUpdateService(Logging));
             services.AddSingleton(_ => new TelemetryService(Logging, Configuration));
             services.AddSingleton(_ => new SystemOptimizationService(Logging));
-            services.AddSingleton(_ => new GpuSwitchService(Logging));
+            services.AddSingleton(sp => new GpuSwitchService(Logging, sp.GetRequiredService<HpWmiBios>()));
             services.AddSingleton(_ => new ProcessMonitoringService(Logging));
             services.AddSingleton(_ => new HotkeyService(Logging));
             services.AddSingleton(_ => new OmenKeyService(Logging, Configuration));

--- a/src/OmenCoreApp/Controls/HardwareMonitoringDashboard.xaml
+++ b/src/OmenCoreApp/Controls/HardwareMonitoringDashboard.xaml
@@ -335,7 +335,7 @@
                     <Border Style="{StaticResource MetricCardStyle}">
                         <StackPanel>
                             <TextBlock Text="Battery Status" Style="{StaticResource MetricTitleStyle}"/>
-                            <TextBlock x:Name="BatteryCyclesValue" Text="127" Style="{StaticResource MetricValueStyle}"/>
+                            <TextBlock x:Name="BatteryCyclesValue" Text="--" Style="{StaticResource MetricValueStyle}"/>
                             <TextBlock Text="cycles" Style="{StaticResource MetricUnitStyle}"/>
                             <TextBlock x:Name="BatteryLifeEstimate" Text="3.0 years remaining" FontSize="10" Foreground="{DynamicResource SecondaryTextBrush}"/>
                         </StackPanel>

--- a/src/OmenCoreApp/Controls/HardwareMonitoringDashboard.xaml.cs
+++ b/src/OmenCoreApp/Controls/HardwareMonitoringDashboard.xaml.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
-using System.Management;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -484,9 +483,26 @@ namespace OmenCore.Controls
                     PowerEfficiencyRating.Foreground = GetEfficiencyBrush(efficiency);
                 }
 
-                // Thermal status - FIXED with null safety
-                if (BatteryCyclesValue != null) BatteryCyclesValue.Text = "0";
-                if (BatteryLifeEstimate != null) BatteryLifeEstimate.Text = "~3.0 years remaining";
+                // Battery wear. Both of these were constants: the cycle count was literally
+                // "0" and the caption was literally "~3.0 years remaining", neither derived
+                // from the machine. The cycle count is readable (root\wmi:BatteryCycleCount)
+                // and is shown; remaining-life in years is not derivable from anything we
+                // measure, so the caption now reports the capacities it actually has.
+                var batteryInfo = BatteryInfoProvider.Get(App.Logging);
+                if (BatteryCyclesValue != null)
+                {
+                    BatteryCyclesValue.Text = batteryInfo.CycleCount?.ToString() ?? "--";
+                }
+                if (BatteryLifeEstimate != null)
+                {
+                    BatteryLifeEstimate.Text =
+                        batteryInfo.FullChargedCapacityMilliwattHours is int full &&
+                        batteryInfo.DesignedCapacityMilliwattHours is int design
+                            ? $"{full:N0} of {design:N0} mWh"
+                            : batteryInfo.CycleCount == null
+                                ? "Not reported by this battery"
+                                : "Capacity unavailable";
+                }
 
                 if (ThermalStatusValue != null)
                 {
@@ -572,62 +588,28 @@ namespace OmenCore.Controls
         /// Uses WMI BatteryStaticData for DesignCapacity and BatteryFullChargedCapacity for current capacity.
         /// Caches result for 5 minutes to avoid excessive WMI queries.
         /// </summary>
+        /// <summary>
+        /// Battery capacity health, or <see cref="double.NaN"/> when the pack does not report
+        /// both capacities. Delegates to <see cref="BatteryInfoProvider"/> so the dashboard and
+        /// the monitoring service read the same numbers from the same place - they used to run
+        /// separate copies of these WMI queries, which is how the cycle count came to be
+        /// hardcoded in one of them.
+        /// </summary>
         private async Task<double> GetBatteryHealthPercentAsync()
         {
-            // Return cached value if recent (battery health doesn't change often)
             if (_lastBatteryHealthCheck > DateTime.MinValue && (DateTime.Now - _lastBatteryHealthCheck).TotalMinutes < 5)
             {
                 return _cachedBatteryHealth;
             }
 
+            // Off the UI thread: BatteryInfoProvider is synchronous WMI, and a cold call has
+            // to wait on the battery class driver.
             return await Task.Run(() =>
             {
-                try
-                {
-                    uint designCapacity = 0;
-                    uint fullChargeCapacity = 0;
-
-                    // Get DesignCapacity from BatteryStaticData (requires admin/elevated access on some systems)
-                    using (var searcher = new ManagementObjectSearcher("root\\WMI", "SELECT DesignedCapacity FROM BatteryStaticData"))
-                    {
-                        foreach (var obj in searcher.Get())
-                        {
-                            designCapacity = Convert.ToUInt32(obj["DesignedCapacity"]);
-                            break;
-                        }
-                    }
-
-                    // Get FullChargeCapacity from BatteryFullChargedCapacity
-                    using (var searcher = new ManagementObjectSearcher("root\\WMI", "SELECT FullChargedCapacity FROM BatteryFullChargedCapacity"))
-                    {
-                        foreach (var obj in searcher.Get())
-                        {
-                            fullChargeCapacity = Convert.ToUInt32(obj["FullChargedCapacity"]);
-                            break;
-                        }
-                    }
-
-                    if (designCapacity > 0 && fullChargeCapacity > 0)
-                    {
-                        _cachedBatteryHealth = (fullChargeCapacity * 100.0) / designCapacity;
-                        _cachedBatteryHealth = Math.Min(100.0, Math.Max(0.0, _cachedBatteryHealth)); // Clamp to 0-100
-                        _lastBatteryHealthCheck = DateTime.Now;
-                        App.Logging.Debug($"[Dashboard] Battery health: {_cachedBatteryHealth:F1}% (FullCharge={fullChargeCapacity} mWh, Design={designCapacity} mWh)");
-                        return _cachedBatteryHealth;
-                    }
-
-                    App.Logging.Debug("[Dashboard] Battery capacity WMI data unavailable; capacity health will be shown as unavailable");
-                    _cachedBatteryHealth = double.NaN;
-                    _lastBatteryHealthCheck = DateTime.Now;
-                    return _cachedBatteryHealth;
-                }
-                catch (Exception ex)
-                {
-                    App.Logging.Debug($"[Dashboard] Failed to get battery health: {ex.Message}");
-                    _cachedBatteryHealth = double.NaN;
-                    _lastBatteryHealthCheck = DateTime.Now;
-                    return _cachedBatteryHealth;
-                }
+                var info = BatteryInfoProvider.Get(App.Logging);
+                _cachedBatteryHealth = info.HealthPercent ?? double.NaN;
+                _lastBatteryHealthCheck = DateTime.Now;
+                return _cachedBatteryHealth;
             });
         }
 

--- a/src/OmenCoreApp/Hardware/CapabilityDetectionService.cs
+++ b/src/OmenCoreApp/Hardware/CapabilityDetectionService.cs
@@ -862,11 +862,26 @@ namespace OmenCore.Hardware
             {
                 if (_wmiBios?.IsAvailable == true)
                 {
-                    // Try to detect backlight capability
-                    Capabilities.HasKeyboardBacklight = true;
-                    Capabilities.Lighting = LightingCapability.FourZone;
-                    Capabilities.HasZoneLighting = true;
-                    _logging?.Info("  → 4-zone keyboard backlight detected");
+                    // Ask the firmware what the keyboard actually is before claiming a topology.
+                    // This used to report "4-zone keyboard backlight detected" for every board
+                    // with a working WMI BIOS, without ever probing - which is wrong wherever the
+                    // keyboard is per-key, and wrong in a way that reads like a detection result.
+                    // Board 8D87 (OMEN MAX 16) is per-key: its keyboard is a 120-lamp HID
+                    // LampArray, and the four-zone command path does not drive it.
+                    var topology = _wmiBios.GetKeyboardLightingType();
+                    if (topology != null)
+                    {
+                        ApplyLightingTopology(topology.Value);
+                    }
+                    else
+                    {
+                        // No topology probe on this board. Keep the previous assumption rather
+                        // than regress boards that rely on it, but say that it is an assumption.
+                        Capabilities.HasKeyboardBacklight = true;
+                        Capabilities.Lighting = LightingCapability.FourZone;
+                        Capabilities.HasZoneLighting = true;
+                        _logging?.Info("  → Keyboard lighting topology not reported; assuming 4-zone");
+                    }
                 }
                 else if (Capabilities.OghRunning)
                 {
@@ -884,6 +899,63 @@ namespace OmenCore.Hardware
             catch (Exception ex)
             {
                 _logging?.Warn($"Lighting detection error: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Translate the firmware's keyboard lighting topology into capability flags.
+        ///
+        /// Zone and per-key lighting are mutually exclusive here: they are different command
+        /// surfaces, and a board reporting both would offer the user a zone control that writes
+        /// to a path its keyboard does not listen on.
+        /// </summary>
+        private void ApplyLightingTopology(HpWmiBios.KeyboardLightingType topology)
+        {
+            switch (topology)
+            {
+                case HpWmiBios.KeyboardLightingType.RgbPerKey:
+                    Capabilities.HasKeyboardBacklight = true;
+                    Capabilities.HasPerKeyLighting = true;
+                    Capabilities.HasZoneLighting = false;
+                    Capabilities.Lighting = LightingCapability.PerKey;
+                    _logging?.Info("  → Per-key RGB keyboard reported by firmware");
+                    break;
+
+                case HpWmiBios.KeyboardLightingType.FourZoneWithNumpad:
+                case HpWmiBios.KeyboardLightingType.FourZoneWithoutNumpad:
+                    Capabilities.HasKeyboardBacklight = true;
+                    Capabilities.HasZoneLighting = true;
+                    Capabilities.Lighting = LightingCapability.FourZone;
+                    _logging?.Info("  → 4-zone keyboard backlight reported by firmware");
+                    break;
+
+                case HpWmiBios.KeyboardLightingType.OneZoneWithNumpad:
+                case HpWmiBios.KeyboardLightingType.OneZoneWithoutNumpad:
+                    // One addressable zone. LightingCapability has no OneZone member, and FourZone
+                    // is the closest thing meaning "zoned colour control" - the zone COUNT comes
+                    // from ModelCapabilities, not from this enum, so nothing downstream reads a
+                    // count out of it. Named awkwardly rather than wrongly.
+                    Capabilities.HasKeyboardBacklight = true;
+                    Capabilities.HasZoneLighting = true;
+                    Capabilities.Lighting = LightingCapability.FourZone;
+                    _logging?.Info("  → Single-zone RGB keyboard backlight reported by firmware");
+                    break;
+
+                case HpWmiBios.KeyboardLightingType.Normal:
+                    // Backlit, but with no colour control at all.
+                    Capabilities.HasKeyboardBacklight = true;
+                    Capabilities.HasZoneLighting = false;
+                    Capabilities.Lighting = LightingCapability.SingleColor;
+                    _logging?.Info("  → Keyboard is backlit but not colour-addressable");
+                    break;
+
+                case HpWmiBios.KeyboardLightingType.None:
+                    Capabilities.HasKeyboardBacklight = false;
+                    Capabilities.HasZoneLighting = false;
+                    Capabilities.HasPerKeyLighting = false;
+                    Capabilities.Lighting = LightingCapability.None;
+                    _logging?.Info("  → No keyboard lighting reported by firmware");
+                    break;
             }
         }
 

--- a/src/OmenCoreApp/Hardware/DojoKeyboardMcu.cs
+++ b/src/OmenCoreApp/Hardware/DojoKeyboardMcu.cs
@@ -1,0 +1,579 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+
+namespace OmenCore.Hardware
+{
+    /// <summary>
+    /// The per-key keyboard MCU's own command surface, over HID interface <c>mi_03</c>.
+    ///
+    /// This is the second of the two lighting paths a per-key OMEN keyboard exposes, and the two
+    /// are not interchangeable:
+    ///
+    ///   mi_04  <see cref="HidLampArray"/>  standard HID LampArray. STATIC per-key colour. One
+    ///          report lights a key and it persists after the writing process exits. No readback.
+    ///   mi_03  this class                  the MCU's vendor protocol. The ANIMATION ENGINE - all
+    ///          twelve effects OMEN Gaming Hub offers are one frame each, rendered device-side with
+    ///          no host involvement. Has a real state readback.
+    ///
+    /// So "per-key RGB" splits cleanly: a static picture goes to mi_04, a running effect goes here.
+    /// A caller that sends an effect and then paints lamps is fighting itself.
+    ///
+    /// PROTOCOL PROVENANCE. Derived from OMEN Gaming Hub 1101.2607.3.0 - McuSDK2.dll's
+    /// <c>GeneralCommandHelper</c> and <c>StarmadeKbLightingEffectCommandHelper</c> - and confirmed
+    /// byte-for-byte against a USBPcap capture of OGH driving board 8D87, then driven independently.
+    /// It is NOT the McuSDK v1 <c>KeyboardCommandHelper</c> path, whose 23-byte record and
+    /// BLength = 22 belong to a different HP keyboard and mismatch this wire. Full map:
+    /// omen-max-16/reference/keyboard-mcu.md.
+    ///
+    /// SCOPE. Measured on ONE machine: board 8D87, BIOS F.07, EC 40.38, Darfon 0D62:54BF. The
+    /// device list below is deliberately narrow for that reason - these are vendor commands, and a
+    /// keyboard that does not speak them may do something other than ignore them.
+    ///
+    /// WHAT AN ACK MEANS. Every command is answered <c>EC AC</c> (accepted) or <c>EC FA</c>
+    /// (refused). Accepted means the frame parsed. It does not mean anything lit: during a stuck
+    /// state on 8D87 every frame HP's own client sent was acknowledged and the keyboard stayed
+    /// dark. <see cref="TryReadEffect"/> is the stronger check, and a person looking is stronger
+    /// still.
+    /// </summary>
+    public sealed class DojoKeyboardMcu : IDisposable
+    {
+        // ── Identity ───────────────────────────────────────────────────────────────
+
+        private const ushort DarfonVid = 0x0D62;
+
+        /// <summary>
+        /// PIDs HP's own device table pairs with <c>mi_03</c> + <c>DojoPerKeyRGB</c>. 0x54BF is
+        /// "HP Gaming Keyboard II", measured on 8D87; 0x30BF sits beside it in HP's list and is
+        /// unmeasured here.
+        /// </summary>
+        private static readonly ushort[] KnownPids = { 0x54BF, 0x30BF };
+
+        /// <summary>
+        /// The PIDs this protocol has actually been driven against, as opposed to the ones HP's own
+        /// table pairs with this code path.
+        ///
+        /// The difference matters to a user. `0x54BF` was measured on 8D87 - twelve effects, a state
+        /// readback, confirmed by eye. `0x30BF` sits beside it in HP's device list and has never been
+        /// seen here, so a machine carrying it gets the same code on the strength of HP's table
+        /// alone. That is a reasonable bet and it is not evidence, and the UI says which one a user
+        /// is on rather than presenting both as equally established.
+        /// </summary>
+        private static readonly ushort[] VerifiedPids = { 0x54BF };
+
+        /// <summary>Whether this device's protocol support was confirmed on hardware, or inferred
+        /// from HP's device table.</summary>
+        public bool IsVerifiedDevice => VerifiedPids.Contains(ProductId);
+
+        /// <summary>
+        /// The vendor collection, not the keyboard one. A composite keyboard exposes several
+        /// interfaces under one PID and only this one carries lighting - selecting on VID:PID
+        /// alone takes whichever Windows enumerated first, which is usually the wrong one.
+        /// </summary>
+        private const string VendorInterface = "MI_03";
+
+        // ── Frame layout ───────────────────────────────────────────────────────────
+
+        // Reports are 65 bytes: a report id of 0 that is stripped on the wire, then the frame.
+        // Wire offset N therefore lives at buffer offset N+1, in both directions.
+        private const int ReportLength = 65;
+        private const byte ReportId = 0x00;
+        private const int PayloadAt = 5;         // buffer index of wire payload[0]
+        private const int PayloadCapacity = 60;
+
+        private const byte AckHigh = 0xEC;       // payload[0] of every reply
+        private const byte AckOk = 0xAC;         // payload[1]: accepted
+        private const byte AckRefused = 0xFA;    //             refused
+
+        // ── Commands ───────────────────────────────────────────────────────────────
+
+        private const byte CmdSetLightingOnOff = 0x09;
+        private const byte CmdStoreLightingToFlash = 0x0A;
+        private const byte CmdSetBrightness = 0x0C;
+        private const byte CmdSetLightingEffect = 0x03;
+        private const byte CmdRestoreDefault = 0x10;
+        private const byte CmdGetLightingEffect = 0x83;
+
+        /// <summary>LightingEffectTarget.ALL_LED_AREA - the only target a keyboard has.</summary>
+        private const byte TargetAllLedArea = 0x00;
+
+        /// <summary>Declared length of the effect record. Six colour slots reach the device but
+        /// only four are inside this length, so only four are written here.</summary>
+        private const int EffectRecordLength = 36;
+
+        private static readonly byte[] FlashMagic = { 0xAC, 0x53 };
+        private static readonly byte[] RestoreMagic = { 0x94, 0x10, 0x98, 0x27 };
+        private const byte RestoreIndex = 7;
+
+        // Field offsets inside the effect record.
+        private const int FxEffect = 0, FxShowMode = 1, FxColorNumber = 2, FxLedSpeed = 3;
+        private const int FxBrightness = 4, FxDirection = 5, FxRippleSize = 6, FxRaindropFreq = 7;
+        private const int FxInnerBrightness = 8, FxOuterBrightness = 9;
+        private const int FxColor0 = 24, FxMaxColors = 4;
+
+        private readonly IntPtr _handle;
+        private bool _disposed;
+
+        public ushort VendorId { get; private init; }
+        public ushort ProductId { get; private init; }
+        public string ProductName { get; private init; } = string.Empty;
+        public string DevicePath { get; private init; } = string.Empty;
+
+        private DojoKeyboardMcu(IntPtr handle) => _handle = handle;
+
+        // ── Effect vocabulary ──────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Wire values from <c>LightingEffectType</c>. NOT the dropdown order, and NOT the light
+        /// bar's numbering - the BIOS four-zone path uses different values for the same names and
+        /// has no Ghosting, Ripple or OMEN X at all. Four numbering schemes exist for these twelve
+        /// names; always say which one a number belongs to.
+        /// </summary>
+        public enum Effect : byte
+        {
+            Off = 0,
+            Breathing = 2,
+            ColorCycle = 4,
+            Starlight = 7,
+            Ghosting = 8,
+            Ripple = 9,
+            Wave = 10,
+            Raindrop = 12,
+            OmenX = 13,
+            AudioPulse = 14,
+            Confetti = 15,
+            Sun = 16,
+            Swipe = 17
+        }
+
+        /// <summary>
+        /// Merges two ideas: 0 and 1 say how many CUSTOM colours the record carries, 2..5 name a
+        /// preset palette instead. The colour block is only meaningful for 0 and 1.
+        /// </summary>
+        public enum ShowMode : byte
+        {
+            SingleCustomColor = 0,
+            MultipleCustomColors = 1,
+            Volcano = 2,
+            Jungle = 3,
+            Ocean = 4,
+            Rainbow = 5
+        }
+
+        public enum EffectSpeed : byte { Slow = 0, Medium = 1, Fast = 2 }
+
+        /// <summary>Wire order. The UI enum swaps the first two, so a value copied out of OGH's
+        /// view-model is not this.</summary>
+        public enum EffectDirection : byte
+        {
+            Inward = 0, Outward = 1, RightToLeft = 2, LeftToRight = 3,
+            Up = 4, Down = 5, Clockwise = 6, CounterClockwise = 7
+        }
+
+        /// <summary>Sentinel for ColorNumber meaning "a preset is selected, ignore the colours".
+        /// The field is otherwise a ZERO-BASED count: four custom colours send 3.</summary>
+        public const byte ColorNumberPreset = 4;
+
+        /// <summary>One effect as the MCU holds it. Colours are RGB.</summary>
+        public struct EffectRecord
+        {
+            public Effect Effect;
+            public ShowMode ShowMode;
+            public byte ColorNumber;
+            public EffectSpeed Speed;
+            public byte Brightness;
+            public EffectDirection Direction;
+            public byte RippleSize;
+            public byte RaindropFrequency;
+
+            /// <summary>Audio Pulse only: the high-band level. Host-fed, see the remarks on
+            /// <see cref="SetEffect"/>.</summary>
+            public byte InnerBrightness;
+
+            /// <summary>Audio Pulse only: the low-band level.</summary>
+            public byte OuterBrightness;
+
+            /// <summary>Up to four RGB triples. Ignored unless ShowMode is a custom mode.</summary>
+            public (byte R, byte G, byte B)[] Colors;
+        }
+
+        // ── Opening ────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Open the MCU's vendor interface, or null if this machine has no such keyboard.
+        ///
+        /// Null is the ordinary answer on most hardware and is not an error - it means the caller
+        /// should fall back to another lighting path, not that something failed.
+        /// </summary>
+        public static DojoKeyboardMcu? Open()
+        {
+            foreach (string path in EnumerateHidPaths())
+            {
+                if (!LooksLikeTheVendorInterface(path)) continue;
+
+                var device = TryOpen(path);
+                if (device != null) return device;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Every candidate path with the reason it was or was not taken. Exists so a field report
+        /// from an unsupported model is actionable: the interesting failure is "the right VID:PID
+        /// was there and mi_03 was missing", which a bare null cannot express.
+        /// </summary>
+        public static IReadOnlyList<string> DescribeCandidates()
+        {
+            var lines = new List<string>();
+
+            foreach (string path in EnumerateHidPaths())
+            {
+                if (path.IndexOf($"VID_{DarfonVid:X4}", StringComparison.OrdinalIgnoreCase) < 0)
+                    continue;
+
+                string pid = KnownPids.Any(p => path.IndexOf($"PID_{p:X4}", StringComparison.OrdinalIgnoreCase) >= 0)
+                    ? "known PID"
+                    : "UNKNOWN PID";
+                string mi = path.IndexOf(VendorInterface, StringComparison.OrdinalIgnoreCase) >= 0
+                    ? VendorInterface
+                    : "not " + VendorInterface;
+
+                lines.Add($"{pid}, {mi} : {path}");
+            }
+
+            return lines;
+        }
+
+        private static bool LooksLikeTheVendorInterface(string path) =>
+            path.IndexOf($"VID_{DarfonVid:X4}", StringComparison.OrdinalIgnoreCase) >= 0 &&
+            path.IndexOf(VendorInterface, StringComparison.OrdinalIgnoreCase) >= 0 &&
+            KnownPids.Any(p => path.IndexOf($"PID_{p:X4}", StringComparison.OrdinalIgnoreCase) >= 0);
+
+        private static DojoKeyboardMcu? TryOpen(string path)
+        {
+            IntPtr h = Native.CreateFileW(path, Native.GenericRead | Native.GenericWrite,
+                                          Native.ShareReadWrite, IntPtr.Zero, Native.OpenExisting,
+                                          Native.FileFlagOverlapped, IntPtr.Zero);
+            if (h == Native.InvalidHandle) return null;
+
+            try
+            {
+                var attrs = new Native.HiddAttributes { Size = Marshal.SizeOf<Native.HiddAttributes>() };
+                if (!Native.HidD_GetAttributes(h, ref attrs)) { Native.CloseHandle(h); return null; }
+
+                if (!Native.HidD_GetPreparsedData(h, out IntPtr preparsed))
+                {
+                    Native.CloseHandle(h);
+                    return null;
+                }
+
+                ushort outLength;
+                try
+                {
+                    var caps = new Native.HidpCaps();
+                    Native.HidP_GetCaps(preparsed, ref caps);
+                    outLength = caps.OutputReportByteLength;
+                }
+                finally { Native.HidD_FreePreparsedData(preparsed); }
+
+                // The report size is the last structural check available before sending vendor
+                // bytes. An interface that cannot carry a 65-byte report is not this protocol
+                // whatever its path says.
+                if (outLength != ReportLength) { Native.CloseHandle(h); return null; }
+
+                string product = string.Empty;
+                var nameBuffer = new byte[256];
+                if (Native.HidD_GetProductString(h, nameBuffer, nameBuffer.Length))
+                    product = Encoding.Unicode.GetString(nameBuffer).Split('\0')[0];
+
+                return new DojoKeyboardMcu(h)
+                {
+                    VendorId = attrs.VendorID,
+                    ProductId = attrs.ProductID,
+                    ProductName = product,
+                    DevicePath = path
+                };
+            }
+            catch
+            {
+                Native.CloseHandle(h);
+                return null;
+            }
+        }
+
+        // ── Commands ───────────────────────────────────────────────────────────────
+
+        /// <summary>Blank or unblank the backlight without disturbing the installed effect.</summary>
+        public bool SetLightingEnabled(bool enabled) =>
+            Send(CmdSetLightingOnOff, 0, new byte[] { (byte)(enabled ? 1 : 0) });
+
+        /// <summary>
+        /// Set the MCU's own brightness.
+        ///
+        /// UNMEASURED ON HARDWARE. Command 0x0C is HP's, read out of McuSDK2, and OGH sends it -
+        /// but it is the one command in this class that has never been put on the wire from here,
+        /// so its ack has never been paired with a person looking. Treat a true return as "the
+        /// frame parsed" and nothing more until someone confirms the keyboard actually dimmed.
+        /// Brightness for STATIC colour does not need this: <see cref="HidLampArray"/> carries an
+        /// intensity channel per lamp, and that path is measured.
+        /// </summary>
+        public bool SetBrightness(byte level) =>
+            Send(CmdSetBrightness, 0, new[] { level });
+
+        /// <summary>
+        /// Install an effect. One frame, and it holds with no host process running - there is no
+        /// repaint loop and no keep-alive on this path.
+        ///
+        /// TWO THINGS THAT SURPRISE CALLERS:
+        ///
+        /// 1. The MCU MERGES; it does not replace. A frame only updates the fields the selected
+        ///    effect actually consumes, and everything else keeps its previous value. So you cannot
+        ///    clear a field by sending zero unless the current effect consumes it - a frame that
+        ///    "sets everything to defaults" does no such thing. To put the record into a known
+        ///    state, write each field while an effect that consumes it is selected, then switch.
+        ///
+        /// 2. Two effects render BLACK when driven naively, and neither is a failure.
+        ///    <see cref="Effect.Swipe"/> has no preset palette, so it needs custom colours -
+        ///    sent with a preset it shows nothing. <see cref="Effect.AudioPulse"/> IS its two
+        ///    level bytes: with Inner/Outer at 0 it is black by definition. Reproducing it means a
+        ///    ~5 Hz loop feeding those two bytes from an audio thread, which is what OGH does.
+        ///
+        /// Volatile until <see cref="StoreToFlash"/>.
+        /// </summary>
+        public bool SetEffect(EffectRecord record)
+        {
+            var payload = new byte[EffectRecordLength];
+            payload[FxEffect] = (byte)record.Effect;
+            payload[FxShowMode] = (byte)record.ShowMode;
+            payload[FxColorNumber] = record.ColorNumber;
+            payload[FxLedSpeed] = (byte)record.Speed;
+            payload[FxBrightness] = record.Brightness;
+            payload[FxDirection] = (byte)record.Direction;
+            payload[FxRippleSize] = record.RippleSize;
+
+            // OGH assigns this the same value as LedSpeed for every effect, so the two always
+            // match in a capture. Separating them is untested rather than known to work.
+            payload[FxRaindropFreq] = record.RaindropFrequency;
+
+            payload[FxInnerBrightness] = record.InnerBrightness;
+            payload[FxOuterBrightness] = record.OuterBrightness;
+
+            var colors = record.Colors ?? Array.Empty<(byte, byte, byte)>();
+            for (int i = 0; i < Math.Min(colors.Length, FxMaxColors); i++)
+            {
+                int at = FxColor0 + (i * 3);
+                payload[at] = colors[i].R;
+                payload[at + 1] = colors[i].G;
+                payload[at + 2] = colors[i].B;
+            }
+
+            return Send(CmdSetLightingEffect, TargetAllLedArea, payload);
+        }
+
+        /// <summary>
+        /// Read the installed effect back, or null if the device refused or did not answer.
+        ///
+        /// This is the merged state the MCU is holding, not an echo of the last write - which is
+        /// what makes it worth reading, and also means a matching readback does not prove the
+        /// firmware took the field from the frame you just sent.
+        /// </summary>
+        public EffectRecord? TryReadEffect()
+        {
+            if (!Write(CmdGetLightingEffect, TargetAllLedArea, 0, Array.Empty<byte>())) return null;
+
+            byte[]? reply = Read();
+            if (reply == null) return null;
+
+            // Reaching colour 4 needs payload[35], which is buffer[40].
+            if (reply.Length < PayloadAt + FxColor0 + (FxMaxColors * 3)) return null;
+            if (reply[PayloadAt] == AckHigh && reply[PayloadAt + 1] == AckRefused) return null;
+
+            byte P(int offset) => reply[PayloadAt + offset];
+
+            var colors = new (byte R, byte G, byte B)[FxMaxColors];
+            for (int i = 0; i < FxMaxColors; i++)
+            {
+                int at = FxColor0 + (i * 3);
+                colors[i] = (P(at), P(at + 1), P(at + 2));
+            }
+
+            return new EffectRecord
+            {
+                Effect = (Effect)P(FxEffect),
+                ShowMode = (ShowMode)P(FxShowMode),
+                ColorNumber = P(FxColorNumber),
+                Speed = (EffectSpeed)P(FxLedSpeed),
+                Brightness = P(FxBrightness),
+                Direction = (EffectDirection)P(FxDirection),
+                RippleSize = P(FxRippleSize),
+                RaindropFrequency = P(FxRaindropFreq),
+                InnerBrightness = P(FxInnerBrightness),
+                OuterBrightness = P(FxOuterBrightness),
+                Colors = colors
+            };
+        }
+
+        /// <summary>
+        /// Persist the current lighting across a power cycle.
+        ///
+        /// THIS IS A REAL FLASH WRITE to the MCU. It is why an effect survives a reboot, and why
+        /// it must never go in a loop or be called once per frame of an animation. Call it when a
+        /// user saves a profile, not when one is applied.
+        /// </summary>
+        public bool StoreToFlash() =>
+            Send(CmdStoreLightingToFlash, TargetAllLedArea, FlashMagic);
+
+        /// <summary>
+        /// Reset the lighting to HP's firmware defaults.
+        ///
+        /// Worth knowing about before the next apparently-bricked keyboard: this is a firmware
+        /// level reset over the ordinary command surface, so it does not need an EC drain or a
+        /// teardown.
+        /// </summary>
+        public bool RestoreFirmwareDefaults() =>
+            Send(CmdRestoreDefault, RestoreIndex, RestoreMagic);
+
+        // ── Wire ───────────────────────────────────────────────────────────────────
+
+        /// <summary>Write a frame and require an <c>EC AC</c> reply. False covers refused,
+        /// unanswered and failed-to-write alike; the caller cannot act differently on those.</summary>
+        private bool Send(byte command, byte index, byte[] payload)
+        {
+            if (!Write(command, index, payload.Length, payload)) return false;
+
+            byte[]? reply = Read();
+            if (reply == null || reply.Length < PayloadAt + 2) return false;
+
+            return reply[PayloadAt] == AckHigh && reply[PayloadAt + 1] == AckOk;
+        }
+
+        private bool Write(byte command, byte index, int bLength, byte[] payload)
+        {
+            ThrowIfDisposed();
+            if (payload.Length > PayloadCapacity)
+                throw new ArgumentException($"payload is {payload.Length} bytes, max {PayloadCapacity}", nameof(payload));
+
+            var report = new byte[ReportLength];
+            report[0] = ReportId;
+            report[1] = command;
+            report[2] = index;
+            report[3] = (byte)(bLength & 0xFF);
+            report[4] = (byte)(bLength >> 8);
+            payload.CopyTo(report, PayloadAt);
+
+            return Transfer(report, write: true) > 0;
+        }
+
+        private byte[]? Read()
+        {
+            var buffer = new byte[ReportLength];
+            return Transfer(buffer, write: false) > 0 ? buffer : null;
+        }
+
+        /// <summary>
+        /// Overlapped rather than synchronous so a device that never answers times out instead of
+        /// hanging the caller forever inside ReadFile. A keyboard that does not reply is a result.
+        /// </summary>
+        private int Transfer(byte[] buffer, bool write)
+        {
+            using var completed = new ManualResetEvent(false);
+            var overlapped = new NativeOverlapped
+            {
+                EventHandle = completed.SafeWaitHandle.DangerousGetHandle()
+            };
+
+            bool started = write
+                ? Native.WriteFile(_handle, buffer, (uint)buffer.Length, out uint transferred, ref overlapped)
+                : Native.ReadFile(_handle, buffer, (uint)buffer.Length, out transferred, ref overlapped);
+
+            if (!started)
+            {
+                if (Marshal.GetLastWin32Error() != Native.ErrorIoPending) return 0;
+
+                if (!completed.WaitOne(IoTimeout))
+                {
+                    Native.CancelIo(_handle);
+                    return 0;
+                }
+
+                if (!Native.GetOverlappedResult(_handle, ref overlapped, out transferred, true)) return 0;
+            }
+
+            return (int)transferred;
+        }
+
+        private static readonly TimeSpan IoTimeout = TimeSpan.FromMilliseconds(1500);
+
+        private static IEnumerable<string> EnumerateHidPaths()
+        {
+            using var searcher = new System.Management.ManagementObjectSearcher(
+                "SELECT PNPDeviceID FROM Win32_PnPEntity WHERE PNPDeviceID LIKE 'HID%'");
+
+            foreach (System.Management.ManagementObject o in searcher.Get())
+            {
+                string? id = o["PNPDeviceID"]?.ToString();
+                if (string.IsNullOrEmpty(id)) continue;
+                yield return $@"\\?\{id.Replace('\\', '#')}#{{4d1e55b2-f16f-11cf-88cb-001111000030}}";
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed) throw new ObjectDisposedException(nameof(DojoKeyboardMcu));
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            if (_handle != IntPtr.Zero && _handle != Native.InvalidHandle) Native.CloseHandle(_handle);
+        }
+
+        private static class Native
+        {
+            internal const uint GenericRead = 0x80000000;
+            internal const uint GenericWrite = 0x40000000;
+            internal const uint ShareReadWrite = 0x03;
+            internal const uint OpenExisting = 3;
+            internal const uint FileFlagOverlapped = 0x40000000;
+            internal const int ErrorIoPending = 997;
+            internal static readonly IntPtr InvalidHandle = new(-1);
+
+            [StructLayout(LayoutKind.Sequential)]
+            internal struct HiddAttributes { public int Size; public ushort VendorID, ProductID, VersionNumber; }
+
+            [StructLayout(LayoutKind.Sequential)]
+            internal struct HidpCaps
+            {
+                public ushort Usage, UsagePage, InputReportByteLength, OutputReportByteLength, FeatureReportByteLength;
+                [MarshalAs(UnmanagedType.ByValArray, SizeConst = 17)] public ushort[] Reserved;
+                public ushort NumberLinkCollectionNodes, NumberInputButtonCaps, NumberInputValueCaps,
+                              NumberInputDataIndices, NumberOutputButtonCaps, NumberOutputValueCaps,
+                              NumberOutputDataIndices, NumberFeatureButtonCaps, NumberFeatureValueCaps,
+                              NumberFeatureDataIndices;
+            }
+
+            [DllImport("hid.dll")] internal static extern bool HidD_GetAttributes(IntPtr h, ref HiddAttributes a);
+            [DllImport("hid.dll")] internal static extern bool HidD_GetPreparsedData(IntPtr h, out IntPtr p);
+            [DllImport("hid.dll")] internal static extern bool HidD_FreePreparsedData(IntPtr p);
+            [DllImport("hid.dll")] internal static extern int HidP_GetCaps(IntPtr p, ref HidpCaps c);
+            [DllImport("hid.dll")] internal static extern bool HidD_GetProductString(IntPtr h, byte[] b, int len);
+
+            [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+            internal static extern IntPtr CreateFileW(string path, uint access, uint share, IntPtr sa,
+                                                      uint disposition, uint flags, IntPtr template);
+            [DllImport("kernel32.dll", SetLastError = true)]
+            internal static extern bool WriteFile(IntPtr h, byte[] b, uint len, out uint written, ref NativeOverlapped o);
+            [DllImport("kernel32.dll", SetLastError = true)]
+            internal static extern bool ReadFile(IntPtr h, byte[] b, uint len, out uint read, ref NativeOverlapped o);
+            [DllImport("kernel32.dll", SetLastError = true)]
+            internal static extern bool GetOverlappedResult(IntPtr h, ref NativeOverlapped o, out uint transferred, bool wait);
+            [DllImport("kernel32.dll")] internal static extern bool CancelIo(IntPtr h);
+            [DllImport("kernel32.dll")] internal static extern bool CloseHandle(IntPtr h);
+        }
+    }
+}

--- a/src/OmenCoreApp/Hardware/DojoKeyboardMcu.cs
+++ b/src/OmenCoreApp/Hardware/DojoKeyboardMcu.cs
@@ -19,8 +19,10 @@ namespace OmenCore.Hardware
     ///          twelve effects OMEN Gaming Hub offers are one frame each, rendered device-side with
     ///          no host involvement. Has a real state readback.
     ///
-    /// So "per-key RGB" splits cleanly: a static picture goes to mi_04, a running effect goes here.
-    /// A caller that sends an effect and then paints lamps is fighting itself.
+    /// The MCU also owns the STATIC COLOUR MAP via commands 0x05/0x06/0x07 - the same path OGH
+    /// uses. A colour set this way is held by the MCU and survives the Fn overlay, because the
+    /// MCU can redraw its own picture. The LampArray (mi_04) path requires host ownership, and
+    /// a picture set that way is lost after Fn because the MCU has no base layer to restore.
     ///
     /// PROTOCOL PROVENANCE. Derived from OMEN Gaming Hub 1101.2607.3.0 - McuSDK2.dll's
     /// <c>GeneralCommandHelper</c> and <c>StarmadeKbLightingEffectCommandHelper</c> - and confirmed
@@ -94,8 +96,17 @@ namespace OmenCore.Hardware
         private const byte CmdStoreLightingToFlash = 0x0A;
         private const byte CmdSetBrightness = 0x0C;
         private const byte CmdSetLightingEffect = 0x03;
+        private const byte CmdSetKeyR = 0x05;
+        private const byte CmdSetKeyG = 0x06;
+        private const byte CmdSetKeyB = 0x07;
         private const byte CmdRestoreDefault = 0x10;
         private const byte CmdGetLightingEffect = 0x83;
+
+        // OGH's key map on 8D87 is 176 entries (60 + 60 + 56), read off the capture rather than
+        // the decompile. Three pages per channel, BLength declared as 0 on all nine pages while
+        // each carries PayloadCapacity colour bytes.
+        private const int ColorMapLength = 176;
+        private const int ColorPages = 3;
 
         /// <summary>LightingEffectTarget.ALL_LED_AREA - the only target a keyboard has.</summary>
         private const byte TargetAllLedArea = 0x00;
@@ -437,13 +448,47 @@ namespace OmenCore.Hardware
         public bool RestoreFirmwareDefaults() =>
             Send(CmdRestoreDefault, RestoreIndex, RestoreMagic);
 
+        /// <summary>
+        /// Set every key to one colour via the MCU's own static colour map (commands 0x05/0x06/0x07).
+        ///
+        /// This is the path OGH uses for per-key colour: command 0x09 with payload 0x01 switches
+        /// to the static display mode, then three channels of colour pages fill the 176-entry map.
+        /// The MCU holds the map and redraws it after the Fn overlay — which is the property the
+        /// LampArray path does not have, and the reason this method exists.
+        ///
+        /// Volatile until <see cref="StoreToFlash"/>.
+        /// </summary>
+        public bool SetStaticColor(byte r, byte g, byte b)
+        {
+            if (!Send(CmdSetLightingOnOff, 0, new byte[] { 0x01 })) return false;
+
+            return SendUniformColorPages(CmdSetKeyR, r)
+                && SendUniformColorPages(CmdSetKeyG, g)
+                && SendUniformColorPages(CmdSetKeyB, b);
+        }
+
+        private bool SendUniformColorPages(byte command, byte value)
+        {
+            for (byte page = 0; page < ColorPages; page++)
+            {
+                int fill = Math.Min(PayloadCapacity, ColorMapLength - page * PayloadCapacity);
+                var payload = new byte[PayloadCapacity];
+                for (int i = 0; i < fill; i++) payload[i] = value;
+                if (!Send(command, page, 0, payload)) return false;
+            }
+            return true;
+        }
+
         // ── Wire ───────────────────────────────────────────────────────────────────
 
         /// <summary>Write a frame and require an <c>EC AC</c> reply. False covers refused,
         /// unanswered and failed-to-write alike; the caller cannot act differently on those.</summary>
-        private bool Send(byte command, byte index, byte[] payload)
+        private bool Send(byte command, byte index, byte[] payload) =>
+            Send(command, index, payload.Length, payload);
+
+        private bool Send(byte command, byte index, int bLength, byte[] payload)
         {
-            if (!Write(command, index, payload.Length, payload)) return false;
+            if (!Write(command, index, bLength, payload)) return false;
 
             byte[]? reply = Read();
             if (reply == null || reply.Length < PayloadAt + 2) return false;

--- a/src/OmenCoreApp/Hardware/DojoKeyboardMcu.cs
+++ b/src/OmenCoreApp/Hardware/DojoKeyboardMcu.cs
@@ -102,10 +102,13 @@ namespace OmenCore.Hardware
         private const byte CmdRestoreDefault = 0x10;
         private const byte CmdGetLightingEffect = 0x83;
 
-        // OGH's key map on 8D87 is 176 entries (60 + 60 + 56), read off the capture rather than
-        // the decompile. Three pages per channel, BLength declared as 0 on all nine pages while
-        // each carries PayloadCapacity colour bytes.
-        private const int ColorMapLength = 176;
+        // OGH's key map on 8D87 is 176 entries, matching HP's own layout resource: the pre-26C1
+        // DojoKBKeysGlobalData.json declares 180 and SetNullBytes zeroes 176-179 as padding. Every
+        // position below that is a real LED - 8D87 is cycle 25C1, so the cycle > 260 row that would
+        // blank 137, 138 and 146 does not apply, and lighting those positions confirms they are
+        // KeyDot and the last cell of KeyShiftR. Three pages per channel, BLength declared as 0 on
+        // all nine pages while each carries PayloadCapacity colour bytes.
+        public const int ColorMapLength = 176;
         private const int ColorPages = 3;
 
         /// <summary>LightingEffectTarget.ALL_LED_AREA - the only target a keyboard has.</summary>
@@ -460,20 +463,60 @@ namespace OmenCore.Hardware
         /// </summary>
         public bool SetStaticColor(byte r, byte g, byte b)
         {
-            if (!Send(CmdSetLightingOnOff, 0, new byte[] { 0x01 })) return false;
+            var rc = new byte[ColorMapLength];
+            var gc = new byte[ColorMapLength];
+            var bc = new byte[ColorMapLength];
+            Array.Fill(rc, r);
+            Array.Fill(gc, g);
+            Array.Fill(bc, b);
 
-            return SendUniformColorPages(CmdSetKeyR, r)
-                && SendUniformColorPages(CmdSetKeyG, g)
-                && SendUniformColorPages(CmdSetKeyB, b);
+            return SetStaticColorMap(rc, gc, bc);
         }
 
-        private bool SendUniformColorPages(byte command, byte value)
+        /// <summary>
+        /// Set every key INDIVIDUALLY via the same static colour map, one entry per LED position.
+        ///
+        /// This is the only way a per-key picture survives the Fn overlay. The MCU redraws its base
+        /// layer from its own state when Fn is released, and this map is that state; a picture
+        /// painted onto the mi_04 LampArray is not, so the display stays on the overlay frame
+        /// indefinitely. Anything that wants a picture to STAY belongs here rather than there.
+        ///
+        /// Each channel is indexed by LED position and must be <see cref="ColorMapLength"/> long.
+        /// Every position is live on this board, so a colour reaches all of them.
+        ///
+        /// Volatile until <see cref="StoreToFlash"/>.
+        /// </summary>
+        public bool SetStaticColorMap(ReadOnlySpan<byte> r, ReadOnlySpan<byte> g, ReadOnlySpan<byte> b)
+        {
+            if (r.Length != ColorMapLength || g.Length != ColorMapLength || b.Length != ColorMapLength)
+                throw new ArgumentException(
+                    $"Each channel must be {ColorMapLength} entries, one per LED position; " +
+                    $"got {r.Length}/{g.Length}/{b.Length}.");
+
+            // Command 0x09 with payload 0x01 selects the static display mode. OGH sends it ahead of
+            // every colour round and so does this - without it the colour pages land in a map the
+            // effect engine is not displaying.
+            if (!Send(CmdSetLightingOnOff, 0, new byte[] { 0x01 })) return false;
+
+            return SendColorPages(CmdSetKeyR, r)
+                && SendColorPages(CmdSetKeyG, g)
+                && SendColorPages(CmdSetKeyB, b);
+        }
+
+        private bool SendColorPages(byte command, ReadOnlySpan<byte> channel)
         {
             for (byte page = 0; page < ColorPages; page++)
             {
-                int fill = Math.Min(PayloadCapacity, ColorMapLength - page * PayloadCapacity);
+                int from = page * PayloadCapacity;
+                int fill = Math.Min(PayloadCapacity, ColorMapLength - from);
+
+                // The payload is always the full 60 bytes even on the last page, where only 56 of
+                // them are map entries - HP's page 2 carries 56 colour bytes and four zeros. BLength
+                // is declared 0 on all nine pages, which is what the capture shows on the wire.
                 var payload = new byte[PayloadCapacity];
-                for (int i = 0; i < fill; i++) payload[i] = value;
+                for (int i = 0; i < fill; i++)
+                    payload[i] = channel[from + i];
+
                 if (!Send(command, page, 0, payload)) return false;
             }
             return true;

--- a/src/OmenCoreApp/Hardware/FanControllerFactory.cs
+++ b/src/OmenCoreApp/Hardware/FanControllerFactory.cs
@@ -423,7 +423,12 @@ namespace OmenCore.Hardware
                     ecAccess: _ecAccess,
                     strictFanModeReadback: !conservativeWmiProfile,
                     allowV1AutoModeFloorClear: allowV1AutoModeFloorClear,
-                    maxModeDropChecksBeforeReapply: _capabilities?.ModelConfig?.MaxModeDropChecksBeforeReapply);
+                    maxModeDropChecksBeforeReapply: _capabilities?.ModelConfig?.MaxModeDropChecksBeforeReapply,
+                    // Not gated on conservativeWmiProfile: that gate is about EC *writes*, and
+                    // these offsets are read-only. A board with EC fan control disabled can
+                    // still have a perfectly readable tachometer, and on the boards where
+                    // GetFanRpmDirect is refused it is the only physical RPM source there is.
+                    ecFanTachometerOffsets: _capabilities?.ModelConfig?.EcFanTachometerOffsets);
                 if (controller.IsAvailable)
                 {
                     if (conservativeWmiProfile)

--- a/src/OmenCoreApp/Hardware/HidLampArray.cs
+++ b/src/OmenCoreApp/Hardware/HidLampArray.cs
@@ -1,0 +1,412 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace OmenCore.Hardware
+{
+    /// <summary>
+    /// Per-key RGB over the standardised HID LampArray surface (usage page 0x59, "Lighting And
+    /// Illumination") - the same protocol Windows Dynamic Lighting speaks.
+    ///
+    /// This is worth stating plainly because it changes what per-key RGB costs: on boards whose
+    /// keyboard implements this, there is no vendor command set to reverse engineer. Board 8D87
+    /// (OMEN MAX 16, 2025 AMD) reports 120 addressable lamps of kind Keyboard across 342 x 125 mm,
+    /// 8-bit per channel, each carrying the HID usage of the key it sits under.
+    ///
+    /// TWO THINGS THIS CANNOT DO, both of which matter before trusting it:
+    ///
+    /// 1. It cannot confirm its own work. The LampArray spec has no colour readback anywhere, so
+    ///    "did that key turn red" has no software answer - only a person looking at the keyboard.
+    ///    Every method here reports whether the WRITE was accepted, which is not the same claim.
+    ///
+    /// 2. It does not own the device. Windows Dynamic Lighting takes LampArray devices when it is
+    ///    enabled and refreshes them continuously, so a colour written here can be overwritten
+    ///    within one refresh interval (33 ms on 8D87). <see cref="SetAutonomousMode"/> asks the
+    ///    device to stop running its own effects; it does not ask Windows to stop running its.
+    ///    Arbitrating with Dynamic Lighting is a policy decision, not a transport one.
+    /// </summary>
+    public sealed class HidLampArray : IDisposable
+    {
+        // Report ids from the HID Lighting And Illumination page.
+        private const byte ReportArrayAttributes = 1;
+        private const byte ReportLampAttributesRequest = 2;
+        private const byte ReportLampAttributesResponse = 3;
+        private const byte ReportMultiUpdate = 4;
+        private const byte ReportRangeUpdate = 5;
+        private const byte ReportControl = 6;
+
+        /// <summary>LampMultiUpdateReport carries at most this many lamps per transaction.</summary>
+        public const int MaxLampsPerUpdate = 8;
+
+        /// <summary>Shortest feature report whose attribute fields this class can parse.</summary>
+        private const int MinReadableReportLength = 29;
+
+        /// <summary>
+        /// Bytes a LampMultiUpdateReport needs: report id, lamp count, flags, eight u16 ids, then
+        /// eight RGBI quads. The id and channel arrays are sized for eight lamps whether or not
+        /// all eight are used, so a shorter report cannot carry this message at all.
+        /// </summary>
+        private const int MultiUpdateReportLength = 3 + (MaxLampsPerUpdate * 2) + (MaxLampsPerUpdate * 4);
+
+        private const ushort LightingUsagePage = 0x59;
+        private const ushort LampArrayUsage = 0x01;
+
+        private readonly IntPtr _handle;
+        private readonly int _reportLength;
+        private bool _disposed;
+
+        /// <summary>Number of addressable lamps.</summary>
+        public ushort LampCount { get; private init; }
+
+        /// <summary>Device kind. 1 is Keyboard.</summary>
+        public uint Kind { get; private init; }
+
+        /// <summary>Shortest interval the device will accept updates at.</summary>
+        public TimeSpan MinUpdateInterval { get; private init; }
+
+        public ushort VendorId { get; private init; }
+        public ushort ProductId { get; private init; }
+        public string DevicePath { get; private init; } = string.Empty;
+
+        private HidLampArray(IntPtr handle, int reportLength)
+        {
+            _handle = handle;
+            _reportLength = reportLength;
+        }
+
+        /// <summary>
+        /// Open every HID LampArray on the system. Callers pick by <see cref="Kind"/> and
+        /// <see cref="LampCount"/> - a machine can expose more than one, and on 8D87 the
+        /// four-zone backlight appears as a separate virtual "Scene" array alongside the keyboard.
+        /// </summary>
+        public static IReadOnlyList<HidLampArray> OpenAll()
+        {
+            var found = new List<HidLampArray>();
+
+            foreach (string path in Native.EnumerateHidPaths())
+            {
+                var device = TryOpen(path);
+                if (device != null) found.Add(device);
+            }
+
+            return found;
+        }
+
+        private static HidLampArray? TryOpen(string path)
+        {
+            // Identify before asking for anything. This runs over EVERY HID device on the machine,
+            // most of which are mice, keyboards and touchpads that have nothing to do with
+            // lighting, so requesting read/write up front would be asking for write access to the
+            // user's input devices just to read a usage page off them. A zero-access handle is
+            // enough for the descriptor queries and cannot write by construction.
+            IntPtr probe = Native.CreateFileW(path, 0, Native.ShareReadWrite, IntPtr.Zero,
+                                              Native.OpenExisting, 0, IntPtr.Zero);
+            if (probe == Native.InvalidHandle) return null;
+
+            ushort usagePage, usage, featureLength;
+            try
+            {
+                if (!Native.HidD_GetPreparsedData(probe, out IntPtr preparsed)) return null;
+                try
+                {
+                    var caps = new Native.HidpCaps();
+                    Native.HidP_GetCaps(preparsed, ref caps);
+                    usagePage = caps.UsagePage;
+                    usage = caps.Usage;
+                    featureLength = caps.FeatureReportByteLength;
+                }
+                finally { Native.HidD_FreePreparsedData(preparsed); }
+            }
+            finally { Native.CloseHandle(probe); }
+
+            // The attributes reports this class reads reach byte 28, so anything shorter than
+            // that cannot be parsed without reading past the buffer. A real LampArray is at
+            // least 51 bytes - that is LampMultiUpdateReport's size - but the check is against
+            // what is actually indexed rather than what is expected.
+            if (usagePage != LightingUsagePage || usage != LampArrayUsage ||
+                featureLength < MinReadableReportLength)
+            {
+                return null;
+            }
+
+            // Only now, and only for a device that really is a LampArray.
+            IntPtr h = Native.CreateFileW(path, Native.GenericReadWrite, Native.ShareReadWrite,
+                                          IntPtr.Zero, Native.OpenExisting, 0, IntPtr.Zero);
+            if (h == Native.InvalidHandle) return null;
+
+            try
+            {
+                var attrs = new Native.HiddAttributes { Size = Marshal.SizeOf<Native.HiddAttributes>() };
+                Native.HidD_GetAttributes(h, ref attrs);
+
+                var buffer = new byte[featureLength];
+                buffer[0] = ReportArrayAttributes;
+                if (!Native.HidD_GetFeature(h, buffer, buffer.Length))
+                {
+                    Native.CloseHandle(h);
+                    return null;
+                }
+
+                return new HidLampArray(h, featureLength)
+                {
+                    LampCount = BitConverter.ToUInt16(buffer, 1),
+                    Kind = BitConverter.ToUInt32(buffer, 15),
+                    MinUpdateInterval = TimeSpan.FromMilliseconds(BitConverter.ToUInt32(buffer, 19) / 1000.0),
+                    VendorId = attrs.VendorID,
+                    ProductId = attrs.ProductID,
+                    DevicePath = path
+                };
+            }
+            catch
+            {
+                Native.CloseHandle(h);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Read one lamp's attributes: where it is, and which key it sits under.
+        ///
+        /// The returned LampId is included deliberately rather than assumed to match
+        /// <paramref name="lampId"/>. On board 8D87's keyboard the response ignores the request
+        /// and free-runs - asking for 0, 1, 2, 3 returns ids 41, 42, 43, 44 - while the virtual
+        /// four-zone array on the same machine pairs correctly. Callers that need a specific
+        /// lamp must check the id they got back.
+        /// </summary>
+        public LampInfo? GetLampInfo(ushort lampId)
+        {
+            ThrowIfDisposed();
+
+            var request = new byte[_reportLength];
+            request[0] = ReportLampAttributesRequest;
+            request[1] = (byte)(lampId & 0xFF);
+            request[2] = (byte)(lampId >> 8);
+            if (!Native.HidD_SetFeature(_handle, request, request.Length)) return null;
+
+            var response = new byte[_reportLength];
+            response[0] = ReportLampAttributesResponse;
+            if (!Native.HidD_GetFeature(_handle, response, response.Length)) return null;
+
+            return new LampInfo(
+                BitConverter.ToUInt16(response, 1),
+                BitConverter.ToUInt32(response, 3),
+                BitConverter.ToUInt32(response, 7),
+                BitConverter.ToUInt32(response, 11),
+                response[28]);
+        }
+
+        /// <summary>
+        /// Take the lamps away from the device's own effect engine, or hand them back.
+        ///
+        /// Ask for host control before writing colours: a device still running its own animation
+        /// will overwrite them. This says nothing about Windows Dynamic Lighting, which is a
+        /// separate owner - see the remarks on the class.
+        /// </summary>
+        public bool SetAutonomousMode(bool autonomous)
+        {
+            ThrowIfDisposed();
+
+            var report = new byte[_reportLength];
+            report[0] = ReportControl;
+            report[1] = (byte)(autonomous ? 1 : 0);
+            return Native.HidD_SetFeature(_handle, report, report.Length);
+        }
+
+        /// <summary>
+        /// Read the current autonomous-mode setting back, or null if the device will not answer.
+        ///
+        /// The HID spec does not require the control report to be readable, so null is a normal
+        /// answer rather than a failure. Where it IS readable it is the only way to tell an
+        /// accepted control report from an applied one - a distinction that matters here, because
+        /// <see cref="SetAutonomousMode"/> returning true means the device took the message, not
+        /// that it acted on it.
+        /// </summary>
+        public bool? TryReadAutonomousMode()
+        {
+            ThrowIfDisposed();
+
+            var report = new byte[_reportLength];
+            report[0] = ReportControl;
+            return Native.HidD_GetFeature(_handle, report, report.Length)
+                ? report[1] != 0
+                : null;
+        }
+
+        /// <summary>
+        /// Set a contiguous run of lamps to one colour, inclusive of both ends.
+        /// Cheaper than <see cref="SetLamps"/> when the colour is uniform - one transaction
+        /// instead of one per eight lamps.
+        /// </summary>
+        public bool SetRange(ushort firstLampId, ushort lastLampId, byte r, byte g, byte b, byte intensity = 255)
+        {
+            ThrowIfDisposed();
+
+            var report = BuildRangeUpdateReport(_reportLength, firstLampId, lastLampId, r, g, b, intensity);
+            return Native.HidD_SetFeature(_handle, report, report.Length);
+        }
+
+        /// <summary>Set every lamp to one colour.</summary>
+        public bool SetAll(byte r, byte g, byte b, byte intensity = 255) =>
+            LampCount > 0 && SetRange(0, (ushort)(LampCount - 1), r, g, b, intensity);
+
+        /// <summary>
+        /// Set individually coloured lamps. Sent in batches of <see cref="MaxLampsPerUpdate"/>,
+        /// which is all one LampMultiUpdateReport holds.
+        ///
+        /// Only the final batch is flagged complete, so the device applies the whole set at once
+        /// rather than tearing partway through a frame.
+        ///
+        /// Returns true when every batch was accepted. That means accepted, not visible - this
+        /// class cannot see the keyboard.
+        /// </summary>
+        public bool SetLamps(IReadOnlyList<LampColor> lamps)
+        {
+            ThrowIfDisposed();
+            if (lamps == null) throw new ArgumentNullException(nameof(lamps));
+            if (lamps.Count == 0) return true;
+
+            // A device whose feature reports are shorter than this cannot carry a multi-update.
+            // Refusing is the honest answer - writing a truncated one would either overrun the
+            // buffer or send a malformed report the device might partly act on.
+            if (_reportLength < MultiUpdateReportLength) return false;
+
+            bool allAccepted = true;
+
+            for (int offset = 0; offset < lamps.Count; offset += MaxLampsPerUpdate)
+            {
+                int count = Math.Min(MaxLampsPerUpdate, lamps.Count - offset);
+                bool isLastBatch = offset + count >= lamps.Count;
+
+                var report = BuildMultiUpdateReport(_reportLength, lamps, offset, count, isLastBatch);
+                if (!Native.HidD_SetFeature(_handle, report, report.Length))
+                {
+                    allAccepted = false;
+                }
+            }
+
+            return allAccepted;
+        }
+
+        /// <summary>
+        /// Lay out one LampMultiUpdateReport. Separated from the write so the byte offsets can be
+        /// tested: a wrong offset here does not fail loudly, it lights the wrong key.
+        /// </summary>
+        internal static byte[] BuildMultiUpdateReport(
+            int reportLength, IReadOnlyList<LampColor> lamps, int offset, int count, bool isLastBatch)
+        {
+            var report = new byte[reportLength];
+            report[0] = ReportMultiUpdate;
+            report[1] = (byte)count;
+            report[2] = (byte)(isLastBatch ? 0x01 : 0x00); // LampUpdateComplete
+
+            for (int i = 0; i < count; i++)
+            {
+                var lamp = lamps[offset + i];
+
+                // Ids are a packed u16 array at byte 3; channels are a packed RGBI array starting
+                // after ALL EIGHT id slots, whether or not they are all used. Packing the channels
+                // immediately after the ids in use would misalign every lamp in a partial batch.
+                int idAt = 3 + (i * 2);
+                report[idAt] = (byte)(lamp.LampId & 0xFF);
+                report[idAt + 1] = (byte)(lamp.LampId >> 8);
+
+                int channelAt = 3 + (MaxLampsPerUpdate * 2) + (i * 4);
+                report[channelAt] = lamp.R;
+                report[channelAt + 1] = lamp.G;
+                report[channelAt + 2] = lamp.B;
+                report[channelAt + 3] = lamp.Intensity;
+            }
+
+            return report;
+        }
+
+        /// <summary>
+        /// Lay out one LampRangeUpdateReport. Separated for the same reason as
+        /// <see cref="BuildMultiUpdateReport"/>.
+        /// </summary>
+        internal static byte[] BuildRangeUpdateReport(
+            int reportLength, ushort firstLampId, ushort lastLampId, byte r, byte g, byte b, byte intensity)
+        {
+            var report = new byte[reportLength];
+            report[0] = ReportRangeUpdate;
+            report[1] = 0x01; // LampUpdateComplete - apply on receipt
+            report[2] = (byte)(firstLampId & 0xFF);
+            report[3] = (byte)(firstLampId >> 8);
+            report[4] = (byte)(lastLampId & 0xFF);
+            report[5] = (byte)(lastLampId >> 8);
+            report[6] = r;
+            report[7] = g;
+            report[8] = b;
+            report[9] = intensity;
+            return report;
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed) throw new ObjectDisposedException(nameof(HidLampArray));
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            if (_handle != IntPtr.Zero && _handle != Native.InvalidHandle) Native.CloseHandle(_handle);
+        }
+
+        /// <summary>One lamp's physical placement and the key it lights.</summary>
+        public readonly record struct LampInfo(ushort LampId, uint XMicrometres, uint YMicrometres,
+                                               uint ZMicrometres, byte KeyUsage);
+
+        /// <summary>A colour destined for one lamp.</summary>
+        public readonly record struct LampColor(ushort LampId, byte R, byte G, byte B, byte Intensity = 255);
+
+        private static class Native
+        {
+            internal const uint GenericReadWrite = 0xC0000000;
+            internal const uint ShareReadWrite = 0x03;
+            internal const uint OpenExisting = 3;
+            internal static readonly IntPtr InvalidHandle = new(-1);
+
+            private static readonly Guid HidInterfaceGuid = new("4d1e55b2-f16f-11cf-88cb-001111000030");
+
+            [StructLayout(LayoutKind.Sequential)]
+            internal struct HiddAttributes { public int Size; public ushort VendorID, ProductID, VersionNumber; }
+
+            [StructLayout(LayoutKind.Sequential)]
+            internal struct HidpCaps
+            {
+                public ushort Usage, UsagePage, InputReportByteLength, OutputReportByteLength, FeatureReportByteLength;
+                [MarshalAs(UnmanagedType.ByValArray, SizeConst = 17)] public ushort[] Reserved;
+                public ushort NumberLinkCollectionNodes, NumberInputButtonCaps, NumberInputValueCaps,
+                              NumberInputDataIndices, NumberOutputButtonCaps, NumberOutputValueCaps,
+                              NumberOutputDataIndices, NumberFeatureButtonCaps, NumberFeatureValueCaps,
+                              NumberFeatureDataIndices;
+            }
+
+            [DllImport("hid.dll")] internal static extern bool HidD_GetAttributes(IntPtr h, ref HiddAttributes a);
+            [DllImport("hid.dll")] internal static extern bool HidD_GetPreparsedData(IntPtr h, out IntPtr p);
+            [DllImport("hid.dll")] internal static extern bool HidD_FreePreparsedData(IntPtr p);
+            [DllImport("hid.dll")] internal static extern int HidP_GetCaps(IntPtr p, ref HidpCaps c);
+            [DllImport("hid.dll")] internal static extern bool HidD_GetFeature(IntPtr h, byte[] b, int len);
+            [DllImport("hid.dll")] internal static extern bool HidD_SetFeature(IntPtr h, byte[] b, int len);
+
+            [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+            internal static extern IntPtr CreateFileW(string path, uint access, uint share, IntPtr sa,
+                                                      uint disposition, uint flags, IntPtr template);
+            [DllImport("kernel32.dll")] internal static extern bool CloseHandle(IntPtr h);
+
+            internal static IEnumerable<string> EnumerateHidPaths()
+            {
+                using var searcher = new System.Management.ManagementObjectSearcher(
+                    "SELECT PNPDeviceID FROM Win32_PnPEntity WHERE PNPDeviceID LIKE 'HID%'");
+
+                foreach (System.Management.ManagementObject o in searcher.Get())
+                {
+                    string? id = o["PNPDeviceID"]?.ToString();
+                    if (string.IsNullOrEmpty(id)) continue;
+                    yield return $@"\\?\{id.Replace('\\', '#')}#{{{HidInterfaceGuid}}}";
+                }
+            }
+        }
+    }
+}

--- a/src/OmenCoreApp/Hardware/HidLampArray.cs
+++ b/src/OmenCoreApp/Hardware/HidLampArray.cs
@@ -68,6 +68,11 @@ namespace OmenCore.Hardware
         public ushort ProductId { get; private init; }
         public string DevicePath { get; private init; } = string.Empty;
 
+        /// <summary>Physical extent of the whole array, in micrometres.</summary>
+        public uint BoundingBoxWidthUm { get; private init; }
+        public uint BoundingBoxHeightUm { get; private init; }
+        public uint BoundingBoxDepthUm { get; private init; }
+
         private HidLampArray(IntPtr handle, int reportLength)
         {
             _handle = handle;
@@ -90,6 +95,73 @@ namespace OmenCore.Hardware
             }
 
             return found;
+        }
+
+        /// <summary>Device kind 1, Keyboard.</summary>
+        public const uint KindKeyboard = 1;
+
+        /// <summary>Device kind 5, Scene. What the light bar enumerates as.</summary>
+        public const uint KindScene = 5;
+
+        /// <summary>
+        /// Open the light bar, which enumerates as a Scene-kind LampArray of its own - on 8D87
+        /// "HID VHF Driver" 0461:0001, four lamps across a 323 x 5 mm strip, ids 0..3 left to right.
+        ///
+        /// THIS IS THE PATH THAT DOES NOT NEED ADMINISTRATOR. HP's WMI BIOS surface, which is the
+        /// only way to reach the bar's brightness and its nine built-in animations, requires
+        /// elevation because invoking methods in root\wmi does. HID feature reports do not: Windows
+        /// Dynamic Lighting is an unelevated user-mode component that drives exactly these devices,
+        /// which is the existence proof.
+        ///
+        /// What is given up by coming in this way is real - colour only, no brightness, no
+        /// animations, and no readback - so this is a fallback with a cost, not a free win.
+        /// </summary>
+        /// <param name="board">
+        /// Baseboard product id to gate on, or null to read the current machine's. Only boards where
+        /// this has been confirmed on hardware are served - see <see cref="OmenBoard.SupportsHidLightBar"/>
+        /// for why that is an allowlist and not a probe.
+        /// </param>
+        public static HidLampArray? OpenLightBar(string? board = null)
+        {
+            if (!OmenBoard.SupportsHidLightBar(board)) return null;
+
+            HidLampArray? bar = null;
+
+            foreach (var candidate in OpenAll())
+            {
+                if (bar == null && LooksLikeALightBar(candidate))
+                    bar = candidate;
+                else
+                    candidate.Dispose();
+            }
+
+            return bar;
+        }
+
+        /// <summary>
+        /// Whether a LampArray is shaped like a light bar.
+        ///
+        /// Kind and lamp count alone are NOT enough, and this is the whole safety property of
+        /// <see cref="OpenLightBar"/>: "Scene, four lamps" would also match a dock, an external
+        /// strip, a mousepad, or a fan hub - and matching one of those means writing colour to a
+        /// device the user never asked about. The geometry is what actually identifies a bar. On
+        /// 8D87 it measures 323 x 5 mm, a ratio of 65:1, which nothing else plausibly is.
+        ///
+        /// Only ever consulted on hardware this code has not seen, so it is deliberately a shape
+        /// test rather than a VID:PID allowlist - an allowlist of one entry would be a claim about
+        /// every other OMEN, made from a sample of one machine.
+        /// </summary>
+        private static bool LooksLikeALightBar(HidLampArray a)
+        {
+            const uint MinWidthUm = 100_000;  // 100 mm - a bar spans the chassis
+            const uint MaxHeightUm = 20_000;  //  20 mm - and is a strip, not a panel
+            const uint MinAspect = 10;
+
+            return a.Kind == KindScene
+                && a.LampCount is >= 2 and <= 8
+                && a.BoundingBoxWidthUm >= MinWidthUm
+                && a.BoundingBoxHeightUm is > 0 and <= MaxHeightUm
+                && a.BoundingBoxWidthUm / a.BoundingBoxHeightUm >= MinAspect;
         }
 
         private static HidLampArray? TryOpen(string path)
@@ -150,6 +222,9 @@ namespace OmenCore.Hardware
                 return new HidLampArray(h, featureLength)
                 {
                     LampCount = BitConverter.ToUInt16(buffer, 1),
+                    BoundingBoxWidthUm = BitConverter.ToUInt32(buffer, 3),
+                    BoundingBoxHeightUm = BitConverter.ToUInt32(buffer, 7),
+                    BoundingBoxDepthUm = BitConverter.ToUInt32(buffer, 11),
                     Kind = BitConverter.ToUInt32(buffer, 15),
                     MinUpdateInterval = TimeSpan.FromMilliseconds(BitConverter.ToUInt32(buffer, 19) / 1000.0),
                     VendorId = attrs.VendorID,

--- a/src/OmenCoreApp/Hardware/HpWmiBios.cs
+++ b/src/OmenCoreApp/Hardware/HpWmiBios.cs
@@ -2071,7 +2071,246 @@ namespace OmenCore.Hardware
             }
             return null;
         }
-        
+
+        #endregion
+
+        #region Light bar
+
+        // The light bar is a SEPARATE DEVICE from the keyboard, and on a per-key chassis it is the
+        // only thing the four-zone commands above can still reach. It has four zones, zone 0
+        // LEFTMOST, and one write command that carries static colour, animation, brightness and off
+        // all at once - which is why the payload below looks like several unrelated features
+        // sharing a buffer. It is.
+        //
+        // Measured on board 8D87 (OMEN MAX 16-ak0xxx, BIOS F.07). Map and evidence:
+        // omen-max-16/reference/wmi-commands.md#the-light-bar.
+
+        private const uint CMD_LIGHTBAR_SET = 0x0B;    // Keyboard class. Static, animation, off.
+        private const uint CMD_LIGHTBAR_GET_COLOR = 0x04;  // Default class. One zone per call.
+
+        /// <summary>Zones on the bar, left to right.</summary>
+        public const int LightBarZoneCount = 4;
+
+        /// <summary>TargetDevice at payload[0]. 1 is the four-zone keyboard animation path.</summary>
+        private const byte LightBarTarget = 0x00;
+
+        /// <summary>
+        /// The one colour this device must never be asked for.
+        ///
+        /// Its colour handling substitutes exactly two input values, and only two - #FF0000 becomes
+        /// #FE0000, which is cosmetically free, and #FFFFFF becomes #FEA3DA, which is VISIBLY
+        /// PURPLE-WHITE next to a real white. #FF0001 and #FFFFFE pass through byte-exact, so this
+        /// is a two-entry lookup rather than a gamma curve or a clamp, and one entry off is enough
+        /// to miss it. Asking for white and getting pink is the first thing a consumer of this API
+        /// would hit and the last thing they could explain, so it is routed around here rather than
+        /// documented and left to bite.
+        /// </summary>
+        private const uint LightBarPinkWhite = 0xFFFFFF;
+        private const byte LightBarWhiteRed = 0xFF, LightBarWhiteGreen = 0xFF, LightBarWhiteBlue = 0xFE;
+
+        /// <summary>Device-side animations. NOT the keyboard MCU's numbering - the same names have
+        /// different values there, and Ghosting, Ripple and OMEN X do not exist on this path.</summary>
+        public enum LightBarEffect : byte
+        {
+            Static = 0,
+            LightingSync = 1,
+            ColorCycle = 2,
+            Starlight = 3,
+            Breathing = 4,
+            Wave = 6,
+            Raindrop = 7,
+            AudioPulse = 8,
+            Confetti = 9,
+            Sun = 10,
+            Swipe = 11
+        }
+
+        public enum LightBarTheme : byte
+        {
+            Galaxy = 16, Volcano = 32, Jungle = 48, Ocean = 64, Custom = 80
+        }
+
+        public enum LightBarSpeed : byte { Slow = 0, Medium = 1, Fast = 2 }
+
+        /// <summary>Only two directions exist here, unlike the keyboard's eight.</summary>
+        public enum LightBarDirection : byte { Left = 4, Right = 8 }
+
+        /// <summary>
+        /// Paint the bar with up to four static colours, zone 0 leftmost.
+        ///
+        /// Fewer than four colours repeats the last one across the remaining zones, so a single
+        /// colour fills the bar.
+        /// </summary>
+        public bool SetLightBarColors(IReadOnlyList<(byte R, byte G, byte B)> zoneColors, byte brightness = 100)
+        {
+            if (!_isAvailable)
+            {
+                _logging?.Warn("Cannot set light bar: WMI BIOS not available");
+                return false;
+            }
+
+            if (zoneColors == null || zoneColors.Count == 0)
+            {
+                _logging?.Warn("SetLightBarColors: no colours given");
+                return false;
+            }
+
+            var payload = new byte[128];
+            payload[0] = LightBarTarget;
+            payload[1] = (byte)LightBarEffect.Static;
+            payload[3] = Math.Clamp(brightness, (byte)0, (byte)100);
+            payload[6] = LightBarZoneCount;
+
+            for (int zone = 0; zone < LightBarZoneCount; zone++)
+            {
+                var c = SubstituteWhite(zoneColors[Math.Min(zone, zoneColors.Count - 1)]);
+                int at = 7 + (zone * 3);
+                payload[at] = c.R;
+                payload[at + 1] = c.G;
+                payload[at + 2] = c.B;
+            }
+
+            return SendLightBar(payload, $"static, brightness {payload[3]}");
+        }
+
+        /// <summary>
+        /// Run one of the bar's built-in animations.
+        ///
+        /// Two of them look broken when driven naively and neither is a fault. Swipe has no preset
+        /// palette, so with a preset theme it renders BLACK - give it custom colours. Audio Pulse IS
+        /// its two level bytes: at 0 it is black by definition, and reproducing it means feeding
+        /// <paramref name="tribe"/> and <paramref name="bass"/> from an audio thread at around 5 Hz.
+        /// Held at a constant level it shows a constant colour rather than pulsing.
+        ///
+        /// NO READBACK EXISTS for animation state on this board - HP's own getter (Keyboard 0x0C)
+        /// answers FAIL. A true return means the firmware took the frame and nothing more.
+        /// </summary>
+        public bool SetLightBarAnimation(
+            LightBarEffect effect,
+            LightBarTheme theme = LightBarTheme.Galaxy,
+            LightBarSpeed speed = LightBarSpeed.Medium,
+            LightBarDirection direction = LightBarDirection.Left,
+            byte brightness = 100,
+            IReadOnlyList<(byte R, byte G, byte B)>? customColors = null,
+            byte tribe = 0,
+            byte bass = 0)
+        {
+            if (!_isAvailable)
+            {
+                _logging?.Warn("Cannot set light bar animation: WMI BIOS not available");
+                return false;
+            }
+
+            var payload = new byte[128];
+            payload[0] = LightBarTarget;
+            payload[1] = (byte)effect;
+
+            // Lighting sync carries no parameters at all; sending them is meaningless rather than
+            // harmful, but leaving the frame bare is what HP does.
+            if (effect != LightBarEffect.LightingSync)
+            {
+                // Speed, direction and theme share one byte. HP builds it by masking then adding -
+                // &= 252 then speed, &= 243 then direction, &= 15 then theme - which is how you can
+                // tell these are three fields in one byte rather than three adjacent bytes.
+                payload[2] = (byte)(((byte)speed & 0x03) | ((byte)direction & 0x0C) | ((byte)theme & 0xF0));
+                payload[3] = Math.Clamp(brightness, (byte)0, (byte)100);
+                payload[4] = tribe;
+                payload[5] = bass;
+
+                if (theme == LightBarTheme.Custom && customColors is { Count: > 0 })
+                {
+                    payload[6] = (byte)Math.Min(customColors.Count, LightBarZoneCount);
+                    for (int i = 0; i < payload[6]; i++)
+                    {
+                        var c = SubstituteWhite(customColors[i]);
+                        int at = 7 + (i * 3);
+                        payload[at] = c.R;
+                        payload[at + 1] = c.G;
+                        payload[at + 2] = c.B;
+                    }
+                }
+            }
+
+            if (effect == LightBarEffect.Swipe && theme != LightBarTheme.Custom)
+                _logging?.Warn("Light bar Swipe has no preset palette and will render BLACK; use Custom colours");
+
+            if (effect == LightBarEffect.AudioPulse && tribe == 0 && bass == 0)
+                _logging?.Warn("Light bar Audio Pulse IS its two level bytes; at 0 it renders BLACK");
+
+            return SendLightBar(payload, $"{effect}, theme {theme}, speed {speed}");
+        }
+
+        /// <summary>Turn the bar off - an all-zero payload, which is exactly what HP sends.</summary>
+        public bool SetLightBarOff() => SendLightBar(new byte[128], "off");
+
+        /// <summary>
+        /// Read one zone's colour back, or null if the read failed.
+        ///
+        /// COLOUR is readable on this path; ANIMATION and BRIGHTNESS are not. That is the opposite
+        /// of the keyboard MCU, where the whole effect record reads back and colour does not, so a
+        /// caller carrying assumptions from one device to the other will be wrong both ways.
+        /// </summary>
+        public (byte R, byte G, byte B)? GetLightBarZoneColor(int zone)
+        {
+            if (!_isAvailable || zone < 0 || zone >= LightBarZoneCount) return null;
+
+            try
+            {
+                var result = SendBiosCommand(BiosCmd.Default, CMD_LIGHTBAR_GET_COLOR,
+                                             new byte[] { (byte)zone, 0, 0, 0 }, 4);
+                if (result is { Length: >= 3 }) return (result[0], result[1], result[2]);
+            }
+            catch (Exception ex)
+            {
+                _logging?.Warn($"Failed to read light bar zone {zone}: {ex.Message}");
+            }
+
+            return null;
+        }
+
+        /// <summary>All four zone colours, left to right. Nulls where a zone would not answer.</summary>
+        public (byte R, byte G, byte B)?[] GetLightBarColors()
+        {
+            var zones = new (byte R, byte G, byte B)?[LightBarZoneCount];
+            for (int zone = 0; zone < LightBarZoneCount; zone++)
+                zones[zone] = GetLightBarZoneColor(zone);
+            return zones;
+        }
+
+        private static (byte R, byte G, byte B) SubstituteWhite((byte R, byte G, byte B) c)
+        {
+            uint packed = ((uint)c.R << 16) | ((uint)c.G << 8) | c.B;
+            return packed == LightBarPinkWhite
+                ? (LightBarWhiteRed, LightBarWhiteGreen, LightBarWhiteBlue)
+                : c;
+        }
+
+        private bool SendLightBar(byte[] payload, string what)
+        {
+            try
+            {
+                // OutSize 128, NOT 0. The firmware answers this command with a 128-byte reply even
+                // though the write needs nothing back, and asking for 0 makes SendBiosCommand
+                // return null on a write that succeeded - so the colours landed while this method
+                // reported failure. Measured: the readback showed the requested colours while the
+                // return value said False. This is the OutSize the measured PowerShell lever uses.
+                var result = SendBiosCommand(BiosCmd.Keyboard, CMD_LIGHTBAR_SET, payload, 128);
+                if (result != null)
+                {
+                    _logging?.Info($"Light bar: {what} accepted");
+                    return true;
+                }
+
+                _logging?.Warn($"Light bar: {what} returned null");
+            }
+            catch (Exception ex)
+            {
+                _logging?.Error($"Light bar: {what} failed: {ex.Message}", ex);
+            }
+
+            return false;
+        }
+
         #endregion
 
         /// <summary>

--- a/src/OmenCoreApp/Hardware/HpWmiBios.cs
+++ b/src/OmenCoreApp/Hardware/HpWmiBios.cs
@@ -119,6 +119,7 @@ namespace OmenCore.Hardware
         private const uint CMD_COLOR_GET = 0x02;      // GetColorTable - uses Keyboard cmd
         private const uint CMD_COLOR_SET = 0x03;      // SetColorTable - uses Keyboard cmd
         private const uint CMD_KBD_TYPE_GET = 0x01;   // GetKbdType - uses Keyboard cmd
+        private const uint CMD_KBD_PLATFORM_INFO = 0x2B; // Keyboard lighting topology - uses Default cmd
         private const uint CMD_BRIGHTNESS_GET = 0x04; // GetBrightness - uses Keyboard cmd (v2.9.0)
         private const uint CMD_HAS_BACKLIGHT = 0x06;  // HasBacklight / GetLedAnimation - uses Keyboard cmd
         private const uint CMD_ANIMATION_SET = 0x07;  // SetLedAnimation - uses Keyboard cmd (v2.9.0)
@@ -1557,16 +1558,118 @@ namespace OmenCore.Hardware
         }
 
         /// <summary>
+        /// Keyboard lighting topology, as HP's own software models it (NbKeyboardLightingType).
+        /// This is a different and wider enumeration than <see cref="KbdType"/>: it describes what
+        /// the lighting looks like, not what the key layout is.
+        /// </summary>
+        public enum KeyboardLightingType
+        {
+            None = -1,
+            /// <summary>Backlit but not addressable - no colour control.</summary>
+            Normal = 0,
+            FourZoneWithNumpad = 1,
+            FourZoneWithoutNumpad = 2,
+            /// <summary>Per-key addressable RGB. The four-zone command path does not apply.</summary>
+            RgbPerKey = 3,
+            OneZoneWithNumpad = 4,
+            OneZoneWithoutNumpad = 5
+        }
+
+        /// <summary>
+        /// Read the keyboard lighting topology: Default 0x2B, no input payload, 4-byte reply whose
+        /// byte 0 is NbKeyboardLightingType. This is the probe HP's own software gates keyboard
+        /// lighting on, and it is on the Default class, not the Keyboard one - the constant is
+        /// named WMI_CMD_TYPE_GET_PLATFORM_INFO and sits on the gaming-input surface.
+        ///
+        /// Measured on board 8D87 (OMEN MAX 16, 2025 AMD): returns 0x03 = RgbPerKey, which agrees
+        /// with the keyboard's own HID descriptors (a 120-lamp HID LampArray, kind Keyboard).
+        ///
+        /// Sends no payload deliberately. The transport rounds input size into buckets and a
+        /// zero-length input is a genuinely different framing from a 4-byte zero-filled one, not a
+        /// cosmetic difference - see the note on <see cref="GetKeyboardType"/>.
+        /// </summary>
+        public KeyboardLightingType? GetKeyboardLightingType()
+        {
+            if (!_isAvailable) return null;
+
+            try
+            {
+                var result = SendBiosCommand(BiosCmd.Default, CMD_KBD_PLATFORM_INFO, null, 4);
+                if (result == null || result.Length == 0)
+                {
+                    return null;
+                }
+
+                // Signed: None is -1, which arrives as 0xFF.
+                var value = (KeyboardLightingType)(sbyte)result[0];
+                if (!Enum.IsDefined(typeof(KeyboardLightingType), value))
+                {
+                    _logging?.Info($"Keyboard lighting topology byte 0x{result[0]:X2} is not a known type - reporting unknown");
+                    return null;
+                }
+
+                _logging?.Info($"Keyboard lighting topology: {value} (0x{result[0]:X2})");
+                return value;
+            }
+            catch (Exception ex)
+            {
+                _logging?.Warn($"Failed to read keyboard lighting topology: {ex.Message}");
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Whether the BIOS reports any addressable keyboard lighting: Keyboard 0x01, bit 0 of
+        /// byte 0, which is the only bit HP's own code reads.
+        ///
+        /// TREAT AS WEAK EVIDENCE, and prefer <see cref="GetKeyboardLightingType"/> wherever it
+        /// answers. This command is widely described as "GetKbdType" and it is not one. Measured
+        /// on board 8D87 across ten identical consecutive calls, byte 0 was:
+        ///
+        ///     0x0F, 0x1F, 0x3F, 0x7F, 0xFF, then 0xFF for every call after
+        ///
+        /// It grows on each call and saturates. A value that changes when nothing about the
+        /// hardware changed cannot be a keyboard type, and once it has saturated at 0xFF bit 0 is
+        /// set no matter what the answer should have been - so on a board behaving like this,
+        /// "supported" is what this returns whether or not it is true. The same probe run against
+        /// the topology command returned a stable 0x03 ten times out of ten.
+        ///
+        /// Kept because it is the right reading of this command on boards where the byte IS
+        /// stable, and because naming the failure is more useful than deleting the evidence of it.
+        /// Nothing in OmenCore gates on it.
+        /// </summary>
+        public bool? IsKeyboardLightingSupported()
+        {
+            if (!_isAvailable) return null;
+
+            try
+            {
+                var result = SendBiosCommand(BiosCmd.Keyboard, CMD_KBD_TYPE_GET, null, 4);
+                if (result == null || result.Length == 0) return null;
+
+                bool supported = (result[0] & 0x01) != 0;
+                _logging?.Info($"Keyboard lighting supported: {supported} (byte 0 = 0x{result[0]:X2})");
+                return supported;
+            }
+            catch (Exception ex)
+            {
+                _logging?.Warn($"Failed to read keyboard lighting support: {ex.Message}");
+            }
+            return null;
+        }
+
+        /// <summary>
         /// Get keyboard type.
         /// OmenMon: Cmd.Keyboard, 0x01
         ///
-        /// Not every board answers this. Board 8D87 (OMEN MAX 16, 2025 AMD) returns 0xFF here, which
-        /// is not a KbdType at all, so this returns null on it. The keyboard topology probe HP's own
-        /// software gates on for that platform is a different command - Default 0x2B, null input,
-        /// 4-byte reply, whose byte 0 is NbKeyboardLightingType (3 = per-key RGB) - and it answers
-        /// correctly where Keyboard 0x01 does not. Adding it needs confirmation on more than one
-        /// board, so it is noted rather than done here; ModelCapabilities.HasPerKeyRgb carries the
-        /// answer for 8D87 in the meantime.
+        /// Not every board answers this, and on some it is not answering the question at all.
+        /// Board 8D87 (OMEN MAX 16, 2025 AMD) returns a byte that CHANGES BETWEEN IDENTICAL CALLS
+        /// - 0x0F, 0x1F, 0x3F, 0x7F, then 0xFF from the fifth call on - so it is an accumulator
+        /// that saturates, not a type. See <see cref="IsKeyboardLightingSupported"/>.
+        ///
+        /// So when this command yields something outside the declared range, fall through to
+        /// <see cref="GetKeyboardLightingType"/>, which is the probe HP's own software uses, and
+        /// map it back. A board where Keyboard 0x01 does answer is left on that path unchanged.
         /// </summary>
         public KbdType? GetKeyboardType()
         {
@@ -1578,38 +1681,68 @@ namespace OmenCore.Hardware
                 if (result != null && result.Length > 0)
                 {
                     var kbdType = DecodeKeyboardType(result);
-                    if (kbdType == null)
+                    if (kbdType != null)
                     {
-                        _logging?.Info($"Keyboard type byte 0x{result[0]:X2} is outside the declared KbdType range - reporting unknown");
-                        return null;
+                        _logging?.Info($"Keyboard type: {kbdType} (0x{result[0]:X2})");
+                        return kbdType;
                     }
 
-                    _logging?.Info($"Keyboard type: {kbdType} (0x{result[0]:X2})");
-                    return kbdType;
+                    _logging?.Info($"Keyboard type byte 0x{result[0]:X2} is outside the declared KbdType range - trying the lighting topology probe");
                 }
             }
             catch (Exception ex)
             {
                 _logging?.Warn($"Failed to get keyboard type: {ex.Message}");
             }
-            return null;
+
+            return MapLightingTypeToKbdType(GetKeyboardLightingType());
         }
+
+        /// <summary>
+        /// Map the lighting topology onto the narrower <see cref="KbdType"/>, for callers that
+        /// still ask that question. Only RgbPerKey has an exact counterpart; the zone topologies
+        /// describe lighting rather than layout, so they deliberately do not claim a key layout.
+        /// </summary>
+        internal static KbdType? MapLightingTypeToKbdType(KeyboardLightingType? lighting) => lighting switch
+        {
+            KeyboardLightingType.RgbPerKey => KbdType.PerKeyRgb,
+            _ => null
+        };
         
         /// <summary>
         /// Check if keyboard backlight is supported.
-        /// OmenMon: Cmd.Keyboard, 0x06
+        ///
+        /// Asks the lighting topology first. That is what HP's own software gates on, and it gives
+        /// a direct answer: anything other than None or Normal has addressable backlighting.
+        ///
+        /// The Keyboard 0x06 fallback below is kept for boards that answer it, but it is a weaker
+        /// reading of a command that is not really this question - HP's constant for Keyboard 0x06
+        /// is GET_LED_ANIMATION, and it wants a 128-byte reply. Asking for 4 bytes returns RTCD 5,
+        /// which means WRONG OUTPUT BUFFER SIZE, not "unsupported". Board 8D87 hit exactly that:
+        /// the old call reported no backlight on a machine whose backlight was lit, because a
+        /// size complaint was being read as a capability answer.
         /// </summary>
         public bool HasBacklight()
         {
             if (!_isAvailable) return false;
-            
+
+            var topology = GetKeyboardLightingType();
+            if (topology != null)
+            {
+                bool lit = topology is not (KeyboardLightingType.None or KeyboardLightingType.Normal);
+                _logging?.Info($"Keyboard backlight supported: {lit} (topology {topology})");
+                return lit;
+            }
+
             try
             {
-                var result = SendBiosCommand(BiosCmd.Keyboard, CMD_HAS_BACKLIGHT, new byte[4], 4);
+                // 128, not 4. See above - the reply is animation state, and the shorter buffer is
+                // rejected rather than answered.
+                var result = SendBiosCommand(BiosCmd.Keyboard, CMD_HAS_BACKLIGHT, new byte[4], 128);
                 if (result != null && result.Length > 0)
                 {
                     var supported = result[0] != 0;
-                    _logging?.Info($"Keyboard backlight supported: {supported}");
+                    _logging?.Info($"Keyboard backlight supported: {supported} (animation byte 0 = 0x{result[0]:X2})");
                     return supported;
                 }
             }
@@ -2517,6 +2650,7 @@ namespace OmenCore.Hardware
             CMD_COLOR_GET => "ColorGet",
             CMD_COLOR_SET => "ColorSet",
             CMD_KBD_TYPE_GET => "KbdTypeGet",
+            CMD_KBD_PLATFORM_INFO => "KbdLightingTopology",
             CMD_BRIGHTNESS_GET => "BrightnessGet",
             CMD_HAS_BACKLIGHT => "HasBacklight",
             CMD_ANIMATION_SET => "AnimationSet",

--- a/src/OmenCoreApp/Hardware/HpWmiBios.cs
+++ b/src/OmenCoreApp/Hardware/HpWmiBios.cs
@@ -112,6 +112,7 @@ namespace OmenCore.Hardware
         private const uint CMD_GPU_GET_POWER = 0x21;  // GetGpuPower (OmenMon 0x21)
         private const uint CMD_GPU_SET_POWER = 0x22;  // SetGpuPower (OmenMon 0x22)
         private const uint CMD_GPU_GET_MODE = 0x52;   // GetGpuMode - uses Legacy cmd
+        private const uint CMD_ADAPTER_GET = 0x0F;    // GetAdapter (smart adapter status + wattage) - uses Legacy cmd
         private const uint CMD_GPU_SET_MODE = 0x52;   // SetGpuMode - uses GpuMode cmd
         private const uint CMD_TEMP_GET = 0x23;       // GetTemperature (OmenMon 0x23)
         private const uint CMD_BACKLIGHT_SET = 0x05;  // SetBacklight - uses Keyboard cmd
@@ -163,6 +164,27 @@ namespace OmenCore.Hardware
             Extended4 = 0x04
         }
 
+        /// <summary>
+        /// Build the 4-byte <c>Default 0x22</c> GPU power payload.
+        /// </summary>
+        /// <remarks>
+        /// Three things about this payload that are easy to re-derive incorrectly:
+        ///
+        /// <para><b>Byte 2 (<c>dState</c>) is hardcoded to 1, matching HP.</b> It is not a knob. On
+        /// MAX-series firmware the 0x22 handler sets the ACPI <c>DSTA</c> field and then immediately
+        /// calls the EC query that overwrites <c>DSTA</c> from the EC's own adapter verdict, so the
+        /// value written here does not survive the call that writes it. Verified on both a compliant
+        /// and an under-rated adapter. Do not add a parameter for it expecting to steer anything.</para>
+        ///
+        /// <para><b>Byte 3 is a GPS temperature threshold in °C, not a spare byte.</b> The
+        /// <c>peakTemperature</c> naming here is correct; a firmware note describing it as a spare is
+        /// wrong on this board. This method sends 0. See <see cref="HpGpsTemperatureThresholdC"/> for
+        /// what HP sends and why matching it is deferred.</para>
+        ///
+        /// <para><b>0x22 is not always 4 bytes.</b> HP has a second call site (<c>SetTGPAsync</c>)
+        /// that issues the same command with a single byte. Nothing here needs that arity today, but
+        /// code reading a 0x22 payload out of a trace should not assume it is 4 bytes wide.</para>
+        /// </remarks>
         public static (byte customTgp, byte ppab, byte dState, byte peakTemperature) BuildGpuPowerPayload(GpuPowerLevel level)
         {
             byte customTgp = 0;
@@ -189,8 +211,44 @@ namespace OmenCore.Hardware
                     break;
             }
 
+            // Byte 3 stays 0. See HpGpsTemperatureThresholdC for what HP sends and why matching it
+            // is deferred rather than declined.
             return (customTgp, ppab, 0x01, 0x00);
         }
+
+        /// <summary>
+        /// The GPS temperature threshold (°C) written in byte 3 of the <c>Default 0x22</c> payload -
+        /// HP's <c>GpsMaxTemperature</c>, the un-throttled setpoint.
+        ///
+        /// <para>Byte 3 is not a per-preset constant in HP's code. It is the output of their
+        /// <c>IRHandler</c>, a closed loop driven by the chassis infra-red (skin) temperature sensor,
+        /// bounded by two <c>PlatformSettings</c> values (<c>GpsMaxTemperature = 87</c>,
+        /// <c>GpsMinTemperature = 75</c>, both JSON-overridable per platform):</para>
+        /// <code>
+        /// IrTemp >= Overheat        -> GpsMinTemperature (75), and dState may be bumped
+        /// Gps &lt;= IrTemp &lt; Overheat  -> clamp(GpuTemp - irGap, 75, 87)
+        /// IrTemp &lt;= Release         -> GpsMaxTemperature (87)
+        /// </code>
+        ///
+        /// <para><b>Recorded, deliberately not applied.</b> Sending 87 is not simply "matching HP",
+        /// and three things argue against it until someone measures:</para>
+        /// <list type="bullet">
+        /// <item>87 is what HP emits <i>only while the IR sensor reports the chassis is cool</i>. It
+        /// is the loop's most permissive output, revised down to 75 the moment skin temperature
+        /// crosses overheat. This application has no such loop and would never revise it, so it would
+        /// pin the firmware permanently in HP's chassis-is-cool state rather than reproduce HP's
+        /// behaviour.</item>
+        /// <item>Both bounds are overridable from HP's per-platform JSON. 87 is one build's default,
+        /// not a universal constant, and <see cref="BuildGpuPowerPayload"/> is not board-gated.</item>
+        /// <item>It cannot be verified by outcome: the <c>0x21</c> readback returns cTGP, PPAB and
+        /// dState only - byte 3 is not observable. There is no way to confirm the firmware did
+        /// anything with it.</item>
+        /// </list>
+        ///
+        /// <para>What would settle it: a before/after on real hardware in watts <i>and</i> GPU and
+        /// skin temperature, on a board where the value can be attributed.</para>
+        /// </summary>
+        public const byte HpGpsTemperatureThresholdC = 87;
 
         public static bool IsGpuPowerReadbackMatch(GpuPowerLevel requestedLevel, bool customTgp, int ppabLevel)
         {
@@ -225,10 +283,254 @@ namespace OmenCore.Hardware
             V2 = 0x02   // OMEN Max 2025+ (new fan commands)
         }
 
+        /// <summary>
+        /// HP's smart adapter verdict, reported in byte 0 of the <c>Legacy 0x0F</c> reply.
+        ///
+        /// Six values, not five: most third-party tables (including OmenMon-Reborn's) stop at 4 and
+        /// treat everything above <see cref="MeetsRequirement"/> as a fault. <see cref="ConnectedTypeC"/>
+        /// is not a fault - it means USB-C PD is supplying the machine, and HP applies a different
+        /// comparison to it (see <see cref="AdapterInfo.IsLowWattage"/>).
+        ///
+        /// <see cref="Error"/> is documented both as -1 and as 0xFF on the wire, so the backing type
+        /// is <c>sbyte</c> - a byte of 0xFF must decode to <see cref="Error"/> and not to 255.
+        /// </summary>
+        public enum SmartAdapterStatus : sbyte
+        {
+            Error = -1,
+            NotSupported = 0,
+            MeetsRequirement = 1,
+            BelowRequirement = 2,
+            BatteryPower = 3,
+            NotFunctioning = 4,
+            ConnectedTypeC = 5
+        }
+
+        /// <summary>
+        /// Decoded <c>Legacy 0x0F</c> reply: the machine's own view of the power adapter attached to it.
+        ///
+        /// This is the only interface in the BIOS that reports the *connected* adapter's wattage as a
+        /// real number rather than a binary meets/below verdict. Paired with
+        /// <see cref="SystemDesignData.ShippingAdapterPowerRatingWatts"/> (the wattage the SKU shipped
+        /// with) it gives both halves of the comparison the firmware itself is making.
+        ///
+        /// Why it matters: on boards that clamp GPU power when the supply is under-rated, a user on a
+        /// low-wattage adapter otherwise sees only the symptom (a GPU pinned well below its rating)
+        /// with nothing anywhere in the UI to explain it.
+        /// </summary>
+        public readonly struct AdapterInfo
+        {
+            /// <summary>Byte 0 - the firmware's verdict on the attached supply.</summary>
+            public SmartAdapterStatus Status { get; init; }
+
+            /// <summary>Byte 1 bit 7 - whether this chassis has a barrel jack at all.</summary>
+            public bool SupportsBarrelConnector { get; init; }
+
+            /// <summary>Byte 2 x 5 - the USB-C *design* rating in watts (a chassis property, not the attached supply).</summary>
+            public int UsbcDesignRatingWatts { get; init; }
+
+            /// <summary>
+            /// Byte 3 x 5 - the connected adapter's rating in watts, or 0 when the firmware reports
+            /// the 0xFF "unknown" sentinel. Check <see cref="PowerRatingKnown"/> before reading a 0
+            /// here as "nothing plugged in".
+            /// </summary>
+            public int PowerRatingWatts { get; init; }
+
+            /// <summary>False when byte 3 was the 0xFF unknown sentinel.</summary>
+            public bool PowerRatingKnown { get; init; }
+
+            /// <summary>The raw 4-byte reply, for diagnostics.</summary>
+            public byte[] RawData { get; init; }
+
+            /// <summary>
+            /// Whether the firmware considers the attached supply under-rated, matching the rule HP's
+            /// own software applies (<c>HP.Omen.Core.Model.Device.IsLowWattage</c>).
+            ///
+            /// The rule has two branches. For USB-C PD the connected rating is compared against the
+            /// chassis USB-C design rating, and a barrel-capable chassis reporting a 0 design rating
+            /// counts as under-rated outright. For everything else, any status other than
+            /// MeetsRequirement is under-rated. Type-C is deliberately not folded into that second
+            /// branch - doing so misreports a PD supply that is exactly what the chassis was designed
+            /// for.
+            /// </summary>
+            public bool IsLowWattage => !HasVerdict
+                ? false
+                : Status == SmartAdapterStatus.ConnectedTypeC
+                    ? (PowerRatingWatts > 0 && PowerRatingWatts < UsbcDesignRatingWatts)
+                      || (SupportsBarrelConnector && UsbcDesignRatingWatts == 0)
+                    : Status != SmartAdapterStatus.MeetsRequirement;
+
+            /// <summary>
+            /// False when the firmware gave no usable answer - <see cref="SmartAdapterStatus.Error"/>
+            /// or <see cref="SmartAdapterStatus.NotSupported"/>.
+            ///
+            /// HP only evaluates its low-wattage rule after a successful query. Applying the
+            /// "anything that isn't MeetsRequirement" branch to a non-answer turns "no verdict" into
+            /// "bad adapter" - which, on a board that replies with zeroes, produces a confident
+            /// on-screen instruction to go and check a power supply that is probably fine.
+            /// </summary>
+            public bool HasVerdict => Status != SmartAdapterStatus.Error
+                                   && Status != SmartAdapterStatus.NotSupported;
+
+            public override string ToString()
+            {
+                var watts = PowerRatingKnown ? $"{PowerRatingWatts}W" : "unknown wattage";
+                return $"{Status} ({watts})";
+            }
+        }
+
+        /// <summary>
+        /// Decoded <c>Default 0x28</c> reply - HP's <c>SystemDesignData</c> block.
+        ///
+        /// The firmware answers 128 bytes here and this class historically parsed exactly one of them
+        /// (byte 3, the thermal policy version). The rest is a per-board capability declaration, and
+        /// HP's own software gates features on it at runtime rather than on a board-ID table.
+        /// </summary>
+        public readonly struct SystemDesignData
+        {
+            /// <summary>Bytes 0-1, 16-bit LE - the wattage of the adapter this SKU shipped with.</summary>
+            public int ShippingAdapterPowerRatingWatts { get; init; }
+
+            /// <summary>Byte 3 - thermal policy version, the one field this class already read.</summary>
+            public ThermalPolicyVersion ThermalPolicyVersion { get; init; }
+
+            /// <summary>Byte 4 bit 0.</summary>
+            public bool IsSwFanControlSupport { get; init; }
+
+            /// <summary>Byte 4 bit 1.</summary>
+            public bool IsExtremeModeSupport { get; init; }
+
+            /// <summary>Byte 4 bit 2. Observed false on a board that reports <see cref="IsExtremeModeSupport"/> true; unexplained.</summary>
+            public bool IsExtremeModeUnlock { get; init; }
+
+            /// <summary>Byte 4 bit 3.</summary>
+            public bool IsDTBiosControl { get; init; }
+
+            /// <summary>
+            /// Byte 4 bit 4. Changes the wire format of <c>Default 0x29 SetPL4</c> from one byte to two.
+            /// Nothing in this repo issues 0x29 yet; this is decoded so that whatever does can branch on
+            /// it rather than assuming a width. Guessing wrong here is a silent write-corruption bug on
+            /// any board where the bit is set.
+            /// </summary>
+            public bool IsTwoBytePL4Support { get; init; }
+
+            /// <summary>Byte 5.</summary>
+            public int PL4DefaultValue { get; init; }
+
+            /// <summary>Byte 6 bit 0.</summary>
+            public bool IsBiosDefinedOcSupport { get; init; }
+
+            /// <summary>Byte 7 - GPU mode switch capability bitfield.</summary>
+            public byte GpuModeSwitch { get; init; }
+
+            /// <summary>Byte 8 - the CPU power budget the platform uses while the dGPU is loaded, in watts.</summary>
+            public int DefaultCpuPowerLimitWithGpuWatts { get; init; }
+
+            /// <summary>Byte 9 low nibble.</summary>
+            public int LoadLineSupportLevels { get; init; }
+
+            /// <summary>Byte 9 high nibble.</summary>
+            public int DefaultLoadLine { get; init; }
+
+            /// <summary>Byte 10 bit 0.</summary>
+            public bool ChangeIrSensorToBoard { get; init; }
+
+            /// <summary>Byte 10 bit 2.</summary>
+            public bool IsPchOverheatSupport { get; init; }
+
+            /// <summary>Byte 10 bit 3.</summary>
+            public bool IsVrSensorSupport { get; init; }
+
+            /// <summary>Byte 11 bit 0.</summary>
+            public bool IsHotkeySupportFnP { get; init; }
+
+            /// <summary>Byte 11 bit 1.</summary>
+            public bool IsHotkeySupportFnF1 { get; init; }
+
+            /// <summary>The first 12 bytes of the reply, for diagnostics.</summary>
+            public byte[] RawData { get; init; }
+        }
+
+        /// <summary>
+        /// Decode the 4-byte <c>Legacy 0x0F</c> reply. Static and side-effect free so it can be tested
+        /// against captured replies without hardware.
+        /// </summary>
+        /// <remarks>
+        /// Byte map, from HP's own accessors (<c>GetSmartAdapterStatus</c>, <c>GetSupportBarrel</c>,
+        /// <c>GetUsbcDesignRating</c>, <c>GetPowerRating</c>):
+        /// <code>
+        /// [0]        SmartAdapterStatus
+        /// [1] bit 7  barrel jack supported
+        /// [2] x 5    USB-C design rating, W
+        /// [3] x 5    connected adapter rating, W  (0xFF = unknown)
+        /// </code>
+        /// </remarks>
+        public static AdapterInfo? DecodeAdapterData(byte[]? data)
+        {
+            if (data == null || data.Length < 4)
+                return null;
+
+            // 0xFF is HP's "I don't know" sentinel, not 1275 W. Decoding it as a wattage would make an
+            // unknown adapter look like the healthiest one on record.
+            bool ratingKnown = data[3] != 0xFF;
+
+            return new AdapterInfo
+            {
+                Status = (SmartAdapterStatus)data[0],
+                SupportsBarrelConnector = (data[1] & 0x80) != 0,
+                UsbcDesignRatingWatts = data[2] * 5,
+                PowerRatingWatts = ratingKnown ? data[3] * 5 : 0,
+                PowerRatingKnown = ratingKnown,
+                RawData = new[] { data[0], data[1], data[2], data[3] }
+            };
+        }
+
+        /// <summary>
+        /// Decode HP's <c>SystemDesignData</c> block from a <c>Default 0x28</c> reply. Static and
+        /// side-effect free so it can be tested against captured replies without hardware.
+        /// </summary>
+        public static SystemDesignData? DecodeSystemDesignData(byte[]? data)
+        {
+            // 12 bytes is everything HP's accessors read, even though the command returns 128.
+            if (data == null || data.Length < 12)
+                return null;
+
+            return new SystemDesignData
+            {
+                ShippingAdapterPowerRatingWatts = data[0] | (data[1] << 8),
+                ThermalPolicyVersion = (ThermalPolicyVersion)data[3],
+                IsSwFanControlSupport = (data[4] & 0x01) != 0,
+                IsExtremeModeSupport = (data[4] & 0x02) != 0,
+                IsExtremeModeUnlock = (data[4] & 0x04) != 0,
+                IsDTBiosControl = (data[4] & 0x08) != 0,
+                IsTwoBytePL4Support = (data[4] & 0x10) != 0,
+                PL4DefaultValue = data[5],
+                IsBiosDefinedOcSupport = (data[6] & 0x01) != 0,
+                GpuModeSwitch = data[7],
+                DefaultCpuPowerLimitWithGpuWatts = data[8],
+                LoadLineSupportLevels = data[9] & 0x0F,
+                DefaultLoadLine = (data[9] & 0xF0) >> 4,
+                // Two bits, not one: HP's rule is bit 0 clear AND bit 1 set. Reading bit 0 alone gets
+                // the wrong answer on a byte 10 of 0x03, which is what this board actually reports.
+                ChangeIrSensorToBoard = (data[10] & 0x03) == 0x02,
+                IsPchOverheatSupport = (data[10] & 0x04) != 0,
+                IsVrSensorSupport = (data[10] & 0x08) != 0,
+                IsHotkeySupportFnP = (data[11] & 0x01) != 0,
+                IsHotkeySupportFnF1 = (data[11] & 0x02) != 0,
+                RawData = data.Take(12).ToArray()
+            };
+        }
+
         public bool IsAvailable => _isAvailable;
         public bool IsConnected => _isAvailable; // Alias for IsAvailable
         public string Status { get; private set; } = "Not initialized";
         public ThermalPolicyVersion ThermalPolicy { get; private set; } = ThermalPolicyVersion.V1;
+
+        /// <summary>
+        /// HP's <c>SystemDesignData</c> capability block, decoded from the same <c>Default 0x28</c>
+        /// reply this class already issues at startup. Null until that query succeeds, or on firmware
+        /// that answers with fewer than 12 bytes.
+        /// </summary>
+        public SystemDesignData? SystemDesign { get; private set; }
         public int FanCount { get; private set; } = 2;
         
         /// <summary>
@@ -266,6 +568,7 @@ namespace OmenCore.Hardware
         // Cache static WMI data to avoid repeated queries
         private bool _staticDataCached = false;
         private readonly object _cacheLock = new();
+
 
         public HpWmiBios(LoggingService? logging = null)
         {
@@ -518,7 +821,32 @@ namespace OmenCore.Hardware
                 {
                     ThermalPolicy = (ThermalPolicyVersion)result[3];
                     _logging?.Info($"  Thermal Policy: V{(int)ThermalPolicy}");
-                    
+
+                    // The same reply carries HP's whole SystemDesignData capability block. Decoding it
+                    // costs nothing extra - it is the bytes we already asked for - and it is what HP's
+                    // own software gates features on at runtime.
+                    SystemDesign = DecodeSystemDesignData(result);
+                    if (SystemDesign is SystemDesignData design)
+                    {
+                        _logging?.Info(
+                            $"  System design: shipping adapter {design.ShippingAdapterPowerRatingWatts}W, " +
+                            $"CPU-with-GPU budget {design.DefaultCpuPowerLimitWithGpuWatts}W, " +
+                            $"SW fan control {design.IsSwFanControlSupport}, BIOS OC {design.IsBiosDefinedOcSupport}, " +
+                            $"2-byte PL4 {design.IsTwoBytePL4Support}");
+
+                        // Recorded, deliberately not acted on: a board has been seen declaring Extreme
+                        // Mode supported while reporting it locked. Nothing is known about what unlocks it.
+                        if (design.IsExtremeModeSupport && !design.IsExtremeModeUnlock)
+                        {
+                            _logging?.Debug("  Extreme Mode declared supported but reports locked (no action taken)");
+                        }
+                    }
+
+                    // Note the ordering: ThermalPolicy is assigned from the firmware byte above and may
+                    // be overridden by the model-name check below. SystemDesign.ThermalPolicyVersion is
+                    // NOT overridden - it stays the value the firmware actually reported, so diagnostics
+                    // can show when the two disagree.
+
                     // OMEN Max 2025+ detection - check model name as well
                     // Some OMEN Max models report V1 but need V2 commands for fan reading
                     if (ThermalPolicy >= ThermalPolicyVersion.V2)
@@ -1058,6 +1386,32 @@ namespace OmenCore.Hardware
                 _logging?.Warn($"Failed to get GPU mode: {ex.Message}");
             }
             return null;
+        }
+
+        /// <summary>
+        /// Read the power adapter's status and wattage. Read-only; issues <c>Legacy 0x0F</c>.
+        ///
+        /// Returns null when the board does not answer, or when WMI is unavailable for any other
+        /// reason. Deliberately does <b>not</b> cache "unsupported": a null here is indistinguishable
+        /// from a transient WMI failure - <c>SendBiosCommand</c> returns null for a disabled command
+        /// path, a dead CIM session and a genuine unimplemented command alike - so latching would let
+        /// one hiccup permanently, and silently, assert something false about the hardware. Nothing
+        /// polls this; it is read when the user opens Diagnostics, so a round trip per call is free.
+        /// </summary>
+        public AdapterInfo? GetAdapter()
+        {
+            if (!_isAvailable) return null;
+
+            try
+            {
+                var result = SendBiosCommand(BiosCmd.Legacy, CMD_ADAPTER_GET, null, 4);
+                return DecodeAdapterData(result);
+            }
+            catch (Exception ex)
+            {
+                _logging?.Warn($"Failed to get adapter status: {ex.Message}");
+                return null;
+            }
         }
 
         /// <summary>

--- a/src/OmenCoreApp/Hardware/HpWmiBios.cs
+++ b/src/OmenCoreApp/Hardware/HpWmiBios.cs
@@ -857,12 +857,34 @@ namespace OmenCore.Hardware
                     {
                         // Check model name for OMEN Max which may report V1 but need V2
                         var modelName = GetModelName();
-                        if (!string.IsNullOrEmpty(modelName) && 
+                        if (!string.IsNullOrEmpty(modelName) &&
                             modelName.Contains("MAX", StringComparison.OrdinalIgnoreCase) &&
                             modelName.Contains("OMEN", StringComparison.OrdinalIgnoreCase))
                         {
-                            _logging?.Info($"  ⚠️ OMEN Max detected by name but reports V1 - forcing V2 for fan commands");
-                            ThermalPolicy = ThermalPolicyVersion.V2;
+                            // Ask the firmware instead of asserting from the model name. Some OMEN Max
+                            // models do report V1 and answer the V2 fan commands - that is what this
+                            // branch exists for - but others report V1 and mean it. Board 8D87 (OMEN
+                            // MAX 16, 2025 AMD) is the second kind: it refuses 0x37 with BIOS return
+                            // code 6 and 0x38 with 4, at every input and output buffer size tried.
+                            //
+                            // This matters beyond which command to send, because DetectMaxFanLevel
+                            // reads ThermalPolicy to decide what UNIT fan levels are in - V2 means
+                            // percent and MaxFanLevel 100, V1 means krpm/100 and MaxFanLevel 55.
+                            // Force-switching a board whose levels are krpm/100 into the percentage
+                            // range makes WmiFanController.MapFanPercentToWmiLevel an identity, so a
+                            // request for 50% writes raw level 50 - roughly 5000 rpm, near maximum
+                            // rather than half. That is the same V1/V2 unit mismatch recorded in
+                            // ModelCapabilityDatabaseTests.GetCapabilities_8C77_Wf1xxx_UsesExactV1WmiProfileNotV2Mismatch,
+                            // which reached the reporter's device as a crash.
+                            if (ProbeV2FanCommands())
+                            {
+                                _logging?.Info("  ✓ OMEN Max reports V1 but answers the V2 fan commands - using V2");
+                                ThermalPolicy = ThermalPolicyVersion.V2;
+                            }
+                            else
+                            {
+                                _logging?.Info($"  OMEN Max detected by name, but the V2 fan commands were refused - keeping firmware-reported {ThermalPolicy}");
+                            }
                         }
                     }
 
@@ -889,6 +911,42 @@ namespace OmenCore.Hardware
             catch (Exception ex)
             {
                 _logging?.Warn($"Failed to query system data: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Ask the firmware whether it implements the V2 (OMEN Max 2025+) fan commands, instead of
+        /// inferring it from the model name.
+        ///
+        /// The two directions are not equally trustworthy, so they are not treated the same way:
+        ///
+        /// <b>Refusal is authoritative.</b> A refused command comes back with a non-zero BIOS return
+        /// code - 6 for 0x37 and 4 for 0x38 on board 8D87 - and <see cref="SendBiosCommand"/> returns
+        /// null for it. The ACPI timeout path cannot produce those codes; it returns zero (see the
+        /// remark on <see cref="SendBiosCommand"/>), so a null here really is the firmware saying no.
+        ///
+        /// <b>Acceptance is weak</b> for exactly that reason: a timeout looks like success. So both
+        /// V2 commands must be accepted before overriding the policy version the firmware itself
+        /// reported. Getting this wrong in the permissive direction changes the unit fan levels are
+        /// interpreted in, which is a user-visible fan-speed error, so the conservative default is to
+        /// believe the firmware's own byte.
+        ///
+        /// Deliberately does not require a non-zero reading: a stopped fan legitimately reads zero,
+        /// and the question here is whether the command exists, not what it currently says.
+        /// </summary>
+        private bool ProbeV2FanCommands()
+        {
+            try
+            {
+                if (SendBiosCommand(BiosCmd.Default, CMD_FAN_GET_LEVEL_V2, new byte[4], 128) == null)
+                    return false;
+
+                return SendBiosCommand(BiosCmd.Default, CMD_FAN_GET_RPM, new byte[4], 128) != null;
+            }
+            catch (Exception ex)
+            {
+                _logging?.Debug($"V2 fan command probe failed, assuming not supported: {ex.Message}");
                 return false;
             }
         }
@@ -1365,8 +1423,29 @@ namespace OmenCore.Hardware
         }
 
         /// <summary>
+        /// Decode the <c>Legacy 0x52</c> reply into a <see cref="GpuMode"/>, or null when the board
+        /// did not report one this method understands.
+        ///
+        /// The validation is the point. <see cref="GpuMode"/> declares 0x00-0x02, and casting an
+        /// out-of-range byte straight to the enum produces an undeclared value that compares equal to
+        /// none of Hybrid/Discrete/Optimus while printing as a bare number in logs - so a caller sees
+        /// neither a valid mode nor a failure. Same defect shape as the SmartAdapterStatus decode,
+        /// where a 0xFF wire byte rendered as the literal "255" instead of Error.
+        /// </summary>
+        public static GpuMode? DecodeGpuMode(byte[]? result)
+        {
+            if (result == null || result.Length < 1) return null;
+            if (!Enum.IsDefined(typeof(GpuMode), result[0])) return null;
+            return (GpuMode)result[0];
+        }
+
+        /// <summary>
         /// Get GPU mode (Hybrid/Discrete/Optimus).
         /// OmenMon: Cmd.Legacy, 0x52 (returns BIOS error 4 on unsupported)
+        ///
+        /// A zero reply decodes to <see cref="GpuMode.Hybrid"/>, which on this transport is also what
+        /// an ACPI timeout looks like - see the remark on <see cref="SendBiosCommand"/>. Treat a
+        /// Hybrid reading as weak evidence unless something else corroborates it.
         /// </summary>
         public GpuMode? GetGpuMode()
         {
@@ -1376,10 +1455,12 @@ namespace OmenCore.Hardware
             {
                 // Use Legacy command for GPU mode get (OmenMon)
                 var result = SendBiosCommand(BiosCmd.Legacy, CMD_GPU_GET_MODE, null, 4);
-                if (result != null && result.Length >= 1)
+                var mode = DecodeGpuMode(result);
+                if (mode == null && result != null && result.Length >= 1)
                 {
-                    return (GpuMode)result[0];
+                    _logging?.Warn($"GPU mode byte 0x{result[0]:X2} is outside the declared GpuMode range - ignoring");
                 }
+                return mode;
             }
             catch (Exception ex)
             {
@@ -1460,19 +1541,49 @@ namespace OmenCore.Hardware
         }
         
         /// <summary>
+        /// Decode the <c>Keyboard 0x01</c> reply into a <see cref="KbdType"/>, or null when the byte
+        /// is not one this method declares.
+        ///
+        /// Board 8D87 returns 0xFF here. Cast straight to the enum that becomes <c>(KbdType)255</c> -
+        /// outside the declared 0x00-0x03 range, logged as a bare "255", and indistinguishable to
+        /// callers from a real keyboard type. Null says what is actually true: the board did not
+        /// answer this question.
+        /// </summary>
+        public static KbdType? DecodeKeyboardType(byte[]? result)
+        {
+            if (result == null || result.Length < 1) return null;
+            if (!Enum.IsDefined(typeof(KbdType), result[0])) return null;
+            return (KbdType)result[0];
+        }
+
+        /// <summary>
         /// Get keyboard type.
         /// OmenMon: Cmd.Keyboard, 0x01
+        ///
+        /// Not every board answers this. Board 8D87 (OMEN MAX 16, 2025 AMD) returns 0xFF here, which
+        /// is not a KbdType at all, so this returns null on it. The keyboard topology probe HP's own
+        /// software gates on for that platform is a different command - Default 0x2B, null input,
+        /// 4-byte reply, whose byte 0 is NbKeyboardLightingType (3 = per-key RGB) - and it answers
+        /// correctly where Keyboard 0x01 does not. Adding it needs confirmation on more than one
+        /// board, so it is noted rather than done here; ModelCapabilities.HasPerKeyRgb carries the
+        /// answer for 8D87 in the meantime.
         /// </summary>
         public KbdType? GetKeyboardType()
         {
             if (!_isAvailable) return null;
-            
+
             try
             {
                 var result = SendBiosCommand(BiosCmd.Keyboard, CMD_KBD_TYPE_GET, new byte[4], 4);
                 if (result != null && result.Length > 0)
                 {
-                    var kbdType = (KbdType)result[0];
+                    var kbdType = DecodeKeyboardType(result);
+                    if (kbdType == null)
+                    {
+                        _logging?.Info($"Keyboard type byte 0x{result[0]:X2} is outside the declared KbdType range - reporting unknown");
+                        return null;
+                    }
+
                     _logging?.Info($"Keyboard type: {kbdType} (0x{result[0]:X2})");
                     return kbdType;
                 }
@@ -1934,6 +2045,35 @@ namespace OmenCore.Hardware
 
         /// <summary>
         /// Send a command to the BIOS via CIM/WMI using OmenMon's exact implementation.
+        ///
+        /// <b>A zero return code is not proof that the EC answered.</b> These WMI methods are ACPI
+        /// handlers that post the request into an EC mailbox and then poll a doorbell for about
+        /// 100 ms. On timeout they return the result package with the return code still zero and the
+        /// output buffer untouched, because the return code is only assigned on the dispatch switch's
+        /// default arm. So a zero return code means "the ACPI method ran", never "the hardware
+        /// replied", and a success carrying an all-zero buffer is indistinguishable from a timeout.
+        ///
+        /// That matters because the mailbox is a single shared buffer with no locking between OS
+        /// agents, and OMEN Gaming Hub polls it continuously. Running alongside it is not the
+        /// supported configuration, but it is a common one, and the failure is silent: during
+        /// reverse-engineering on board 8D87, repeated identical reads returned four different
+        /// values that were traceable to OGH's replies to its own questions - one byte tracked
+        /// MSAcpi_ThermalZoneTemperature exactly. Stopping OGH made every reading stable.
+        ///
+        /// Callers should therefore validate the reply's content, not just its return code:
+        /// <list type="bullet">
+        /// <item>treat an all-zero buffer from a command that must report something non-zero as a
+        /// failure, the way <see cref="GetFanLevel"/> already does before falling back;</item>
+        /// <item>range-check decoded values where a range is known, the way
+        /// <see cref="ParseFanRpmBuffer"/> already does;</item>
+        /// <item>for anything that drives a write, prefer reading a second time and requiring
+        /// agreement over trusting a single reply.</item>
+        /// </list>
+        ///
+        /// A non-zero return code is the trustworthy direction: the firmware produced it
+        /// deliberately, and the timeout path cannot. Note that 5 specifically means the output
+        /// buffer was the wrong size, not that the command is unsupported - a genuine refusal
+        /// persists across every size.
         /// </summary>
         /// <param name="command">The BIOS command class (Default, Keyboard, Legacy, GpuMode)</param>
         /// <param name="commandType">The specific command type/ID</param>

--- a/src/OmenCoreApp/Hardware/IHpWmiBios.cs
+++ b/src/OmenCoreApp/Hardware/IHpWmiBios.cs
@@ -29,6 +29,12 @@ namespace OmenCore.Hardware
         bool SetGpuPower(HpWmiBios.GpuPowerLevel level);
         HpWmiBios.GpuMode? GetGpuMode();
 
+        // GetAdapter() and SystemDesign are deliberately NOT on this interface. Every consumer holds
+        // the concrete HpWmiBios, so putting them here would add unused surface whose only effect is
+        // to make "silently return null" the default for any future implementer - and null is
+        // rendered as the affirmative claim "this board does not report an adapter". A wrong
+        // diagnostic statement is a worse failure than a compile error.
+
         void Dispose();
     }
 }

--- a/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
+++ b/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
@@ -1077,12 +1077,18 @@ namespace OmenCore.Hardware
                 // Stays false until the whole profile is confirmed. Power, thermal policy, EC, the
                 // fan range, the keyboard topology and both MUX flags are now owner-verified on
                 // hardware - the MUX rows by an actual mode switch and reboot, not by inference.
-                // What is still inherited: SupportsFanCurves and SupportsIndependentFanCurves, and
-                // the named PerformanceModes including "L5P" - all three need writes to confirm, and
-                // read-only identification work does not license them. The flag is all-or-nothing,
-                // so it reports the weakest claim in the entry.
+                // SupportsFanCurves is now MEASURED on this board, not inherited. With the fans
+                // coasting down from a previous command, a commanded 100% reversed the decay and
+                // drove them from ~3500 to 6000 rpm - the ceiling implied by MaxFanLevel 60 - read
+                // at the EC tachometers by an instrument outside the app. At 60% the same run
+                // measured 3600 rpm against an expected 3600. Levels move these fans.
+                //
+                // What is still inherited: the named PerformanceModes, including "L5P". Confirming
+                // those means showing each is accepted AND changes delivered power, which is a
+                // separate measurement. UserVerified is all-or-nothing across the entry, so it
+                // still reports the weakest claim - this one.
                 UserVerified = false,
-                Notes = "OMEN MAX Gaming Laptop 16-ak0xxx (GitHub #117), Product ID 8D87 — Ryzen AI 9 HX 375 + RTX 5080, BIOS F.07 / EC 40.38. Power, thermal-policy, fan-range, keyboard-topology and MUX fields owner-verified on hardware; fan curves and performance modes are still inherited from the adjacent MAX generation. Firmware reports thermal policy V1 and rejects the V2 fan commands (0x37/0x38), so fan levels come from the V1 0x2D fallback in krpm/100 — hence MaxFanLevel 60, measured, not 100. Keyboard is per-key RGB (topology probe 0x2B returns 3), so the four-zone path does not apply. Display MUX confirmed by switching modes: BIOS offers Hybrid/Discrete/UMA, and in Discrete the internal panel is driven by the dGPU while Legacy 0x52 reads 0x01 — but it is routed at boot, not under live ACPI control, so Advanced Optimus is false. EC is memory-mapped, so legacy EC offsets do not apply; the EC mailbox power block was forced with no effect."
+                Notes = "OMEN MAX Gaming Laptop 16-ak0xxx (GitHub #117), Product ID 8D87 — Ryzen AI 9 HX 375 + RTX 5080, BIOS F.07 / EC 40.38. Power, thermal-policy, fan-range, fan-curve, keyboard-topology and MUX fields owner-verified on hardware; only the named performance modes are still inherited from the adjacent MAX generation. Fan curves measured: a commanded 100% drove the fans to 6000 rpm against a decaying baseline, and 60% measured 3600 rpm against an expected 3600, read at the EC tachometers independently of the app. Firmware reports thermal policy V1 and rejects the V2 fan commands (0x37/0x38), so fan levels come from the V1 0x2D fallback in krpm/100 — hence MaxFanLevel 60, measured, not 100. Keyboard is per-key RGB (topology probe 0x2B returns 3), so the four-zone path does not apply. Display MUX confirmed by switching modes: BIOS offers Hybrid/Discrete/UMA, and in Discrete the internal panel is driven by the dGPU while Legacy 0x52 reads 0x01 — but it is routed at boot, not under live ACPI control, so Advanced Optimus is false. EC is memory-mapped, so legacy EC offsets do not apply; the EC mailbox power block was forced with no effect."
             });
             // -----------------------------------------------------------------------------------
             // OMEN 17 Series (17.3" laptops)

--- a/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
+++ b/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
@@ -58,6 +58,29 @@ namespace OmenCore.Hardware
         
         /// <summary>Whether RPM readback is available.</summary>
         public bool SupportsRpmReadback { get; set; } = true;
+
+        /// <summary>
+        /// EC RAM offsets of the fan tachometers, one per fan, each a 16-bit little-endian raw
+        /// RPM value at <c>offset</c> / <c>offset + 1</c>. Null (the default) means no EC
+        /// tachometer is known for this model and RPM comes from WMI, as before.
+        ///
+        /// Deliberately independent of <see cref="SupportsFanControlEc"/>. That flag gates EC
+        /// *writes*; this is a read, and the two have different risk profiles and different
+        /// evidence behind them - board 8D87 has EC fan control disabled and still has perfectly
+        /// readable tachometers. Nothing here may be used to derive a write address.
+        ///
+        /// Why this exists: on boards where the V2 command GetFanRpmDirect (0x38) is refused,
+        /// the only remaining RPM source is GetFanLevel x 100, which is the *commanded* level
+        /// echoed back. Under BIOS-automatic fan control nothing has been commanded, so that
+        /// reads 0 while the fans are physically turning - measured on 8D87 as 0 RPM reported
+        /// against 2760 RPM actual. An estimate derived from a command can never verify that a
+        /// command took effect; a tachometer can.
+        ///
+        /// Populate this only from a measured capture on the model in question. The legacy
+        /// single-byte offsets (0x34/0x35, krpm units) are NOT a safe default: on 8D87 they land
+        /// in the middle of the ASCII serial number and decode as a plausible-looking 6500 RPM.
+        /// </summary>
+        public ushort[]? EcFanTachometerOffsets { get; set; }
         
         /// <summary>Number of fan zones (typically 2: CPU + GPU).</summary>
         public int FanZoneCount { get; set; } = 2;
@@ -994,6 +1017,13 @@ namespace OmenCore.Hardware
                 SupportsFanCurves = true,
                 SupportsIndependentFanCurves = false,
                 SupportsRpmReadback = true, // measured: V1 0x2D tracks the EC tachometers at four points
+                // Fan 1 at 0x70, fan 2 at 0x5C, both 16-bit little-endian raw RPM. Read through
+                // the ACPI EC port pair, which aliases the MMIO state window: measured 2026-08-05
+                // over PawnIO's LpcACPIEC - the same module PawnIOEcAccess loads - at 99.2%
+                // agreement on stable bytes with 7 of 7 entropy-carrying anchors matching, 0x70
+                // reading 2760 through both views simultaneously. Reads only; this board keeps
+                // SupportsFanControlEc = false and nothing here implies a write address.
+                EcFanTachometerOffsets = new ushort[] { 0x70, 0x5C },
                 FanZoneCount = 2,
                 // Measured, not inherited: 60. This board reports thermal policy V1 and REJECTS the
                 // V2 fan commands outright - 0x37 returns RTCD 6 and 0x38 returns RTCD 4, at every

--- a/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
+++ b/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
@@ -211,6 +211,38 @@ namespace OmenCore.Hardware
         };
         
         /// <summary>
+        /// Boards on HP's <c>Vibrance25C1</c> platform - the 2025 OMEN MAX family that shares one
+        /// firmware base and one EC layout with <c>8D87</c>, the board that layout was reverse
+        /// engineered on.
+        ///
+        /// This is a <b>scope list for raw EC offsets, not a capability claim.</b> Only 8D87 has been
+        /// measured; the others are listed because they share the firmware, so an offset derived from
+        /// 8D87 is plausible on them and definitely wrong off-platform. Anything that writes a raw EC
+        /// offset derived from this platform should refuse to run on a board outside this list.
+        ///
+        /// Note that it is deliberately not a set of database entries: HP's own software gates power
+        /// features on the runtime <c>Default 0x28</c> capability query rather than on board ID, and
+        /// inventing three unmeasured profiles here would assert fan, RGB and MUX behaviour nobody
+        /// has confirmed. Prefer <see cref="HpWmiBios.SystemDesignData"/> for capability; use this
+        /// list only to bound raw-offset access.
+        /// </summary>
+        public static readonly IReadOnlyList<string> Vibrance25C1BoardIds = new[]
+        {
+            "8D87", // OMEN MAX 16-ak0xxx AMD - the measured board
+            "8D88",
+            "8DD5",
+            "8DD6"
+        };
+
+        /// <summary>
+        /// True when the board is on the <c>Vibrance25C1</c> platform. See
+        /// <see cref="Vibrance25C1BoardIds"/> for what this does and does not license.
+        /// </summary>
+        public static bool IsVibrance25C1Board(string? productId) =>
+            !string.IsNullOrWhiteSpace(productId) &&
+            Vibrance25C1BoardIds.Contains(productId, StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
         /// Default capabilities used when model is not in the database.
         /// Assumes standard OMEN laptop capabilities.
         /// </summary>
@@ -926,6 +958,25 @@ namespace OmenCore.Hardware
             });
 
             // OMEN MAX 16 (2025) - ak0xxx family (GitHub #117 / Product ID 8D87)
+            //
+            // Field-confirmed by the board's owner (BIOS F.07, EC 40.38) via ACPI decompilation plus
+            // live measurement. See docs/8D87-OMEN-MAX-16-SUPPORT-PLAN.md. Two things worth knowing
+            // before editing this entry:
+            //
+            //   * The firmware reports thermal policy V1 (Default 0x28 byte 3 = 0x01), but HpWmiBios
+            //     force-switches this board to V2 on a model-name substring match. That switch is
+            //     wrong here - the board refuses the V2 fan commands - and MaxFanLevel = 60 below is
+            //     what currently contains the damage, because it reaches DetectMaxFanLevel as the
+            //     model override and returns before the V2 branch. The diagnostics export prints
+            //     both the firmware-reported and effective values when they disagree.
+            //   * The EC here is memory-mapped, not at the legacy port offsets. The legacy EC map
+            //     does not apply: 0x9F on this board is battery remaining capacity in mAh, not a GPU
+            //     tachometer. The real fan tachometers are 0x70 (fan 1) and 0x5C (fan 2), both
+            //     16-bit raw rpm in the state window at 0xFE700600. 0x7E is NOT the second
+            //     tachometer - it is a commanded setpoint gated by the level byte at 0x5B, it reads
+            //     0 whenever nothing has been commanded, and it stays fixed while the fan it
+            //     supposedly measures changes speed. OmenCore has never inherited the legacy
+            //     mistake; the note is here so nobody introduces it.
             AddModel(new ModelCapabilities
             {
                 ProductId = "8D87",
@@ -935,22 +986,73 @@ namespace OmenCore.Hardware
                 Family = OmenModelFamily.OMEN2024Plus,
                 SupportsFanControlWmi = true,
                 SupportsFanControlEc = false, // MAX-series EC layout diverges from legacy mappings
+                // The EC mailbox power block at 0xF5-0xF8 (mailbox window, not the state window) was
+                // forced to its high-power values with no effect - it is a mirror the SMU never reads
+                // back. PowerLimitController's own 0xC0-0xC5 offsets are a different window and have
+                // not been tested here, so this stays false for both reasons.
+                SupportsEcPowerLimits = false,
                 SupportsFanCurves = true,
                 SupportsIndependentFanCurves = false,
-                SupportsRpmReadback = true,
+                SupportsRpmReadback = true, // measured: V1 0x2D tracks the EC tachometers at four points
                 FanZoneCount = 2,
-                MaxFanLevel = 100,
+                // Measured, not inherited: 60. This board reports thermal policy V1 and REJECTS the
+                // V2 fan commands outright - 0x37 returns RTCD 6 and 0x38 returns RTCD 4, at every
+                // input and output buffer size tried. Fan levels therefore arrive through the V1
+                // 0x2D fallback in krpm/100, not percent, so MaxFanLevel = 100 made
+                // MapFanPercentToWmiLevel an identity: a request for 50% wrote raw level 50, which
+                // is ~5000 rpm - near maximum, not half. Sampled against the EC tachometers and
+                // OGH's own readout at four points (0/0, 22/2220, 47/4680, 60/6000), linear within
+                // ~1%, ceiling 60. This value reaches DetectMaxFanLevel as the model override and
+                // returns before the V2 branch, so it is what actually takes effect.
+                // Same defect class as GetCapabilities_8C77_Wf1xxx_UsesExactV1WmiProfileNotV2Mismatch.
+                MaxFanLevel = 60,
                 MaxModeDropChecksBeforeReapply = 1,
                 SupportsPerformanceModes = true,
                 PerformanceModes = new[] { "Default", "Performance", "Cool", "L5P" },
+                // Measured across a reboot in each direction. BIOS setup offers Hybrid / Discrete /
+                // UMA; switching to Discrete moves Legacy 0x52 byte 0 from 0x00 to 0x01 and moves
+                // the INTERNAL PANEL to the dGPU - in Discrete the sole display is the built-in
+                // CMN1652 at its native 2560x1600 driven by the RTX 5080, with the Radeon reporting
+                // no active mode and nvidia-smi reporting display_active = Enabled. The panel does
+                // not merely stay lit, it changes which GPU lights it, which is what HasMuxSwitch
+                // claims. Fully reversible: the restored capture matches the baseline on every WMI
+                // and AMD_PBS_SETUP field.
                 HasMuxSwitch = true,
                 SupportsGpuPowerBoost = true,
-                SupportsAdvancedOptimus = true,
+                // Measured false, and it was inherited true. Advanced Optimus is the *dynamic* kind
+                // of switching - the display mux moves under live ACPI control with no reboot - and
+                // that whole block is switched off in firmware: AMD_PBS_SETUP 0xB6 Smart Mux Support
+                // = 0 (Disabled), 0xC7 Smart Mux Acpi Control = 0, 0xCA MDM Support Level = 0 (No
+                // Support), 0xC8 Display Panel Multiplexer = 0.
+                //
+                // The mode switch above is what makes this conclusive rather than merely suggestive:
+                // that block still read 0 in Discrete and again after returning to Hybrid. It stays
+                // off through a switch that demonstrably works, so the routing decision is taken at
+                // boot by firmware and there is no runtime control surface. A mux without Advanced
+                // Optimus is exactly this board.
+                SupportsAdvancedOptimus = false,
+                // Measured via the keyboard topology probe - class 0x00020008, command 0x2B, null
+                // input, 4-byte return - which returns 0x03 = NbKeyboardLightingType.RgbPerKey,
+                // stable across repeated reads. That is the probe HP itself gates on for this
+                // platform; the Keyboard command class (0x00020009) is NOT the gate here and
+                // returns an 0xFF sentinel for the type query.
                 HasKeyboardBacklight = true,
                 HasPerKeyRgb = true,
+                // False, and deliberately explicit rather than left to the property default of
+                // true. HP's own gate (FourZoneHelper.IsSupported) returns false for lighting type
+                // 3, so the four-zone command path does not drive a per-key keyboard. Without this
+                // line the entry claimed per-key AND four-zone simultaneously.
+                HasFourZoneRgb = false,
                 SupportsUndervolt = false, // AMD Ryzen AI path does not use Intel MSR undervolt
+                // Stays false until the whole profile is confirmed. Power, thermal policy, EC, the
+                // fan range, the keyboard topology and both MUX flags are now owner-verified on
+                // hardware - the MUX rows by an actual mode switch and reboot, not by inference.
+                // What is still inherited: SupportsFanCurves and SupportsIndependentFanCurves, and
+                // the named PerformanceModes including "L5P" - all three need writes to confirm, and
+                // read-only identification work does not license them. The flag is all-or-nothing,
+                // so it reports the weakest claim in the entry.
                 UserVerified = false,
-                Notes = "GitHub #117 — OMEN MAX Gaming Laptop 16-ak0xxx, Product ID 8D87. Model profile inferred from adjacent MAX ak/ah generation; verify keyboard/fan behavior on real hardware."
+                Notes = "OMEN MAX Gaming Laptop 16-ak0xxx (GitHub #117), Product ID 8D87 — Ryzen AI 9 HX 375 + RTX 5080, BIOS F.07 / EC 40.38. Power, thermal-policy, fan-range, keyboard-topology and MUX fields owner-verified on hardware; fan curves and performance modes are still inherited from the adjacent MAX generation. Firmware reports thermal policy V1 and rejects the V2 fan commands (0x37/0x38), so fan levels come from the V1 0x2D fallback in krpm/100 — hence MaxFanLevel 60, measured, not 100. Keyboard is per-key RGB (topology probe 0x2B returns 3), so the four-zone path does not apply. Display MUX confirmed by switching modes: BIOS offers Hybrid/Discrete/UMA, and in Discrete the internal panel is driven by the dGPU while Legacy 0x52 reads 0x01 — but it is routed at boot, not under live ACPI control, so Advanced Optimus is false. EC is memory-mapped, so legacy EC offsets do not apply; the EC mailbox power block was forced with no effect."
             });
             // -----------------------------------------------------------------------------------
             // OMEN 17 Series (17.3" laptops)

--- a/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
+++ b/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
@@ -973,11 +973,26 @@ namespace OmenCore.Hardware
                 SupportsGpuPowerBoost = true,
                 SupportsAdvancedOptimus = true,
                 HasKeyboardBacklight = true,
-                HasFourZoneRgb = true,
+                // False, corrected from an inherited true. This entry's ModelNamePattern
+                // ("max 16 ak0") matches the same AMD OMEN MAX 16 hardware as the 8D87 entry
+                // below, where the keyboard topology probe (Default 0x2B) returns RgbPerKey and
+                // the four-zone commands were owner-observed driving the LIGHT BAR rather than the
+                // keyboard. This entry was never UserVerified, so these two flags were defaults
+                // rather than a report.
+                HasFourZoneRgb = false,
                 HasPerKeyRgb = true,
+                HasLightBar = true,
                 SupportsUndervolt = false, // AMD Ryzen — Intel-style undervolt unsupported
                 UserVerified = false,
-                Notes = "OMEN MAX 16 ak0003nr — AMD HX 375 + RTX 5080. ThermalPolicy V2 (WMI V2) support; avoid EC writes that target legacy registers."
+                // WARNING: this entry describes the same hardware as the 8D87 entry below and
+                // disagrees with it on more than lighting - MaxFanLevel (100 here, measured 60
+                // there), an "L5P" mode that HpWmiBios.FanMode cannot send, SupportsAdvancedOptimus
+                // (true here, measured false there) and SupportsUndervolt (false here, measured
+                // true there). Only the lighting flags were corrected, because only lighting was
+                // in scope for the change that touched this. The rest is a real divergence and
+                // whichever entry wins a lookup decides the behaviour.
+                Notes = "OMEN MAX 16 ak0003nr — AMD HX 375 + RTX 5080. ThermalPolicy V2 (WMI V2) support; avoid EC writes that target legacy registers. " +
+                        "Overlaps board 8D87; see the warning above before trusting the non-lighting fields here."
             });
 
             // OMEN MAX 16 (2025) - ak0xxx family (GitHub #117 / Product ID 8D87)
@@ -1083,10 +1098,22 @@ namespace OmenCore.Hardware
                 // Optimus is exactly this board.
                 SupportsAdvancedOptimus = false,
                 // Measured via the keyboard topology probe - class 0x00020008, command 0x2B, null
-                // input, 4-byte return - which returns 0x03 = NbKeyboardLightingType.RgbPerKey,
-                // stable across repeated reads. That is the probe HP itself gates on for this
-                // platform; the Keyboard command class (0x00020009) is NOT the gate here and
-                // returns an 0xFF sentinel for the type query.
+                // input, 4-byte return - which returns 0x03 = NbKeyboardLightingType.RgbPerKey on
+                // all ten of ten repeated reads. That is the probe HP itself gates on for this
+                // platform.
+                //
+                // The Keyboard command class (0x00020009) command 0x01 is NOT the gate here, and
+                // the earlier note that it "returns an 0xFF sentinel" understated the problem: it
+                // is not a sentinel, it is an accumulator. Ten identical consecutive calls
+                // returned 0x0F, 0x1F, 0x3F, 0x7F, 0xFF, and then 0xFF for every call after. It
+                // grows until it saturates, which is why a later reading looks like a fixed 0xFF.
+                // Nothing about the hardware changes between those calls, so the byte cannot be a
+                // keyboard type - and once saturated its bit 0 reads "lighting supported" whether
+                // or not that is true.
+                //
+                // Corroborated independently by the keyboard's own HID descriptors: it is a
+                // 120-lamp HID LampArray of kind Keyboard, 342 x 125 mm, 8-bit RGB per lamp, with
+                // per-lamp HID key bindings. See tools/LightingProbe.
                 HasKeyboardBacklight = true,
                 HasPerKeyRgb = true,
                 // False, and deliberately explicit rather than left to the property default of

--- a/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
+++ b/src/OmenCoreApp/Hardware/ModelCapabilityDatabase.cs
@@ -1038,7 +1038,28 @@ namespace OmenCore.Hardware
                 MaxFanLevel = 60,
                 MaxModeDropChecksBeforeReapply = 1,
                 SupportsPerformanceModes = true,
-                PerformanceModes = new[] { "Default", "Performance", "Cool", "L5P" },
+                // Measured in watts, not return codes. SetFanMode (Default 0x1A) writes NPCF.MODE,
+                // and the firmware consumes it as (MODE & 0x0F) - so the three mode bytes collapse
+                // onto two profiles. With the OGHP gate armed, on the 330 W adapter:
+                //
+                //   Default     0x30 -> nibble 0 -> enforced.power.limit ~102 W (floating)
+                //   Performance 0x31 -> nibble 1 -> enforced.power.limit  175.00 W (pinned)
+                //   Cool        0x50 -> nibble 0 -> enforced.power.limit ~103 W  <- same as Default
+                //
+                // Performance was re-run as a positive control between every pair of readings and
+                // hit 175.00 W every time, so the gate was up throughout; a dropped gate reads
+                // 80.00 W and would otherwise masquerade as MODE 0. All three bytes return RTCD 0,
+                // including the two that select the same profile, which is why acceptance was never
+                // evidence here.
+                //
+                // "L5P" IS REMOVED, and it was inherited from the adjacent AK0003NR entry rather
+                // than measured. HpWmiBios.FanMode has no L5P member at all, so the string could
+                // never reach SetFanMode - it resolves only inside OghServiceProxy.ThermalPolicy,
+                // a different transport. Listing it here advertised a mode the WMI path cannot
+                // send. The firmware does have a fourth profile - MODE 4, reachable with a raw
+                // byte whose low nibble is 4, measured at 175.00 W approached from MODE 0 - but it
+                // is not L5P and no consumer project names it, so nothing is claimed for it here.
+                PerformanceModes = new[] { "Default", "Performance", "Cool" },
                 // Measured across a reboot in each direction. BIOS setup offers Hybrid / Discrete /
                 // UMA; switching to Discrete moves Legacy 0x52 byte 0 from 0x00 to 0x01 and moves
                 // the INTERNAL PANEL to the dGPU - in Discrete the sole display is the built-in
@@ -1072,23 +1093,75 @@ namespace OmenCore.Hardware
                 // true. HP's own gate (FourZoneHelper.IsSupported) returns false for lighting type
                 // 3, so the four-zone command path does not drive a per-key keyboard. Without this
                 // line the entry claimed per-key AND four-zone simultaneously.
-                HasFourZoneRgb = false,
-                SupportsUndervolt = false, // AMD Ryzen AI path does not use Intel MSR undervolt
-                // Stays false until the whole profile is confirmed. Power, thermal policy, EC, the
-                // fan range, the keyboard topology and both MUX flags are now owner-verified on
-                // hardware - the MUX rows by an actual mode switch and reboot, not by inference.
-                // SupportsFanCurves is now MEASURED on this board, not inherited. With the fans
-                // coasting down from a previous command, a commanded 100% reversed the decay and
-                // drove them from ~3500 to 6000 rpm - the ceiling implied by MaxFanLevel 60 - read
-                // at the EC tachometers by an instrument outside the app. At 60% the same run
-                // measured 3600 rpm against an expected 3600. Levels move these fans.
                 //
-                // What is still inherited: the named PerformanceModes, including "L5P". Confirming
-                // those means showing each is accepted AND changes delivered power, which is a
-                // separate measurement. UserVerified is all-or-nothing across the entry, so it
-                // still reports the weakest claim - this one.
-                UserVerified = false,
-                Notes = "OMEN MAX Gaming Laptop 16-ak0xxx (GitHub #117), Product ID 8D87 — Ryzen AI 9 HX 375 + RTX 5080, BIOS F.07 / EC 40.38. Power, thermal-policy, fan-range, fan-curve, keyboard-topology and MUX fields owner-verified on hardware; only the named performance modes are still inherited from the adjacent MAX generation. Fan curves measured: a commanded 100% drove the fans to 6000 rpm against a decaying baseline, and 60% measured 3600 rpm against an expected 3600, read at the EC tachometers independently of the app. Firmware reports thermal policy V1 and rejects the V2 fan commands (0x37/0x38), so fan levels come from the V1 0x2D fallback in krpm/100 — hence MaxFanLevel 60, measured, not 100. Keyboard is per-key RGB (topology probe 0x2B returns 3), so the four-zone path does not apply. Display MUX confirmed by switching modes: BIOS offers Hybrid/Discrete/UMA, and in Discrete the internal panel is driven by the dGPU while Legacy 0x52 reads 0x01 — but it is routed at boot, not under live ACPI control, so Advanced Optimus is false. EC is memory-mapped, so legacy EC offsets do not apply; the EC mailbox power block was forced with no effect."
+                // What the four-zone path DOES drive here is the light bar. Owner-observed: issuing
+                // the four-zone colour commands on this board visibly changes the light bar colour
+                // and leaves the keyboard untouched. So "four-zone returned success" was never a
+                // null result on this machine - it was landing on a different lighting surface than
+                // the one being watched, which is a more misleading failure than an outright
+                // refusal. Read this flag as "four-zone KEYBOARD", which is what it gates.
+                HasFourZoneRgb = false,
+                // True, owner-confirmed by the above: this chassis has a light bar and it is the
+                // surface that responds to the four-zone commands. Previously left at the property
+                // default of false, which the entry would now be asserting as verified.
+                HasLightBar = true,
+                // TRUE, and it was previously false with the comment "AMD Ryzen AI path does not use
+                // Intel MSR undervolt" - which gave the wrong reason by conflating "not Intel MSR"
+                // with "not undervoltable". This part undervolts fine via AMD Curve Optimizer;
+                // owner-confirmed on this machine.
+                //
+                // The distinction this field has to keep straight: it describes what the HARDWARE
+                // supports, not whether OmenCore's SMU backend can drive it today. Those are
+                // separate gates and DeviceCapabilities.ShowUndervolt already ANDs both -
+                //     CanUndervolt && UndervoltRuntimeReady && ModelConfig.SupportsUndervolt
+                // - so a missing or unmapped SMU is caught by UndervoltRuntimeReady, which surfaces
+                // AmdUndervoltProvider's own RuntimeBlockReason text. Setting this false as a proxy
+                // for backend readiness suppressed the feature twice and hid the actionable message
+                // behind a capability claim that was simply untrue.
+                //
+                // Nothing here rules Curve Optimizer out either: RyzenControl's exclusion is
+                // (family == 0x1A && model >= 0x40), and this part reports AMD64 Family 26 Model 36
+                // - family 0x1A, model 0x24 - so it is below that bound and not excluded.
+                SupportsUndervolt = true,
+                // Same reason as SupportsUndervolt, and previously left at the property default of
+                // true: TCC offset is an Intel thermal-control-circuit knob and there is no such
+                // register on a Ryzen AI 9 HX 375. Explicit rather than defaulted so the entry does
+                // not claim an Intel-only capability on an AMD board.
+                SupportsTccOffset = false,
+                // Explicit, and it agrees with the property default. Default 0x28 byte 4 = 0x03:
+                // bit 0 SwFanCtl set, bit 1 ExtremeMode SUPPORTED - but bit 2 ExtremeModeUnlock is
+                // CLEAR. The SKU knows the feature and the firmware has not unlocked it, so the
+                // effective capability is false. Recorded here so a later reader does not see
+                // "ExtremeMode supported" in the capability block and flip this to true.
+                SupportsOverboost = false,
+                // TRUE. Every board-specific claim in this entry is now owner-verified on the
+                // hardware itself, by outcome rather than by return code:
+                //
+                //   power / thermal policy   Default 0x28 decoded and cross-checked; V1 confirmed
+                //                            by the V2 fan commands being refused outright
+                //   EC layout                memory-mapped window located; port view cross-checked
+                //                            against MMIO at 99.2% on stable bytes
+                //   fan range                MaxFanLevel 60 sampled at four points, linear to ~1%
+                //   fan curves               a commanded 100% reversed a coast-down, ~3500 -> 6000
+                //                            rpm; 60% measured 3600 against an expected 3600, read
+                //                            at the EC tachometers by an instrument outside the app
+                //   RPM readback             0x70 / 0x5C tracking the rotor through a full ramp
+                //   keyboard topology        probe 0x2B returns 3 = RgbPerKey, stable on reread
+                //   both MUX flags           an actual BIOS mode switch and reboot, in both
+                //                            directions, not inference from adapter activity
+                //   performance modes        the sweep documented above, with a positive control
+                //                            between every reading
+                //
+                // What is NOT claimed, so that this flag is not read as more than it is. The
+                // remaining fields are property defaults that were never board-specific claims:
+                // SupportsNetworkBoost and SupportsPowerLimits are untested here, and
+                // SupportsIndependentFanCurves is set false as the conservative choice rather than
+                // because independent curves were shown impossible. UserVerified is all-or-nothing
+                // across the entry, so it is being flipped on the strength of the measured rows;
+                // a defect in one of those defaults is a reason to fix the field, not to reset
+                // this flag.
+                UserVerified = true,
+                Notes = "OMEN MAX Gaming Laptop 16-ak0xxx (GitHub #117), Product ID 8D87 — Ryzen AI 9 HX 375 + RTX 5080, BIOS F.07 / EC 40.38. Fully owner-verified on hardware. Performance modes measured in delivered watts: SetFanMode writes NPCF.MODE and the firmware consumes (MODE & 0x0F), so Default (0x30) and Cool (0x50) both select nibble 0 and deliver the same ~102 W GPU limit, while Performance (0x31) selects nibble 1 and pins enforced.power.limit at 175 W — Cool differs from Default as fan policy, not as a power tier. All three return RTCD 0, so acceptance was never the evidence. \"L5P\" has been removed: it was inherited from the adjacent AK0003NR entry and HpWmiBios.FanMode has no byte for it, so the WMI path could never send it. Fan curves measured: a commanded 100% drove the fans to 6000 rpm against a decaying baseline, and 60% measured 3600 rpm against an expected 3600, read at the EC tachometers independently of the app. Firmware reports thermal policy V1 and rejects the V2 fan commands (0x37/0x38), so fan levels come from the V1 0x2D fallback in krpm/100 — hence MaxFanLevel 60, measured, not 100. Keyboard is per-key RGB (topology probe 0x2B returns 3), so the four-zone keyboard path does not apply — the four-zone commands instead drive this chassis's light bar, owner-observed, which is why they appeared to succeed while the keyboard never changed. Display MUX confirmed by switching modes: BIOS offers Hybrid/Discrete/UMA, and in Discrete the internal panel is driven by the dGPU while Legacy 0x52 reads 0x01 — but it is routed at boot, not under live ACPI control, so Advanced Optimus is false. EC is memory-mapped, so legacy EC offsets do not apply; the EC mailbox power block was forced with no effect."
             });
             // -----------------------------------------------------------------------------------
             // OMEN 17 Series (17.3" laptops)

--- a/src/OmenCoreApp/Hardware/OmenBoard.cs
+++ b/src/OmenCoreApp/Hardware/OmenBoard.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Management;
+
+namespace OmenCore.Hardware
+{
+    /// <summary>
+    /// Board identity, and the one place where a feature is restricted to boards it was measured on.
+    ///
+    /// OmenCore spans years of OMEN and Victus firmware, and most of what is known about any given
+    /// surface was learned on ONE machine. Where a capability can be probed, probe it - the shape
+    /// test in <see cref="HidLampArray.OpenLightBar"/> is doing real work and would be worth keeping
+    /// with no allowlist at all. This is for the window between "measured here" and "confirmed
+    /// there", and it should shrink: an entry that gets broadly confirmed belongs in a real probe.
+    /// </summary>
+    public static class OmenBoard
+    {
+        private static string? _product;
+        private static bool _read;
+
+        /// <summary>
+        /// Win32_BaseBoard.Product - HP's four-character board id, e.g. "8D87". Empty when it
+        /// cannot be read, which is treated as "unknown board" rather than as any particular one.
+        /// </summary>
+        public static string Product
+        {
+            get
+            {
+                if (_read) return _product ?? string.Empty;
+                _read = true;
+
+                try
+                {
+                    using var searcher = new ManagementObjectSearcher("SELECT Product FROM Win32_BaseBoard");
+                    foreach (ManagementObject o in searcher.Get())
+                    {
+                        _product = o["Product"]?.ToString()?.Trim();
+                        break;
+                    }
+                }
+                catch
+                {
+                    // An unreadable baseboard is an unknown board, and unknown boards get the
+                    // conservative path. Nothing here is worth failing startup over.
+                    _product = null;
+                }
+
+                return _product ?? string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Boards where the light bar was confirmed reachable over its own HID LampArray, without
+        /// administrator.
+        ///
+        /// 8D87 - OMEN MAX 16-ak0xxx, BIOS F.07 / EC 40.38. The bar enumerates as "HID VHF Driver"
+        /// 0461:0001, Kind Scene, four lamps across 323 x 5 mm; colour writes were confirmed by eye
+        /// from a non-elevated process. Whether that virtual device exists on any other OMEN, and is
+        /// the light bar there, one machine cannot say - hence a list rather than a blanket enable.
+        /// </summary>
+        private static readonly HashSet<string> HidLightBarBoards =
+            new(StringComparer.OrdinalIgnoreCase) { "8D87" };
+
+        /// <summary>
+        /// Whether to reach the light bar over HID on this machine.
+        ///
+        /// The HID path is used ONLY where HP's WMI surface is unavailable - unelevated, where the
+        /// bar currently does nothing at all. It never displaces WMI, so a false here restores
+        /// exactly today's behaviour and an elevated user is unaffected either way.
+        /// </summary>
+        public static bool SupportsHidLightBar(string? product = null) =>
+            HidLightBarBoards.Contains((product ?? Product).Trim());
+    }
+}

--- a/src/OmenCoreApp/Hardware/WmiFanController.cs
+++ b/src/OmenCoreApp/Hardware/WmiFanController.cs
@@ -24,6 +24,22 @@ namespace OmenCore.Hardware
     {
         private readonly IHpWmiBios _wmiBios;
         private readonly IEcAccess? _ecAccess;
+
+        /// <summary>
+        /// Per-fan EC offsets of 16-bit little-endian raw RPM tachometers, or null when this
+        /// model has none. See <see cref="ModelCapabilities.EcFanTachometerOffsets"/>; this is
+        /// a read-only capability and is not tied to EC fan control.
+        /// </summary>
+        private readonly ushort[]? _ecFanTachometerOffsets;
+
+        /// <summary>
+        /// Above this, a tachometer pair is not a fan speed - it is a mis-aimed offset reading
+        /// whatever else lives in EC RAM. Matches the existing WMI RPM sanity ceiling.
+        /// </summary>
+        private const int MaxPlausibleFanRpm = 8000;
+
+        /// <summary>Set once the EC tachometer read has failed, to stop retrying every tick.</summary>
+        private bool _ecTachometerUnavailable;
         private readonly LibreHardwareMonitorImpl? _hwMonitor;
         private readonly LoggingService? _logging;
         private readonly bool _strictFanModeReadback;
@@ -185,12 +201,14 @@ namespace OmenCore.Hardware
             IEcAccess? ecAccess = null,
             bool strictFanModeReadback = true,
             bool allowV1AutoModeFloorClear = true,
-            int? maxModeDropChecksBeforeReapply = null)
+            int? maxModeDropChecksBeforeReapply = null,
+            ushort[]? ecFanTachometerOffsets = null)
         {
             _hwMonitor = hwMonitor;
             _logging = logging;
             _wmiBios = injectedWmiBios ?? new HpWmiBios(logging);
             _ecAccess = ecAccess;
+            _ecFanTachometerOffsets = ecFanTachometerOffsets;
             _strictFanModeReadback = strictFanModeReadback;
             _allowV1AutoModeFloorClear = allowV1AutoModeFloorClear;
             _maxModeDropChecksBeforeReapply = Math.Clamp(
@@ -1335,6 +1353,24 @@ namespace OmenCore.Hardware
                     }
                 }
                 
+                // Try the EC tachometers before falling back to the fan level. Order matters:
+                // the level fallback below is the *commanded* value echoed back, so preferring
+                // it over a physical tachometer would replace a measurement with an estimate.
+                if (!gotValidData)
+                {
+                    var ecRpm = TryReadEcTachometers();
+                    if (ecRpm.HasValue)
+                    {
+                        fan1Rpm = ecRpm.Value.fan1Rpm;
+                        fan2Rpm = ecRpm.Value.fan2Rpm;
+                        fan1Percent = Math.Clamp((fan1Rpm * 100) / 5500, 0, 100);
+                        fan2Percent = Math.Clamp((fan2Rpm * 100) / 5500, 0, 100);
+                        gotValidData = true;
+                        rpmSource = RpmSource.EcDirect;
+                        _logging?.Debug($"[FanRPM] EC tachometers: CPU={fan1Rpm} ({fan1Percent}%), GPU={fan2Rpm} ({fan2Percent}%)");
+                    }
+                }
+
                 // Try fan level if direct RPM unavailable
                 if (!gotValidData)
                 {
@@ -1832,6 +1868,73 @@ namespace OmenCore.Hardware
 
             _lastCountdownExtendUtc = nowUtc;
             _wmiBios.ExtendFanCountdown();
+        }
+
+        /// <summary>
+        /// Read the fan tachometers straight out of EC RAM, for models whose profile supplies
+        /// their offsets. Returns null when this model has none, when EC access is unavailable,
+        /// or when the values read back are not plausible fan speeds.
+        ///
+        /// A zero from here is reported as a zero. That is the point: on a board where the only
+        /// other RPM source is the commanded level echoed back, "0 RPM" and "no reading" were
+        /// indistinguishable, and a fan-speed change could be declared verified against a
+        /// reading that came from the request itself.
+        ///
+        /// No transition debounce is applied, unlike the WMI paths below. Those filter readings
+        /// taken while the BIOS is still reporting a stale *target*; a tachometer has no target
+        /// to be stale about, and suppressing its output during spin-up or spin-down would
+        /// discard exactly the measurements that show the fan responding.
+        /// </summary>
+        private (int fan1Rpm, int fan2Rpm)? TryReadEcTachometers()
+        {
+            if (_ecFanTachometerOffsets is not { Length: >= 2 } offsets ||
+                _ecAccess?.IsAvailable != true ||
+                _ecTachometerUnavailable)
+            {
+                return null;
+            }
+
+            try
+            {
+                var fan1Rpm = ReadEcTachometer(offsets[0]);
+                var fan2Rpm = ReadEcTachometer(offsets[1]);
+
+                // A mis-aimed offset usually reads as something far too large rather than as an
+                // error - on this board's neighbours the legacy offsets land in an ASCII serial
+                // number and decode to a believable-looking four-digit RPM. Refuse the pair
+                // rather than publish a number no fan could produce.
+                if (fan1Rpm > MaxPlausibleFanRpm || fan2Rpm > MaxPlausibleFanRpm)
+                {
+                    _logging?.Warn($"[FanRPM] EC tachometers at 0x{offsets[0]:X2}/0x{offsets[1]:X2} " +
+                                   $"read {fan1Rpm}/{fan2Rpm} RPM, beyond {MaxPlausibleFanRpm} - " +
+                                   "treating the offsets as wrong for this board and falling back");
+                    _ecTachometerUnavailable = true;
+                    return null;
+                }
+
+                return (fan1Rpm, fan2Rpm);
+            }
+            catch (Exception ex)
+            {
+                // PawnIOEcAccess throws rather than returning 0 on a failed transaction, which
+                // is what makes a returned 0 above trustworthy. Stop asking after the first
+                // failure; an EC that will not answer this tick will not answer the next either,
+                // and retrying every tick is how EC contention gets amplified.
+                _logging?.Warn($"[FanRPM] EC tachometer read failed ({ex.GetType().Name}: {ex.Message}); " +
+                               "falling back to WMI fan level for RPM");
+                _ecTachometerUnavailable = true;
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// One 16-bit little-endian raw RPM value at <paramref name="offset"/> / offset + 1.
+        /// </summary>
+        private int ReadEcTachometer(ushort offset)
+        {
+            int low = _ecAccess!.ReadByte(offset);
+            int high = _ecAccess.ReadByte((ushort)(offset + 1));
+            return low | (high << 8);
         }
 
         private bool ConfirmFanModeReadback(HpWmiBios.FanMode expectedMode, string operation)

--- a/src/OmenCoreApp/Hardware/WmiFanController.cs
+++ b/src/OmenCoreApp/Hardware/WmiFanController.cs
@@ -1842,6 +1842,21 @@ namespace OmenCore.Hardware
                 return true;
             }
 
+            // Decide this BEFORE reading. EcFanModeRegister is the legacy port-EC offset, and on
+            // boards whose profile disables direct EC fan control it does not hold the fan mode at
+            // all - on 8D87 (memory-mapped EC) it reads 0x02 where 0x30 is expected. The mismatch
+            // was already being ignored, but only after three reads, two 40 ms sleeps and a WARN
+            // pair per fan-mode change: a scary log line and an EC transaction, both for an answer
+            // that could not be used either way.
+            if (!_strictFanModeReadback)
+            {
+                _logging?.Debug(
+                    $"Fan mode readback skipped for {operation}; model profile does not allow direct " +
+                    $"EC fan-mode verification (EC[0x{EcFanModeRegister:X2}] is the legacy offset and " +
+                    "is not authoritative on this board)");
+                return true;
+            }
+
             byte expected = (byte)expectedMode;
             byte? lastRead = null;
 
@@ -1871,12 +1886,6 @@ namespace OmenCore.Hardware
 
             var actualText = lastRead.HasValue ? $"0x{lastRead.Value:X2}" : "n/a";
             _logging?.Warn($"Fan mode readback mismatch for {operation}: expected EC[0x{EcFanModeRegister:X2}]=0x{expected:X2}, got {actualText}");
-            if (!_strictFanModeReadback)
-            {
-                _logging?.Warn($"Fan mode readback mismatch ignored for {operation}; model profile does not allow direct EC fan-mode verification");
-                return true;
-            }
-
             return false;
         }
 

--- a/src/OmenCoreApp/Hardware/WmiFanController.cs
+++ b/src/OmenCoreApp/Hardware/WmiFanController.cs
@@ -38,8 +38,36 @@ namespace OmenCore.Hardware
         /// </summary>
         private const int MaxPlausibleFanRpm = 8000;
 
-        /// <summary>Set once the EC tachometer read has failed, to stop retrying every tick.</summary>
+        /// <summary>
+        /// Consecutive EC transaction failures before the tachometer path backs off. A single
+        /// timeout is normal: the ACPI EC port pair is shared with the firmware's own traffic and
+        /// a busy tick returns "output buffer not full" rather than an answer. Measured on 8D87 -
+        /// one run of the app logged a single timeout 39 seconds in and none before or after,
+        /// while the run before it logged none at all.
+        /// </summary>
+        private const int EcTachometerFailuresBeforeBackoff = 3;
+
+        /// <summary>
+        /// How long to stop asking after a run of failures. Long enough that a genuinely dead EC
+        /// costs almost no traffic, short enough that a recovered one is picked up in seconds.
+        /// </summary>
+        private static readonly TimeSpan EcTachometerBackoff = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Consecutive implausible readings before the offsets are written off for this board.
+        /// A tachometer is read as two separate byte transactions, so a single garbage pair can
+        /// be a torn read; a run of them means the offsets are pointed at something else.
+        /// </summary>
+        private const int EcTachometerImplausibleReadsBeforeGivingUp = 3;
+
+        /// <summary>
+        /// Set only when the offsets are judged wrong for this board - a permanent condition.
+        /// A failed *transaction* never sets this; it backs off and retries instead.
+        /// </summary>
         private bool _ecTachometerUnavailable;
+        private int _ecTachometerFailureStreak;
+        private int _ecTachometerImplausibleStreak;
+        private DateTime _ecTachometerRetryAfterUtc = DateTime.MinValue;
         private readonly LibreHardwareMonitorImpl? _hwMonitor;
         private readonly LoggingService? _logging;
         private readonly bool _strictFanModeReadback;
@@ -1873,7 +1901,10 @@ namespace OmenCore.Hardware
         /// <summary>
         /// Read the fan tachometers straight out of EC RAM, for models whose profile supplies
         /// their offsets. Returns null when this model has none, when EC access is unavailable,
-        /// or when the values read back are not plausible fan speeds.
+        /// when the transaction fails, or when the values read back are not plausible fan speeds.
+        ///
+        /// Both failure kinds are treated as transient until proven otherwise - see the streak
+        /// counters above. A single refused transaction is ordinary EC contention.
         ///
         /// A zero from here is reported as a zero. That is the point: on a board where the only
         /// other RPM source is the commanded level echoed back, "0 RPM" and "no reading" were
@@ -1889,7 +1920,8 @@ namespace OmenCore.Hardware
         {
             if (_ecFanTachometerOffsets is not { Length: >= 2 } offsets ||
                 _ecAccess?.IsAvailable != true ||
-                _ecTachometerUnavailable)
+                _ecTachometerUnavailable ||
+                DateTime.UtcNow < _ecTachometerRetryAfterUtc)
             {
                 return null;
             }
@@ -1905,24 +1937,49 @@ namespace OmenCore.Hardware
                 // rather than publish a number no fan could produce.
                 if (fan1Rpm > MaxPlausibleFanRpm || fan2Rpm > MaxPlausibleFanRpm)
                 {
+                    if (++_ecTachometerImplausibleStreak < EcTachometerImplausibleReadsBeforeGivingUp)
+                    {
+                        _logging?.Debug($"[FanRPM] EC tachometers read {fan1Rpm}/{fan2Rpm} RPM, beyond " +
+                                        $"{MaxPlausibleFanRpm} - discarding as a torn read " +
+                                        $"({_ecTachometerImplausibleStreak}/{EcTachometerImplausibleReadsBeforeGivingUp})");
+                        return null;
+                    }
+
                     _logging?.Warn($"[FanRPM] EC tachometers at 0x{offsets[0]:X2}/0x{offsets[1]:X2} " +
-                                   $"read {fan1Rpm}/{fan2Rpm} RPM, beyond {MaxPlausibleFanRpm} - " +
-                                   "treating the offsets as wrong for this board and falling back");
+                                   $"read {fan1Rpm}/{fan2Rpm} RPM, beyond {MaxPlausibleFanRpm}, " +
+                                   $"{_ecTachometerImplausibleStreak} times running - treating the " +
+                                   "offsets as wrong for this board and falling back for good");
                     _ecTachometerUnavailable = true;
                     return null;
                 }
 
+                _ecTachometerFailureStreak = 0;
+                _ecTachometerImplausibleStreak = 0;
                 return (fan1Rpm, fan2Rpm);
             }
             catch (Exception ex)
             {
-                // PawnIOEcAccess throws rather than returning 0 on a failed transaction, which
-                // is what makes a returned 0 above trustworthy. Stop asking after the first
-                // failure; an EC that will not answer this tick will not answer the next either,
-                // and retrying every tick is how EC contention gets amplified.
-                _logging?.Warn($"[FanRPM] EC tachometer read failed ({ex.GetType().Name}: {ex.Message}); " +
-                               "falling back to WMI fan level for RPM");
-                _ecTachometerUnavailable = true;
+                // PawnIOEcAccess throws rather than returning 0 on a failed transaction, which is
+                // what makes a returned 0 above trustworthy. A failure is not evidence the EC will
+                // keep refusing: the port pair is shared with the firmware's own traffic, so a
+                // single "output buffer not full" is contention, not absence. Back off after a run
+                // of them so a genuinely dead EC costs no traffic, but always come back - giving up
+                // on the first timeout leaves the board on the fan-level estimate for the rest of
+                // the session, which is what shipped and what a verification run then scored.
+                if (++_ecTachometerFailureStreak >= EcTachometerFailuresBeforeBackoff)
+                {
+                    _ecTachometerRetryAfterUtc = DateTime.UtcNow + EcTachometerBackoff;
+                    _ecTachometerFailureStreak = 0;
+                    _logging?.Warn($"[FanRPM] EC tachometer read failed ({ex.GetType().Name}: {ex.Message}) " +
+                                   $"{EcTachometerFailuresBeforeBackoff} times running; using the WMI fan " +
+                                   $"level for RPM and retrying in {EcTachometerBackoff.TotalSeconds:F0}s");
+                }
+                else
+                {
+                    _logging?.Debug($"[FanRPM] EC tachometer read failed ({ex.GetType().Name}: {ex.Message}); " +
+                                    "falling back to the WMI fan level for this tick");
+                }
+
                 return null;
             }
         }

--- a/src/OmenCoreApp/OmenCoreApp.csproj
+++ b/src/OmenCoreApp/OmenCoreApp.csproj
@@ -112,6 +112,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>LogitechLedEnginesWrapper.dll</Link>
     </Content>
+    <!-- Per-key keyboard layouts: which LED byte belongs to which key, and which keyboard a
+         given board has. Generated - regenerate with omen-max-16's
+         tools/static/emit-omencore-layouts.py rather than editing it. -->
+    <EmbeddedResource Include="Services\KeyboardLighting\KeyboardLayouts.json" />
   </ItemGroup>
 
   <!-- Ensure ModernStyles.xaml is compiled as a WPF resource (BAML) and embedded -->

--- a/src/OmenCoreApp/Services/BatteryInfoProvider.cs
+++ b/src/OmenCoreApp/Services/BatteryInfoProvider.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Management;
+
+namespace OmenCore.Services
+{
+    /// <summary>
+    /// Battery facts that Win32_Battery does not carry.
+    ///
+    /// The dashboard previously showed a hardcoded cycle count because Win32_Battery has no
+    /// cycle-count property. That is true of Win32_Battery and false of Windows: the battery
+    /// class driver publishes these values under <c>root\wmi</c>, which is where powercfg's
+    /// own battery report gets them. Measured on an OMEN MAX 16 whose dashboard was showing
+    /// 0 cycles and "Capacity unavailable": 14 cycles, 79416 of 83029 mWh.
+    ///
+    /// Not every pack populates these - plenty leave the fields unimplemented and the query
+    /// then throws or returns nothing. Every accessor here distinguishes "read a value" from
+    /// "could not read" instead of folding both into 0. A battery that genuinely has 0 cycles
+    /// is a real state; a controller that declines to answer is not the same thing, and
+    /// showing them identically is what made the old reading indistinguishable from a
+    /// placeholder.
+    /// </summary>
+    public static class BatteryInfoProvider
+    {
+        /// <summary>
+        /// These change on the order of once per full discharge, so re-querying them on the
+        /// monitoring cadence would be pure overhead. Long enough to be free, short enough
+        /// that a long uptime still tracks reality.
+        /// </summary>
+        private static readonly TimeSpan CacheLifetime = TimeSpan.FromMinutes(30);
+
+        private static readonly object Gate = new();
+        private static BatteryInfo _cached = BatteryInfo.Unknown;
+        private static DateTime _cachedAtUtc = DateTime.MinValue;
+        private static bool _unavailableLogged;
+
+        /// <summary>
+        /// Everything readable about the pack's wear state. Any member may be <c>null</c>,
+        /// independently of the others - the three values come from three separate WMI
+        /// classes and a pack can implement one without the others.
+        /// </summary>
+        public readonly struct BatteryInfo
+        {
+            public int? CycleCount { get; init; }
+            public int? DesignedCapacityMilliwattHours { get; init; }
+            public int? FullChargedCapacityMilliwattHours { get; init; }
+
+            public static BatteryInfo Unknown => default;
+
+            /// <summary>
+            /// Remaining capacity as a percentage of design capacity, or <c>null</c> when
+            /// either capacity is unreadable. Not clamped to 100: a pack reporting slightly
+            /// over design is a real (and common) reading, and silently trimming it would
+            /// hide a miscalibrated gauge.
+            /// </summary>
+            public double? HealthPercent =>
+                DesignedCapacityMilliwattHours is > 0 && FullChargedCapacityMilliwattHours is > 0
+                    ? FullChargedCapacityMilliwattHours.Value * 100.0 / DesignedCapacityMilliwattHours.Value
+                    : null;
+        }
+
+        /// <summary>
+        /// Cached battery wear state. Never throws: unreadable counters are an expected
+        /// outcome on many packs, not an error.
+        /// </summary>
+        public static BatteryInfo Get(LoggingService? logging = null)
+        {
+            lock (Gate)
+            {
+                if (DateTime.UtcNow - _cachedAtUtc < CacheLifetime)
+                {
+                    return _cached;
+                }
+
+                _cached = Query(logging);
+                _cachedAtUtc = DateTime.UtcNow;
+                return _cached;
+            }
+        }
+
+        private static BatteryInfo Query(LoggingService? logging)
+        {
+            var info = new BatteryInfo
+            {
+                CycleCount = ReadFirst("BatteryCycleCount", "CycleCount", logging),
+
+                // WARNING: this MUST stay a projected query. "SELECT * FROM BatteryStaticData"
+                // fails outright with "Generic failure" on this hardware - one of the class's
+                // string properties does not marshal, and asking for all of them poisons the
+                // whole result set. Naming the one column needed returns it fine. Anything
+                // added here should name its columns for the same reason.
+                DesignedCapacityMilliwattHours =
+                    ReadFirst("BatteryStaticData", "DesignedCapacity", logging),
+
+                FullChargedCapacityMilliwattHours =
+                    ReadFirst("BatteryFullChargedCapacity", "FullChargedCapacity", logging)
+            };
+
+            if (info.CycleCount == null &&
+                info.DesignedCapacityMilliwattHours == null &&
+                info.FullChargedCapacityMilliwattHours == null &&
+                !_unavailableLogged)
+            {
+                logging?.Debug("[Battery] No root\\wmi battery wear data available on this system");
+                _unavailableLogged = true;
+            }
+
+            return info;
+        }
+
+        private static int? ReadFirst(string className, string property, LoggingService? logging)
+        {
+            try
+            {
+                using var searcher = new ManagementObjectSearcher(
+                    @"root\wmi", $"SELECT {property}, Active FROM {className}");
+                using var results = searcher.Get();
+
+                int? firstSeen = null;
+                foreach (ManagementObject instance in results)
+                {
+                    using (instance)
+                    {
+                        var raw = instance[property];
+                        if (raw == null)
+                        {
+                            continue;
+                        }
+
+                        var value = Convert.ToInt32(raw);
+
+                        // Multi-battery machines enumerate every bay, including empty ones.
+                        // Prefer the active pack; fall back to the first that answered so a
+                        // single-battery machine reporting Active = false still gets a value.
+                        if (instance["Active"] is bool active && active)
+                        {
+                            return value;
+                        }
+
+                        firstSeen ??= value;
+                    }
+                }
+
+                return firstSeen;
+            }
+            catch (Exception ex)
+            {
+                // ManagementException "Not supported" is the normal answer from a controller
+                // that does not implement the counter. Debug, not Warn - this is not a fault.
+                logging?.Debug($"[Battery] {className}.{property} unavailable: {ex.Message}");
+                return null;
+            }
+        }
+    }
+}

--- a/src/OmenCoreApp/Services/Diagnostics/DiagnosticExportService.cs
+++ b/src/OmenCoreApp/Services/Diagnostics/DiagnosticExportService.cs
@@ -111,6 +111,7 @@ namespace OmenCore.Services.Diagnostics
                     CollectEcStateAsync(exportPath, effectiveEcAccess),
                     CollectHardwareInfoAsync(exportPath, effectiveMonitoringService),
                     CollectWmiCommandHistoryAsync(exportPath, effectiveWmiController, effectiveFanService),
+                    CollectPowerAdapterSnapshotAsync(exportPath, effectiveWmiController),
                     CollectTuningAndFanFocusAsync(exportPath, effectiveWmiController, effectiveFanService),
                     CollectMonitoringCadenceAndFanHoldAsync(exportPath, effectiveMonitoringService, effectiveFanService, effectiveWmiController),
                     CollectResumeRecoveryDiagnosticsAsync(exportPath)
@@ -2487,6 +2488,109 @@ namespace OmenCore.Services.Diagnostics
             catch (Exception ex)
             {
                 _logging.Warn($"Failed to collect WMI command history: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Capture the machine's own view of its power adapter and its SystemDesignData capability
+        /// block. Both are read-only BIOS queries.
+        ///
+        /// This is in the export because an under-rated adapter is invisible in every other artifact:
+        /// the firmware silently reduces power limits, and the resulting report reads as "GPU stuck
+        /// well below its rating" with nothing to attribute it to. Carrying the adapter verdict means
+        /// a reviewer can rule that out in one line instead of a round trip to the reporter.
+        /// </summary>
+        private async Task CollectPowerAdapterSnapshotAsync(string exportPath, object? wmiController)
+        {
+            try
+            {
+                if (wmiController is not HpWmiBios bios)
+                {
+                    await Task.CompletedTask;
+                    return;
+                }
+
+                var sb = new StringBuilder();
+                sb.AppendLine("=== POWER ADAPTER + SYSTEM DESIGN DATA ===");
+                sb.AppendLine($"Captured: {DateTime.UtcNow:O}");
+                sb.AppendLine("Source: BIOS Legacy 0x0F (adapter) and Default 0x28 (system design). Both read-only.");
+                sb.AppendLine();
+
+                sb.AppendLine("--- Adapter (Legacy 0x0F) ---");
+
+                // Deliberately dispatched off the task-list thread and awaited. This is the only
+                // collector that issues a hardware command rather than reading cached state, and
+                // SendBiosCommand appends to the same WMI command history that
+                // CollectWmiCommandHistoryAsync is capturing concurrently - running it inline made the
+                // export non-deterministically include its own query in the artifact describing the
+                // session, and perturbed the success-rate statistics reported alongside it.
+                var adapter = await Task.Run(() => bios.GetAdapter());
+                if (adapter is HpWmiBios.AdapterInfo info)
+                {
+                    sb.AppendLine($"Raw:                    {BitConverter.ToString(info.RawData)}");
+                    sb.AppendLine($"Status:                 {info.Status} ({(int)info.Status})");
+                    sb.AppendLine($"Connected rating:       {(info.PowerRatingKnown ? $"{info.PowerRatingWatts} W" : "unknown (0xFF sentinel)")}");
+                    sb.AppendLine($"USB-C design rating:    {info.UsbcDesignRatingWatts} W");
+                    sb.AppendLine($"Barrel jack supported:  {info.SupportsBarrelConnector}");
+                    sb.AppendLine($"Firmware gave a usable verdict: {info.HasVerdict}");
+                    sb.AppendLine($"Low wattage (HP logic): {(info.HasVerdict ? info.IsLowWattage.ToString() : "n/a - no verdict")}");
+
+                    if (info.IsLowWattage)
+                    {
+                        sb.AppendLine();
+                        sb.AppendLine("NOTE: the firmware considers this supply under-rated. Some HP firmware reduces");
+                        sb.AppendLine("      CPU and GPU power limits in this state. Rule this out before reading any");
+                        sb.AppendLine("      low-power-limit symptom in this export as an OmenCore or driver fault.");
+                    }
+                }
+                else
+                {
+                    sb.AppendLine("Not reported (board does not answer Legacy 0x0F, or WMI unavailable).");
+                }
+
+                sb.AppendLine();
+                sb.AppendLine("--- System design data (Default 0x28) ---");
+                if (bios.SystemDesign is HpWmiBios.SystemDesignData design)
+                {
+                    sb.AppendLine($"Raw (first 12 bytes):        {BitConverter.ToString(design.RawData)}");
+                    sb.AppendLine($"Shipping adapter rating:     {design.ShippingAdapterPowerRatingWatts} W");
+                    sb.AppendLine($"Thermal policy (firmware):   V{(int)design.ThermalPolicyVersion}");
+                    sb.AppendLine($"Thermal policy (in use):     V{(int)bios.ThermalPolicy}");
+                    if (design.ThermalPolicyVersion != bios.ThermalPolicy)
+                    {
+                        sb.AppendLine("  ^ These disagree: the firmware reported one version and OmenCore is running");
+                        sb.AppendLine("    another. That override is a model-name substring match, not a per-board");
+                        sb.AppendLine("    decision - worth checking if fan behaviour on this machine looks wrong.");
+                    }
+                    sb.AppendLine($"SW fan control support:      {design.IsSwFanControlSupport}");
+                    sb.AppendLine($"Extreme mode support:        {design.IsExtremeModeSupport}");
+                    sb.AppendLine($"Extreme mode unlocked:       {design.IsExtremeModeUnlock}");
+                    sb.AppendLine($"DT BIOS control:             {design.IsDTBiosControl}");
+                    sb.AppendLine($"Two-byte PL4 support:        {design.IsTwoBytePL4Support}");
+                    sb.AppendLine($"PL4 default value:           {design.PL4DefaultValue}");
+                    sb.AppendLine($"BIOS-defined OC support:     {design.IsBiosDefinedOcSupport}");
+                    sb.AppendLine($"GPU mode switch:             0x{design.GpuModeSwitch:X2}");
+                    sb.AppendLine($"CPU power limit with GPU:    {design.DefaultCpuPowerLimitWithGpuWatts} W");
+                    sb.AppendLine($"Load line levels / default:  {design.LoadLineSupportLevels} / {design.DefaultLoadLine}");
+                    sb.AppendLine($"IR sensor on board:          {design.ChangeIrSensorToBoard}");
+                    sb.AppendLine($"PCH overheat support:        {design.IsPchOverheatSupport}");
+                    sb.AppendLine($"VR sensor support:           {design.IsVrSensorSupport}");
+                    sb.AppendLine($"Hotkey Fn+P / Fn+F1:         {design.IsHotkeySupportFnP} / {design.IsHotkeySupportFnF1}");
+                    sb.AppendLine("  ^ These are known to read false on boards that do have the keys.");
+                    sb.AppendLine("    Treat as firmware's declaration, not as a hardware inventory.");
+                }
+                else
+                {
+                    sb.AppendLine("Not available (0x28 query failed, or the reply was shorter than 12 bytes).");
+                }
+
+                File.WriteAllText(Path.Combine(exportPath, "power-adapter.txt"), sb.ToString());
+                _logging.Info("Collected power adapter snapshot");
+                await Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                _logging.Warn($"Failed to collect power adapter snapshot: {ex.Message}");
             }
         }
 

--- a/src/OmenCoreApp/Services/FanVerificationService.cs
+++ b/src/OmenCoreApp/Services/FanVerificationService.cs
@@ -353,13 +353,7 @@ namespace OmenCore.Services
 
                     if (result.VerificationPassed)
                     {
-                        var verificationBasis = result.VerificationEvidence switch
-                        {
-                            "Level" => $"level readback matched ({result.ActualLevelAfter}/{result.ExpectedLevel})",
-                            "RPM+Level" => $"RPM + level matched (~{result.ExpectedRpm}, {result.ActualLevelAfter}/{result.ExpectedLevel})",
-                            _ => $"RPM matched (expected ~{result.ExpectedRpm})"
-                        };
-                        _logging.Info($"✓ Fan {fanIndex} verified: {result.ActualRpmAfter} RPM, level {result.ActualLevelAfter} ({verificationBasis}, deviation {result.DeviationPercent:F1}%, score {result.VerificationScore}/100 {result.ScoreRating})");
+                        _logging.Info(DescribeVerificationPass(fanIndex, result));
                         break;
                     }
                     else if (attempt < VerificationRetries)
@@ -496,13 +490,7 @@ namespace OmenCore.Services
 
                     if (result.VerificationPassed)
                     {
-                        var verificationBasis = result.VerificationEvidence switch
-                        {
-                            "Level" => $"level readback matched ({result.ActualLevelAfter}/{result.ExpectedLevel})",
-                            "RPM+Level" => $"RPM + level matched (~{result.ExpectedRpm}, {result.ActualLevelAfter}/{result.ExpectedLevel})",
-                            _ => $"RPM matched (expected ~{result.ExpectedRpm})"
-                        };
-                        _logging.Info($"✓ Fan {fanIndex} verified: {result.ActualRpmAfter} RPM, level {result.ActualLevelAfter} ({verificationBasis}, deviation {result.DeviationPercent:F1}%, score {result.VerificationScore}/100 {result.ScoreRating})");
+                        _logging.Info(DescribeVerificationPass(fanIndex, result));
                         break;
                     }
                     else if (attempt < VerificationRetries)
@@ -690,6 +678,19 @@ namespace OmenCore.Services
                 return false;
             }
 
+            // A level readback is the firmware echoing back the value we just wrote. That is real
+            // evidence the command was accepted, but it is NOT evidence the fan moved, and on a
+            // board whose RPM tachometer is unavailable it is the ONLY thing that can ever be
+            // checked - so accepting it unconditionally makes this method incapable of failing.
+            // Requesting a non-zero speed and measuring a flat zero from a physical source is a
+            // contradiction at any percentage, so it is rejected here rather than at >40% only.
+            if (IsPhysicalRpmSource(result.RpmSource) &&
+                result.ActualRpmAfter <= 0 &&
+                result.RequestedPercent > 0)
+            {
+                return false;
+            }
+
             if (result.RequestedPercent <= 40)
             {
                 return true;
@@ -772,6 +773,33 @@ namespace OmenCore.Services
             if (rpmMatched) return "RPM";
             if (levelMatched) return "Level";
             return "None";
+        }
+
+        /// <summary>
+        /// Render a passing verification for the log, stating WHICH evidence carried it.
+        /// </summary>
+        /// <remarks>
+        /// A pass on level evidence alone is a weaker claim than a pass corroborated by a
+        /// tachometer, and the two used to be logged with identical wording - so a result with no
+        /// physical RPM reading at all was reported as "✓ verified" alongside its own
+        /// "score 5/100 Failed". The score is not restated here: it grades RPM accuracy and
+        /// stability, which is not what was measured when the evidence is level-only, so quoting it
+        /// on that path invited exactly the contradiction it produced.
+        /// </remarks>
+        private static string DescribeVerificationPass(int fanIndex, FanApplyResult result)
+        {
+            if (result.VerificationEvidence == "Level")
+            {
+                return $"✓ Fan {fanIndex} command accepted: level {result.ActualLevelAfter}/{result.ExpectedLevel} " +
+                       $"read back from firmware. Fan motion NOT confirmed - {result.RpmDisplay}.";
+            }
+
+            var basis = result.VerificationEvidence == "RPM+Level"
+                ? $"RPM + level matched (~{result.ExpectedRpm}, {result.ActualLevelAfter}/{result.ExpectedLevel})"
+                : $"RPM matched (expected ~{result.ExpectedRpm})";
+
+            return $"✓ Fan {fanIndex} verified: {result.ActualRpmAfter} RPM, level {result.ActualLevelAfter} " +
+                   $"({basis}, deviation {result.DeviationPercent:F1}%, score {result.VerificationScore}/100 {result.ScoreRating})";
         }
 
         private bool VerifyAppliedState(FanApplyResult result)

--- a/src/OmenCoreApp/Services/GpuSwitchService.cs
+++ b/src/OmenCoreApp/Services/GpuSwitchService.cs
@@ -9,12 +9,19 @@ namespace OmenCore.Services
     public class GpuSwitchService
     {
         private readonly LoggingService _logging;
+        private readonly Hardware.HpWmiBios? _wmiBios;
         private bool _gpuModeSupported = false;
         private string _unsupportedReason = "";
 
-        public GpuSwitchService(LoggingService logging)
+        /// <summary>
+        /// <paramref name="wmiBios"/> is optional so the existing call sites - and the tests - keep
+        /// working without it. When supplied, <see cref="DetectCurrentMode"/> asks the firmware
+        /// instead of inferring the mode from which adapter happens to be painting a display.
+        /// </summary>
+        public GpuSwitchService(LoggingService logging, Hardware.HpWmiBios? wmiBios = null)
         {
             _logging = logging;
+            _wmiBios = wmiBios;
             CheckGpuModeSwitchingSupport();
         }
         
@@ -122,12 +129,32 @@ namespace OmenCore.Services
         public string UnsupportedReason => _unsupportedReason;
 
         /// <summary>
-        /// Detect current GPU mode through WMI and NVIDIA/AMD control panels
+        /// Detect the current GPU mode, preferring the firmware's own answer over inference.
+        ///
+        /// <para><b>Why the firmware comes first.</b> The adapter-activity methods below decide the
+        /// mode from which GPU is currently driving a display, and a healthy Optimus laptop spends
+        /// most of its time with the dGPU powered down by RTD3 - <c>Win32_VideoController</c> reports
+        /// it <c>Availability: 8</c> (Off Line) with no resolution, refresh rate or bit depth. That is
+        /// indistinguishable, to those methods, from a machine whose dGPU is switched off in firmware,
+        /// so Hybrid gets reported as Integrated whenever the dGPU happens to be asleep. Waking it to
+        /// find out would be worse than the wrong answer.</para>
+        ///
+        /// <para>Adapter activity stays as a fallback and as corroboration, because a zero reply from
+        /// <c>Legacy 0x52</c> is not unambiguous either: zero decodes to Hybrid and is also what an
+        /// ACPI timeout leaves in the buffer (see the remark on <c>HpWmiBios.SendBiosCommand</c>). So
+        /// a firmware Hybrid reading is cross-checked, and only a disagreement is logged - the
+        /// firmware still wins, since a sleeping dGPU is the far more likely explanation.</para>
         /// </summary>
         public GpuSwitchMode DetectCurrentMode()
         {
             try
             {
+                // Method 0: ask the firmware. Authoritative for Discrete/Optimus; cross-checked for
+                // Hybrid, which shares its encoding with an ACPI timeout.
+                var firmwareMode = DetectFirmwareGpuMode();
+                if (firmwareMode.HasValue)
+                    return firmwareMode.Value;
+
                 // Method 1: Check NVIDIA Optimus status via WMI
                 var nvidiaMode = DetectNvidiaOptimusMode();
                 if (nvidiaMode.HasValue)
@@ -160,6 +187,76 @@ namespace OmenCore.Services
             {
                 _logging.Error("Failed to detect GPU mode", ex);
                 return GpuSwitchMode.Hybrid;
+            }
+        }
+
+        /// <summary>
+        /// The firmware's own GPU mode via <c>Legacy 0x52</c>, or null when it cannot answer or
+        /// answers something this maps no meaning onto.
+        ///
+        /// Returning null on an unrecognised byte is deliberate rather than defensive. The firmware
+        /// enum covers Hybrid, Discrete and Optimus; a machine routed to iGPU-only (the BIOS calls it
+        /// UMA on board 8D87) is a state <c>GpuMode</c> does not declare, and no capture has pinned
+        /// what 0x52 reads there. Falling through to adapter inference is the honest answer for a byte
+        /// nobody has mapped - and inference is at its most reliable in exactly that case, because a
+        /// machine with no usable dGPU really does have only one adapter driving displays.
+        /// </summary>
+        /// <summary>
+        /// Map the firmware's <see cref="Hardware.HpWmiBios.GpuMode"/> onto the UI's
+        /// <see cref="GpuSwitchMode"/>, or null for a value this does not map.
+        ///
+        /// Static and public so the mapping is test-covered without a WMI round trip, following the
+        /// same pattern as <c>HpWmiBios.DecodeAdapterData</c> and <c>DecodeGpuMode</c>.
+        /// </summary>
+        public static GpuSwitchMode? MapFirmwareGpuMode(Hardware.HpWmiBios.GpuMode mode) => mode switch
+        {
+            Hardware.HpWmiBios.GpuMode.Discrete => GpuSwitchMode.Discrete,
+            // Optimus is a hybrid arrangement with dGPU-direct display routing available;
+            // GpuSwitchMode has no separate member, and Hybrid is what the UI means by it.
+            Hardware.HpWmiBios.GpuMode.Optimus => GpuSwitchMode.Hybrid,
+            Hardware.HpWmiBios.GpuMode.Hybrid => GpuSwitchMode.Hybrid,
+            _ => null
+        };
+
+        private GpuSwitchMode? DetectFirmwareGpuMode()
+        {
+            if (_wmiBios == null) return null;
+
+            try
+            {
+                var mode = _wmiBios.GetGpuMode();
+                if (mode == null) return null;
+
+                var mapped = MapFirmwareGpuMode(mode.Value);
+                if (mapped == null) return null;
+
+                // A Hybrid reading is the ambiguous one - 0x00 is also what an ACPI timeout leaves
+                // behind. Corroborate it, but do not overturn it: a dGPU asleep under RTD3 is the
+                // ordinary reason the adapter check would disagree here.
+                if (mode.Value == Hardware.HpWmiBios.GpuMode.Hybrid)
+                {
+                    var inferred = DetectNvidiaOptimusMode();
+                    if (inferred.HasValue && inferred.Value != GpuSwitchMode.Hybrid)
+                    {
+                        _logging.Info(
+                            $"GPU mode: firmware reports Hybrid, adapter activity suggests {inferred.Value} " +
+                            "- using the firmware's answer (a dGPU idled by RTD3 reads as inactive)");
+                    }
+                    else
+                    {
+                        _logging.Info("Detected GPU mode via firmware (Legacy 0x52): Hybrid");
+                    }
+
+                    return GpuSwitchMode.Hybrid;
+                }
+
+                _logging.Info($"Detected GPU mode via firmware (Legacy 0x52): {mode.Value}");
+                return mapped.Value;
+            }
+            catch (Exception ex)
+            {
+                _logging.Debug($"Firmware GPU mode query failed, falling back to adapter inference: {ex.Message}");
+                return null;
             }
         }
 

--- a/src/OmenCoreApp/Services/HardwareMonitoringService.cs
+++ b/src/OmenCoreApp/Services/HardwareMonitoringService.cs
@@ -964,6 +964,7 @@ namespace OmenCore.Services
         private void UpdateDashboardMetrics(MonitoringSample sample)
         {
             var now = DateTime.Now;
+            var batteryInfo = BatteryInfoProvider.Get(_logging);
             var metrics = new HardwareMetrics
             {
                 Timestamp = now,
@@ -973,11 +974,12 @@ namespace OmenCore.Services
                 BatteryChargePercentage = sample.BatteryChargePercent > 0
                     ? Math.Clamp(sample.BatteryChargePercent, 0, 100)
                     : -1,
-                // Battery health is not the same as current charge. Leave health unknown
-                // until a real full-charge/design-capacity source is available.
-                BatteryHealthPercentage = -1,
-                BatteryCycles = 0, // Win32_Battery does not expose cycle count; reserved for future use
-                EstimatedBatteryLifeYears = 3.0, // Static estimate; expandable via HP WMI in a future revision
+                // Battery health is not the same as current charge: it is full-charge capacity
+                // against design capacity. Both come from root\wmi via BatteryInfoProvider,
+                // which caches them - this runs on every monitoring tick. -1 means the pack
+                // did not report the capacities, and must stay distinguishable from a real 0.
+                BatteryHealthPercentage = batteryInfo.HealthPercent ?? -1,
+                BatteryCycles = batteryInfo.CycleCount ?? -1,
                 PowerEfficiency = CalculatePowerEfficiency(sample),
                 // Use average RPM from the two fan sensors as an efficiency proxy (0-100 scale)
                 FanEfficiency = sample.Fan1Rpm > 0 || sample.Fan2Rpm > 0

--- a/src/OmenCoreApp/Services/HardwareMonitoringService.cs
+++ b/src/OmenCoreApp/Services/HardwareMonitoringService.cs
@@ -982,6 +982,12 @@ namespace OmenCore.Services
                 // Use average RPM from the two fan sensors as an efficiency proxy (0-100 scale)
                 FanEfficiency = sample.Fan1Rpm > 0 || sample.Fan2Rpm > 0
                     ? Math.Min(100, ((sample.Fan1Rpm + sample.Fan2Rpm) / 2.0) / 50.0)
+                    : 0,
+                // The same mean, unscaled. The fan chart's axis is labelled "RPM", so it needs the
+                // RPM figure rather than the 0-100 proxy above; plotting the proxy there rendered
+                // ~2800 RPM as "28 RPM".
+                FanRpmAverage = sample.Fan1Rpm > 0 || sample.Fan2Rpm > 0
+                    ? (sample.Fan1Rpm + sample.Fan2Rpm) / 2.0
                     : 0
             };
 
@@ -1147,7 +1153,9 @@ namespace OmenCore.Services
                 ChartType.PowerConsumption => metrics.PowerConsumption,
                 ChartType.BatteryHealth => metrics.BatteryChargePercentage >= 0 ? metrics.BatteryChargePercentage : 0,
                 ChartType.Temperature => (metrics.CpuTemperature + metrics.GpuTemperature) / 2,
-                ChartType.FanSpeeds => metrics.FanEfficiency, // Real average fan efficiency derived from RPM sample data
+                // Must match GetLabelForChartType, which labels this series "RPM". FanEfficiency is
+                // a 0-100 proxy, so charting it under an RPM axis understated the reading by ~50x.
+                ChartType.FanSpeeds => metrics.FanRpmAverage,
                 _ => 0
             };
         }

--- a/src/OmenCoreApp/Services/IHardwareMonitoringService.cs
+++ b/src/OmenCoreApp/Services/IHardwareMonitoringService.cs
@@ -28,6 +28,16 @@ namespace OmenCore.Services
         public double GpuTemperature { get; set; }
         public double PowerEfficiency { get; set; }
         public double FanEfficiency { get; set; }
+
+        /// <summary>
+        /// Mean of the two fan tachometer readings, in RPM. Distinct from
+        /// <see cref="FanEfficiency"/>, which is that same mean rescaled to a 0-100 proxy: the fan
+        /// chart is labelled "RPM" and must plot this, not the proxy. Zero when no fan telemetry
+        /// source is reporting, which on some boards is the normal state rather than a stopped fan
+        /// - a true RPM tachometer is not available on every model.
+        /// </summary>
+        public double FanRpmAverage { get; set; }
+
         public DateTime Timestamp { get; set; }
     }
 

--- a/src/OmenCoreApp/Services/IHardwareMonitoringService.cs
+++ b/src/OmenCoreApp/Services/IHardwareMonitoringService.cs
@@ -21,9 +21,20 @@ namespace OmenCore.Services
         public double PowerConsumption { get; set; }
         public double PowerConsumptionTrend { get; set; }
         public double BatteryChargePercentage { get; set; }
+
+        /// <summary>
+        /// Full-charge capacity as a percentage of design capacity, or -1 when the pack does
+        /// not report both capacities. -1 rather than 0 because a worn-to-nothing battery and
+        /// an unreadable one are different states and the UI shows them differently.
+        /// </summary>
         public double BatteryHealthPercentage { get; set; }
+
+        /// <summary>
+        /// Charge/discharge cycles the pack has recorded, or -1 when it does not report them.
+        /// A new battery legitimately reads 0, so 0 cannot double as "unknown".
+        /// </summary>
         public int BatteryCycles { get; set; }
-        public double EstimatedBatteryLifeYears { get; set; }
+
         public double CpuTemperature { get; set; }
         public double GpuTemperature { get; set; }
         public double PowerEfficiency { get; set; }

--- a/src/OmenCoreApp/Services/KeyboardLighting/DojoPerKeyBackend.cs
+++ b/src/OmenCoreApp/Services/KeyboardLighting/DojoPerKeyBackend.cs
@@ -17,17 +17,20 @@ namespace OmenCore.Services.KeyboardLighting
     /// else entirely. Both are kept: they serve different hardware, and neither is a fallback for
     /// the other.
     ///
-    /// TWO INTERFACES, TWO JOBS, and using the wrong one is the main way to get lost here:
+    /// TWO INTERFACES, and routing colour to the right one is the main way to get lost here:
     ///
-    ///   mi_04, <see cref="HidLampArray"/>     STATIC colour, addressed per key. One report lands
-    ///                                         and persists with no host process running.
-    ///   mi_03, <see cref="DojoKeyboardMcu"/>  the device's own ANIMATION ENGINE. Twelve effects,
-    ///                                         one frame each, rendered without the host.
+    ///   mi_03, <see cref="DojoKeyboardMcu"/>  the MCU's own protocol. STATIC COLOUR MAP (commands
+    ///                                         0x05/0x06/0x07, 176-entry key map) and the twelve
+    ///                                         device ANIMATIONS (command 0x03). The MCU holds the
+    ///                                         map, draws it, and restores it after the Fn overlay.
+    ///   mi_04, <see cref="HidLampArray"/>     HID LampArray, per-key addressed by lamp id. Used
+    ///                                         for the per-key editor's individual key painting.
+    ///                                         Requires host ownership, which means the MCU stops
+    ///                                         drawing — and cannot restore after Fn.
     ///
-    /// So a static picture and a running effect are mutually exclusive states of the same keyboard,
-    /// and switching between them means handing ownership over: taking host control of the lamps
-    /// for a picture, giving it back for an effect. Painting lamps while an effect runs produces a
-    /// fight the device wins.
+    /// Uniform and zone colour go through mi_03, so the MCU owns the picture and the Fn key works.
+    /// Per-key painting (the editor) goes through mi_04 for individual addressing, with an mi_03
+    /// base layer as a fallback the MCU can restore to after Fn.
     ///
     /// Effects can be read back off the MCU and are checked here. Colours cannot - the LampArray
     /// spec has no colour readback - so "did that key turn red" has no software answer, and the
@@ -135,32 +138,36 @@ namespace OmenCore.Services.KeyboardLighting
 
             try
             {
-                if (_lamps == null)
-                {
-                    result.FailureReason = "No LampArray interface; static colour needs mi_04";
-                    return Task.FromResult(result);
-                }
-
                 var normalized = Normalize(zoneColors);
-                TakeHostControl();
-
-                // A uniform picture is one range report instead of fifteen chained multi-updates.
-                // Worth the special case for more than speed: the range report is the primitive
-                // this device is measured on, so when a uniform fill lands and a four-colour one
-                // does not, the difference is the batching rather than the colour path.
                 bool uniform = normalized.All(c => c.ToArgb() == normalized[0].ToArgb());
 
-                if (uniform && _lampMap.Count > 0)
+                if (uniform && _mcu != null)
                 {
+                    // MI_03: the MCU holds the colour map and redraws after the Fn overlay.
+                    // No host control needed — the device is autonomous and draws its own picture.
+                    ReleaseHostControlIfHeld();
+                    var c = normalized[0];
+                    result.BackendReportedSuccess = _mcu.SetStaticColor(c.R, c.G, c.B);
+                    _logging.Info($"[DojoPerKey] Uniform fill via mi_03: " +
+                                  $"{(result.BackendReportedSuccess ? "accepted" : "REFUSED")}");
+                }
+                else if (uniform && _lamps != null && _lampMap.Count > 0)
+                {
+                    TakeHostControl();
                     var c = normalized[0];
                     ushort first = _lampMap.Min(l => l.LampId);
                     ushort last = _lampMap.Max(l => l.LampId);
                     result.BackendReportedSuccess = _lamps.SetRange(first, last, c.R, c.G, c.B, _brightness);
-                    _logging.Info($"[DojoPerKey] Uniform fill over lamps {first}-{last}: " +
+                    _logging.Info($"[DojoPerKey] Uniform fill over lamps {first}-{last} (mi_04 fallback): " +
                                   $"{(result.BackendReportedSuccess ? "accepted" : "REFUSED")}");
                 }
-                else
+                else if (_lamps != null && _lampMap.Count > 0)
                 {
+                    // Mixed zones: set mi_03 base with zone 0's colour as Fn fallback, then
+                    // mi_04 for the actual per-zone picture.
+                    _mcu?.SetStaticColor(normalized[0].R, normalized[0].G, normalized[0].B);
+                    TakeHostControl();
+
                     var lamps = new List<HidLampArray.LampColor>(_lampMap.Count);
                     for (int i = 0; i < _lampMap.Count; i++)
                     {
@@ -173,11 +180,16 @@ namespace OmenCore.Services.KeyboardLighting
                                   $"{(lamps.Count + HidLampArray.MaxLampsPerUpdate - 1) / HidLampArray.MaxLampsPerUpdate} " +
                                   $"batches: {(result.BackendReportedSuccess ? "accepted" : "REFUSED")}");
                 }
+                else
+                {
+                    result.FailureReason = "No interface available for static colour";
+                    return Task.FromResult(result);
+                }
 
                 if (result.BackendReportedSuccess)
                     _lastZoneColors = normalized;
                 else
-                    result.FailureReason = "The device refused one or more lamp update reports";
+                    result.FailureReason = "The device refused one or more colour writes";
             }
             catch (Exception ex)
             {
@@ -360,11 +372,21 @@ namespace OmenCore.Services.KeyboardLighting
         /// Colour individual keys, addressed by lamp id. Ids come from <see cref="GetKeyMap"/>;
         /// each carries the HID usage of the key it sits under.
         ///
+        /// Uses mi_04 for individual addressing, but first writes an mi_03 base layer so the MCU
+        /// has something to restore after the Fn overlay. The mi_03 base is a uniform fill with
+        /// the most common colour — not a perfect match, but not a black keyboard.
+        ///
         /// Accepted, not verified - there is no colour readback to check it against.
         /// </summary>
         public bool SetKeyColors(IReadOnlyDictionary<ushort, Color> keyColors)
         {
             if (_lamps == null || keyColors.Count == 0) return false;
+
+            if (_mcu != null && keyColors.Count > 0)
+            {
+                var dominant = MostCommonColor(keyColors.Values);
+                _mcu.SetStaticColor(dominant.R, dominant.G, dominant.B);
+            }
 
             TakeHostControl();
 
@@ -376,6 +398,14 @@ namespace OmenCore.Services.KeyboardLighting
             _logging.Info($"[DojoPerKey] {lamps.Count} lamps at intensity {_brightness}: " +
                           $"{(ok ? "accepted" : "REFUSED")}");
             return ok;
+        }
+
+        private static Color MostCommonColor(IEnumerable<Color> colors)
+        {
+            return colors
+                .GroupBy(c => c.ToArgb())
+                .OrderByDescending(g => g.Count())
+                .First().First();
         }
 
         /// <summary>
@@ -637,6 +667,14 @@ namespace OmenCore.Services.KeyboardLighting
             _hostOwnsLamps = true;
         }
 
+        private void ReleaseHostControlIfHeld()
+        {
+            if (!_hostOwnsLamps || _lamps == null) return;
+
+            _lamps.SetAutonomousMode(true);
+            _hostOwnsLamps = false;
+        }
+
         private RgbApplyResult NewResult() => new() { Method = Method, SupportsVerification = false };
 
         private static Color[] Normalize(Color[] zoneColors)
@@ -652,15 +690,17 @@ namespace OmenCore.Services.KeyboardLighting
             if (_disposed) return;
             _disposed = true;
 
-            // DO NOT hand the lamps back here. A static picture's whole value is that it survives
-            // the process that painted it - one report lands and holds with nothing maintaining it.
-            // Restoring autonomous mode on the way out gives the keyboard back to its own effect
-            // engine, which repaints all 120 keys within a frame and erases the picture before
-            // anyone can look at it. Measured: --zones over a running Wave appeared to do nothing
-            // at all, because this line ran microseconds after the colours landed.
+            // Hand the lamps back so the MCU can draw its own lighting. Without this, the keyboard
+            // stays in host-control mode permanently — it outlives the process, survives a reboot
+            // (the internal USB bus stays powered), and the MCU cannot restore its picture after the
+            // Fn overlay or any other device-side redraw. That is the root cause of the reported
+            // Fn-key bug: the overlay goes up, and nothing comes back.
             //
-            // Callers that really do want the device animating again say so with
-            // ReleaseToDeviceEffects, or install an effect, which hands ownership over on purpose.
+            // With static colour routed through mi_03, the MCU holds the picture and draws it
+            // autonomously, so releasing here does not erase anything — it lets the MCU resume
+            // drawing what it already has.
+            ReleaseHostControlIfHeld();
+
             _lamps?.Dispose();
             _mcu?.Dispose();
             _lamps = null;

--- a/src/OmenCoreApp/Services/KeyboardLighting/DojoPerKeyBackend.cs
+++ b/src/OmenCoreApp/Services/KeyboardLighting/DojoPerKeyBackend.cs
@@ -1,0 +1,670 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Linq;
+using System.Threading.Tasks;
+using OmenCore.Hardware;
+
+namespace OmenCore.Services.KeyboardLighting
+{
+    /// <summary>
+    /// Per-key RGB for OMEN MAX keyboards, over the two interfaces the keyboard actually exposes.
+    ///
+    /// This backend exists because <see cref="HidPerKeyBackend"/>'s protocol is not this keyboard's.
+    /// That one speaks the 0x0F / 0x42 / 0x52 command set from the 0x03F0 OMEN family, inferred
+    /// from OpenRGB; measured on board 8D87, the keyboard is Darfon 0D62:54BF and speaks something
+    /// else entirely. Both are kept: they serve different hardware, and neither is a fallback for
+    /// the other.
+    ///
+    /// TWO INTERFACES, TWO JOBS, and using the wrong one is the main way to get lost here:
+    ///
+    ///   mi_04, <see cref="HidLampArray"/>     STATIC colour, addressed per key. One report lands
+    ///                                         and persists with no host process running.
+    ///   mi_03, <see cref="DojoKeyboardMcu"/>  the device's own ANIMATION ENGINE. Twelve effects,
+    ///                                         one frame each, rendered without the host.
+    ///
+    /// So a static picture and a running effect are mutually exclusive states of the same keyboard,
+    /// and switching between them means handing ownership over: taking host control of the lamps
+    /// for a picture, giving it back for an effect. Painting lamps while an effect runs produces a
+    /// fight the device wins.
+    ///
+    /// Effects can be read back off the MCU and are checked here. Colours cannot - the LampArray
+    /// spec has no colour readback - so "did that key turn red" has no software answer, and the
+    /// colour methods report only that the device ACCEPTED the report.
+    ///
+    /// Board scope: measured on 8D87 (OMEN MAX 16-ak0xxx, BIOS F.07, EC 40.38). Protocol map and
+    /// evidence: omen-max-16/reference/keyboard-mcu.md.
+    /// </summary>
+    public sealed class DojoPerKeyBackend : IKeyboardBackend
+    {
+        private readonly LoggingService _logging;
+
+        private DojoKeyboardMcu? _mcu;
+        private HidLampArray? _lamps;
+        private IReadOnlyList<HidLampArray.LampInfo> _lampMap = Array.Empty<HidLampArray.LampInfo>();
+        private ushort[] _lampZone = Array.Empty<ushort>();
+
+        private Color[] _lastZoneColors = Enumerable.Repeat(Color.Black, ZoneCountConst).ToArray();
+        private byte _brightness = 255;
+        private bool _hostOwnsLamps;
+        private bool _disposed;
+
+        private const int ZoneCountConst = 4;
+
+        public DojoPerKeyBackend(LoggingService logging) => _logging = logging;
+
+        // ── IKeyboardBackend ───────────────────────────────────────────────────────
+
+        public string Name => "OMEN MAX per-key (LampArray + MCU)";
+        public KeyboardMethod Method => KeyboardMethod.HidPerKey;
+        public bool IsAvailable => _lamps != null || _mcu != null;
+
+        /// <summary>False, and it means COLOUR readback specifically. Effects are verified in
+        /// <see cref="SetEffectAsync"/>; colours have no readback on either interface.</summary>
+        public bool SupportsReadback => false;
+
+        public int ZoneCount => ZoneCountConst;
+        public bool IsPerKey => true;
+
+        /// <summary>Number of individually addressable keys, or 0 if the lamp interface is absent.</summary>
+        public int KeyCount => _lampMap.Count;
+
+        /// <summary>Whether the device's animation engine is reachable.</summary>
+        public bool SupportsDeviceEffects => _mcu != null;
+
+        /// <summary>
+        /// Whether this exact keyboard's protocol support was confirmed on hardware.
+        ///
+        /// False means the device is in HP's table for this code path but nobody here has driven it -
+        /// so the code will be sent to it and may well work, but "may well" is the claim. A caller
+        /// showing this to a user should say so; silently treating inference as measurement is how
+        /// the guessed PID 0x054F ended up in the model database in the first place.
+        /// </summary>
+        public bool IsVerifiedDevice => _mcu?.IsVerifiedDevice ?? false;
+
+        /// <summary>USB identity of the keyboard MCU, for display and field reports.</summary>
+        public string DeviceIdentity => _mcu == null
+            ? "no MCU"
+            : $"{_mcu.VendorId:X4}:{_mcu.ProductId:X4}";
+
+        public Task<bool> InitializeAsync()
+        {
+            try
+            {
+                _mcu = DojoKeyboardMcu.Open();
+                if (_mcu != null)
+                {
+                    _logging.Info($"[DojoPerKey] MCU on mi_03: {_mcu.VendorId:X4}:{_mcu.ProductId:X4} " +
+                                  $"'{_mcu.ProductName}' - device effects available");
+                }
+                else
+                {
+                    // The interesting failure is a matching keyboard whose mi_03 is missing or
+                    // held open, which a bare "not found" cannot express.
+                    var candidates = DojoKeyboardMcu.DescribeCandidates();
+                    if (candidates.Count == 0)
+                        _logging.Info("[DojoPerKey] No Darfon keyboard MCU present; device effects unavailable");
+                    else
+                        foreach (string line in candidates)
+                            _logging.Info($"[DojoPerKey]   candidate: {line}");
+                }
+
+                OpenLampArray();
+
+                if (!IsAvailable)
+                {
+                    _logging.Info("[DojoPerKey] Neither interface available; this is not an OMEN MAX per-key keyboard");
+                    return Task.FromResult(false);
+                }
+
+                return Task.FromResult(true);
+            }
+            catch (Exception ex)
+            {
+                _logging.Error($"[DojoPerKey] Initialization failed: {ex.Message}", ex);
+                Dispose();
+                return Task.FromResult(false);
+            }
+        }
+
+        public Task<RgbApplyResult> SetZoneColorsAsync(Color[] zoneColors)
+        {
+            var result = NewResult();
+            var sw = Stopwatch.StartNew();
+
+            try
+            {
+                if (_lamps == null)
+                {
+                    result.FailureReason = "No LampArray interface; static colour needs mi_04";
+                    return Task.FromResult(result);
+                }
+
+                var normalized = Normalize(zoneColors);
+                TakeHostControl();
+
+                // A uniform picture is one range report instead of fifteen chained multi-updates.
+                // Worth the special case for more than speed: the range report is the primitive
+                // this device is measured on, so when a uniform fill lands and a four-colour one
+                // does not, the difference is the batching rather than the colour path.
+                bool uniform = normalized.All(c => c.ToArgb() == normalized[0].ToArgb());
+
+                if (uniform && _lampMap.Count > 0)
+                {
+                    var c = normalized[0];
+                    ushort first = _lampMap.Min(l => l.LampId);
+                    ushort last = _lampMap.Max(l => l.LampId);
+                    result.BackendReportedSuccess = _lamps.SetRange(first, last, c.R, c.G, c.B, _brightness);
+                    _logging.Info($"[DojoPerKey] Uniform fill over lamps {first}-{last}: " +
+                                  $"{(result.BackendReportedSuccess ? "accepted" : "REFUSED")}");
+                }
+                else
+                {
+                    var lamps = new List<HidLampArray.LampColor>(_lampMap.Count);
+                    for (int i = 0; i < _lampMap.Count; i++)
+                    {
+                        var c = normalized[_lampZone[i]];
+                        lamps.Add(new HidLampArray.LampColor(_lampMap[i].LampId, c.R, c.G, c.B, _brightness));
+                    }
+
+                    result.BackendReportedSuccess = _lamps.SetLamps(lamps);
+                    _logging.Info($"[DojoPerKey] {lamps.Count} lamps in " +
+                                  $"{(lamps.Count + HidLampArray.MaxLampsPerUpdate - 1) / HidLampArray.MaxLampsPerUpdate} " +
+                                  $"batches: {(result.BackendReportedSuccess ? "accepted" : "REFUSED")}");
+                }
+
+                if (result.BackendReportedSuccess)
+                    _lastZoneColors = normalized;
+                else
+                    result.FailureReason = "The device refused one or more lamp update reports";
+            }
+            catch (Exception ex)
+            {
+                result.FailureReason = ex.Message;
+                _logging.Error($"[DojoPerKey] SetZoneColorsAsync failed: {ex.Message}", ex);
+            }
+            finally
+            {
+                sw.Stop();
+                result.DurationMs = (int)sw.ElapsedMilliseconds;
+            }
+
+            return Task.FromResult(result);
+        }
+
+        public Task<RgbApplyResult> SetZoneColorAsync(int zone, Color color)
+        {
+            if (zone < 0 || zone >= ZoneCountConst)
+            {
+                var bad = NewResult();
+                bad.FailureReason = $"Invalid zone {zone}, must be 0-{ZoneCountConst - 1}";
+                return Task.FromResult(bad);
+            }
+
+            // Neither interface reads colour back, so the other zones come from what was last
+            // requested. Reconstructing them from the device is not an option here.
+            var colors = _lastZoneColors.ToArray();
+            colors[zone] = color;
+            return SetZoneColorsAsync(colors);
+        }
+
+        /// <summary>Null - see <see cref="SupportsReadback"/>. Neither interface reads colour back.</summary>
+        public Task<Color[]?> ReadZoneColorsAsync() => Task.FromResult<Color[]?>(null);
+
+        /// <summary>
+        /// Set brightness, which on this keyboard means the LampArray intensity channel and only that.
+        ///
+        /// MCU command 0x0C IS STILL SENT, and is expected to fail: measured on 8D87 it is refused at
+        /// every payload value while every other command in this class is acknowledged through the
+        /// same path. It costs one frame and would be the right lever on a board that implements it.
+        ///
+        /// The gap that leaves is real. Intensity scales a HOST-PAINTED picture, and a device-rendered
+        /// effect is drawn by the MCU with no host involvement - so nothing here dims a running
+        /// effect, and a UI implying otherwise would be lying.
+        /// </summary>
+        public async Task<bool> SetBrightnessAsync(int brightness)
+        {
+            int clamped = Math.Clamp(brightness, 0, 100);
+            _brightness = (byte)(clamped * 255 / 100);
+
+            bool mcuTook = _mcu?.SetBrightness((byte)clamped) ?? false;
+            bool lampsTook = false;
+
+            // Repaint ONLY when the host is already displaying a picture. Repainting
+            // unconditionally would take the lamps away from a running device effect and freeze it
+            // into a static frame - so asking to dim an animation would silently stop it, which is
+            // not what anyone means by a brightness change.
+            if (_hostOwnsLamps && _lamps != null && _lampMap.Count > 0)
+            {
+                var repaint = await SetZoneColorsAsync(_lastZoneColors);
+                lampsTook = repaint.BackendReportedSuccess;
+            }
+
+            if (mcuTook)
+                _logging.Info($"[DojoPerKey] MCU accepted brightness {clamped} via 0x0C - unexpected on 8D87, worth reporting");
+            else if (!lampsTook)
+                _logging.Info("[DojoPerKey] Brightness had nowhere to land: the MCU refused 0x0C and no " +
+                              "host-painted picture was displayed to re-scale. A running device effect " +
+                              "cannot be dimmed on this hardware.");
+
+            return mcuTook || lampsTook;
+        }
+
+        public Task<bool> SetBacklightEnabledAsync(bool enabled)
+        {
+            // The MCU's own blank is the right lever: it leaves the installed effect in place, so
+            // turning the backlight back on restores what was there rather than a black keyboard.
+            if (_mcu != null) return Task.FromResult(_mcu.SetLightingEnabled(enabled));
+
+            if (_lamps == null) return Task.FromResult(false);
+
+            if (!enabled)
+            {
+                TakeHostControl();
+                return Task.FromResult(_lamps.SetAll(0, 0, 0));
+            }
+
+            return SetZoneColorsAsync(_lastZoneColors)
+                .ContinueWith(t => t.Result.BackendReportedSuccess);
+        }
+
+        /// <summary>
+        /// Apply an effect, choosing the interface the effect belongs to.
+        ///
+        /// Static goes to the lamps as a picture. Everything else is a device-side animation, which
+        /// means handing the lamps back first - an effect and a host-painted picture cannot both
+        /// own the keyboard.
+        /// </summary>
+        public Task<RgbApplyResult> SetEffectAsync(
+            KeyboardEffect effect, Color primaryColor, Color secondaryColor, int speed)
+        {
+            if (effect == KeyboardEffect.Off)
+                return SetBacklightEnabledAsync(false)
+                    .ContinueWith(t =>
+                    {
+                        var r = NewResult();
+                        r.BackendReportedSuccess = t.Result;
+                        if (!t.Result) r.FailureReason = "The device refused the blank command";
+                        return r;
+                    });
+
+            if (effect == KeyboardEffect.Static)
+            {
+                var colors = Enumerable.Repeat(primaryColor, ZoneCountConst).ToArray();
+                return SetZoneColorsAsync(colors);
+            }
+
+            var result = NewResult();
+
+            if (_mcu == null)
+            {
+                result.FailureReason = $"Effect '{effect}' needs the MCU on mi_03, which is not open";
+                return Task.FromResult(result);
+            }
+
+            if (!TryMapEffect(effect, out DojoKeyboardMcu.Effect wire))
+            {
+                // Reactive has no counterpart among the twelve: they all render without host
+                // input, and a keypress-driven effect is not one of them.
+                result.FailureReason = $"Effect '{effect}' has no equivalent in this MCU's effect set";
+                return Task.FromResult(result);
+            }
+
+            var record = BuildRecord(wire, primaryColor, secondaryColor, speed);
+            return Task.FromResult(ApplyRecord(record, result));
+        }
+
+        // ── Beyond the interface ───────────────────────────────────────────────────
+
+        /// <summary>
+        /// Drive one of the device's twelve effects directly, with the fields that effect actually
+        /// consumes. The <see cref="IKeyboardBackend"/> vocabulary reaches four of them; this is
+        /// how a caller reaches Ghosting, Ripple, Raindrop, OMEN X, Confetti, Sun, Swipe and
+        /// Starlight, and how it picks a preset palette rather than a colour.
+        /// </summary>
+        public RgbApplyResult SetDeviceEffect(DojoKeyboardMcu.EffectRecord record)
+        {
+            var result = NewResult();
+
+            if (_mcu == null)
+            {
+                result.FailureReason = "The MCU on mi_03 is not open";
+                return result;
+            }
+
+            return ApplyRecord(record, result);
+        }
+
+        /// <summary>The effect the MCU is currently holding, or null if it will not answer.</summary>
+        public DojoKeyboardMcu.EffectRecord? ReadDeviceEffect() => _mcu?.TryReadEffect();
+
+        /// <summary>
+        /// Send MCU brightness (command 0x0C) and NOTHING ELSE.
+        ///
+        /// Separate from <see cref="SetBrightnessAsync"/> because that one also repaints the lamps
+        /// with a new intensity, and when a static picture is displayed the repaint alone accounts
+        /// for any visible change - so it cannot tell you whether 0x0C did anything. Isolating the
+        /// command is the only way to attribute the result to it, and this exists to make that
+        /// test possible rather than for callers to prefer.
+        /// </summary>
+        public bool SetMcuBrightnessOnly(byte level) => _mcu?.SetBrightness(level) ?? false;
+
+        /// <summary>
+        /// Set the intensity attached to each lamp in subsequent colour writes. Does not repaint.
+        /// </summary>
+        public void SetLampIntensity(int brightness) =>
+            _brightness = (byte)(Math.Clamp(brightness, 0, 100) * 255 / 100);
+
+        /// <summary>
+        /// Colour individual keys, addressed by lamp id. Ids come from <see cref="GetKeyMap"/>;
+        /// each carries the HID usage of the key it sits under.
+        ///
+        /// Accepted, not verified - there is no colour readback to check it against.
+        /// </summary>
+        public bool SetKeyColors(IReadOnlyDictionary<ushort, Color> keyColors)
+        {
+            if (_lamps == null || keyColors.Count == 0) return false;
+
+            TakeHostControl();
+
+            var lamps = keyColors
+                .Select(kv => new HidLampArray.LampColor(kv.Key, kv.Value.R, kv.Value.G, kv.Value.B, _brightness))
+                .ToList();
+
+            bool ok = _lamps.SetLamps(lamps);
+            _logging.Info($"[DojoPerKey] {lamps.Count} lamps at intensity {_brightness}: " +
+                          $"{(ok ? "accepted" : "REFUSED")}");
+            return ok;
+        }
+
+        /// <summary>
+        /// Every addressable lamp: its id, where it sits, and which key usage it lights.
+        ///
+        /// The ids come from what the DEVICE reported, not from what was asked for. On 8D87 the
+        /// lamp-attributes response ignores the requested id and free-runs - ask for 0, 1, 2 and
+        /// get back 41, 42, 43 - so a caller that assumed "ask for N, get N" would light the wrong
+        /// keys and have no way to notice.
+        /// </summary>
+        public IReadOnlyList<HidLampArray.LampInfo> GetKeyMap() => _lampMap;
+
+        /// <summary>
+        /// Persist the installed effect so it survives a power cycle.
+        ///
+        /// A REAL FLASH WRITE. Call it when a user saves a profile; never on every apply, and never
+        /// in a loop.
+        /// </summary>
+        public bool StoreToFlash() => _mcu?.StoreToFlash() ?? false;
+
+        /// <summary>Put the lighting back to HP's firmware defaults. The recovery lever.</summary>
+        public bool RestoreFirmwareDefaults() => _mcu?.RestoreFirmwareDefaults() ?? false;
+
+        /// <summary>
+        /// Give the lamps back to the device's own effect engine, which resumes whatever effect is
+        /// installed and repaints over any host-painted picture.
+        ///
+        /// Explicit because it is destructive to a static picture and there is no undo - the
+        /// picture is not stored anywhere the device can restore it from.
+        /// </summary>
+        public bool ReleaseToDeviceEffects()
+        {
+            if (_lamps == null) return false;
+
+            bool ok = _lamps.SetAutonomousMode(true);
+            _hostOwnsLamps = false;
+            return ok;
+        }
+
+        // ── Internals ──────────────────────────────────────────────────────────────
+
+        private RgbApplyResult ApplyRecord(DojoKeyboardMcu.EffectRecord record, RgbApplyResult result)
+        {
+            var sw = Stopwatch.StartNew();
+
+            try
+            {
+                // The device is about to animate, so it needs its lamps back. Skipped when the
+                // host never took them - handing back something never taken is a no-op the device
+                // would still have to parse.
+                if (_hostOwnsLamps && _lamps != null)
+                {
+                    _lamps.SetAutonomousMode(true);
+                    _hostOwnsLamps = false;
+                }
+
+                result.BackendReportedSuccess = _mcu!.SetEffect(record);
+                if (!result.BackendReportedSuccess)
+                {
+                    result.FailureReason = $"The MCU refused effect {record.Effect}";
+                    return result;
+                }
+
+                // The one place on this keyboard where a write can be checked. It confirms the
+                // MCU installed the effect, not that anything is visible - two effects render
+                // black by design, so a person still has the final say.
+                var readback = _mcu.TryReadEffect();
+                result.SupportsVerification = readback != null;
+                result.VerificationPassed = readback?.Effect == record.Effect;
+
+                if (readback == null)
+                    _logging.Info($"[DojoPerKey] {record.Effect} accepted; the MCU did not answer the readback");
+                else if (!result.VerificationPassed)
+                    _logging.Warn($"[DojoPerKey] {record.Effect} accepted but the MCU reports {readback.Value.Effect}");
+                else
+                    _logging.Info($"[DojoPerKey] {record.Effect} installed and confirmed by readback");
+
+                WarnIfEffectWillRenderBlack(record);
+            }
+            catch (Exception ex)
+            {
+                result.BackendReportedSuccess = false;
+                result.FailureReason = ex.Message;
+                _logging.Error($"[DojoPerKey] Effect write failed: {ex.Message}", ex);
+            }
+            finally
+            {
+                sw.Stop();
+                result.DurationMs = (int)sw.ElapsedMilliseconds;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Two effects render black for reasons that are in the field map rather than in a fault,
+        /// and both look exactly like a broken backend from the user's chair. Say so in the log
+        /// before someone spends an evening on it.
+        /// </summary>
+        private void WarnIfEffectWillRenderBlack(DojoKeyboardMcu.EffectRecord record)
+        {
+            if (record.Effect == DojoKeyboardMcu.Effect.Swipe &&
+                record.ColorNumber == DojoKeyboardMcu.ColorNumberPreset)
+            {
+                _logging.Warn("[DojoPerKey] Swipe has no preset palette and will render BLACK with a preset " +
+                              "selected. Give it custom colours.");
+            }
+
+            if (record.Effect == DojoKeyboardMcu.Effect.AudioPulse &&
+                record.InnerBrightness == 0 && record.OuterBrightness == 0)
+            {
+                _logging.Warn("[DojoPerKey] Audio Pulse IS its two level bytes; at 0 it renders BLACK. " +
+                              "Feed InnerBrightness/OuterBrightness from an audio thread at ~5 Hz.");
+            }
+        }
+
+        private static DojoKeyboardMcu.EffectRecord BuildRecord(
+            DojoKeyboardMcu.Effect wire, Color primary, Color secondary, int speed)
+        {
+            // A secondary that is black or identical to the primary is how the shared profile model
+            // spells "one colour", so it is read that way rather than sent as a second slot.
+            bool twoColors = secondary.ToArgb() != primary.ToArgb() &&
+                             !(secondary.R == 0 && secondary.G == 0 && secondary.B == 0);
+
+            var colors = twoColors
+                ? new[] { (primary.R, primary.G, primary.B), (secondary.R, secondary.G, secondary.B) }
+                : new[] { (primary.R, primary.G, primary.B) };
+
+            return new DojoKeyboardMcu.EffectRecord
+            {
+                Effect = wire,
+                ShowMode = twoColors
+                    ? DojoKeyboardMcu.ShowMode.MultipleCustomColors
+                    : DojoKeyboardMcu.ShowMode.SingleCustomColor,
+
+                // Zero-based count, not a count. Two colours send 1.
+                ColorNumber = (byte)(colors.Length - 1),
+
+                Speed = MapSpeed(speed),
+
+                // OGH never sets this in an effect frame and uses command 0x0C instead; sending a
+                // value here is an unexercised path, so it stays at what OGH sends.
+                Brightness = 0,
+
+                Direction = DojoKeyboardMcu.EffectDirection.LeftToRight,
+                RippleSize = 1,
+                RaindropFrequency = (byte)MapSpeed(speed),
+                Colors = colors
+            };
+        }
+
+        private static DojoKeyboardMcu.EffectSpeed MapSpeed(int speed) => speed switch
+        {
+            < 34 => DojoKeyboardMcu.EffectSpeed.Slow,
+            < 67 => DojoKeyboardMcu.EffectSpeed.Medium,
+            _ => DojoKeyboardMcu.EffectSpeed.Fast
+        };
+
+        private static bool TryMapEffect(KeyboardEffect effect, out DojoKeyboardMcu.Effect wire)
+        {
+            switch (effect)
+            {
+                case KeyboardEffect.Breathing: wire = DojoKeyboardMcu.Effect.Breathing; return true;
+                case KeyboardEffect.ColorCycle: wire = DojoKeyboardMcu.Effect.ColorCycle; return true;
+                case KeyboardEffect.Wave: wire = DojoKeyboardMcu.Effect.Wave; return true;
+                default: wire = default; return false;
+            }
+        }
+
+        private void OpenLampArray()
+        {
+            var arrays = HidLampArray.OpenAll();
+
+            // Kind 1 is Keyboard. The lamp-count floor rejects the virtual four-zone array that
+            // appears on the same machine, which is the light bar wearing a LampArray costume.
+            var keyboard = arrays.FirstOrDefault(a => a.Kind == 1 && a.LampCount > 8);
+
+            foreach (var other in arrays.Where(a => !ReferenceEquals(a, keyboard)))
+                other.Dispose();
+
+            if (keyboard == null)
+            {
+                _logging.Info("[DojoPerKey] No keyboard-kind LampArray; static per-key colour unavailable");
+                return;
+            }
+
+            _lamps = keyboard;
+            BuildLampMap(keyboard);
+
+            _logging.Info($"[DojoPerKey] LampArray on mi_04: {keyboard.LampCount} lamps, " +
+                          $"{_lampMap.Count} mapped, min update {keyboard.MinUpdateInterval.TotalMilliseconds:F0} ms");
+        }
+
+        /// <summary>
+        /// Walk the lamps and key the map on the id the DEVICE reports.
+        ///
+        /// The extra pass is not defensive padding: on 8D87 the attributes response ignores the
+        /// requested id and free-runs, so a single pass of LampCount requests returns a rotated
+        /// set and misses some ids entirely. Walking twice and keying on what came back converges.
+        /// </summary>
+        private void BuildLampMap(HidLampArray keyboard)
+        {
+            var byId = new SortedDictionary<ushort, HidLampArray.LampInfo>();
+
+            for (int i = 0; i < keyboard.LampCount * 2 && byId.Count < keyboard.LampCount; i++)
+            {
+                var info = keyboard.GetLampInfo((ushort)(i % keyboard.LampCount));
+                if (info != null) byId[info.Value.LampId] = info.Value;
+            }
+
+            if (byId.Count < keyboard.LampCount)
+            {
+                _logging.Warn($"[DojoPerKey] Lamp map incomplete: {byId.Count} of {keyboard.LampCount} lamps " +
+                              "answered. Unmapped lamps will not be coloured.");
+            }
+
+            _lampMap = byId.Values.ToList();
+            _lampZone = AssignZones(_lampMap);
+        }
+
+        /// <summary>
+        /// Zone each lamp by where it physically sits, left to right.
+        ///
+        /// Splitting the lamp INDEX into quarters instead would be simpler and wrong: lamp order is
+        /// the device's wiring order, not a left-to-right sweep, so index quarters produce four
+        /// scattered patches rather than four bands. The lamps carry their own coordinates for
+        /// exactly this reason.
+        /// </summary>
+        private static ushort[] AssignZones(IReadOnlyList<HidLampArray.LampInfo> lamps)
+        {
+            var zones = new ushort[lamps.Count];
+            if (lamps.Count == 0) return zones;
+
+            uint minX = lamps.Min(l => l.XMicrometres);
+            uint maxX = lamps.Max(l => l.XMicrometres);
+            double span = Math.Max(1, (double)maxX - minX);
+
+            for (int i = 0; i < lamps.Count; i++)
+            {
+                double fraction = (lamps[i].XMicrometres - minX) / span;
+                zones[i] = (ushort)Math.Clamp((int)(fraction * ZoneCountConst), 0, ZoneCountConst - 1);
+            }
+
+            return zones;
+        }
+
+        /// <summary>
+        /// Ask the device to stop running its own effects before painting lamps.
+        ///
+        /// This does not stop Windows Dynamic Lighting, which is a separate owner of LampArray
+        /// devices and repaints continuously when enabled. A colour that vanishes within a frame
+        /// with this already called is Dynamic Lighting, not the device.
+        /// </summary>
+        private void TakeHostControl()
+        {
+            if (_hostOwnsLamps || _lamps == null) return;
+
+            _lamps.SetAutonomousMode(false);
+            _hostOwnsLamps = true;
+        }
+
+        private RgbApplyResult NewResult() => new() { Method = Method, SupportsVerification = false };
+
+        private static Color[] Normalize(Color[] zoneColors)
+        {
+            var normalized = Enumerable.Repeat(Color.Black, ZoneCountConst).ToArray();
+            for (int i = 0; i < Math.Min(zoneColors.Length, ZoneCountConst); i++)
+                normalized[i] = zoneColors[i];
+            return normalized;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            // DO NOT hand the lamps back here. A static picture's whole value is that it survives
+            // the process that painted it - one report lands and holds with nothing maintaining it.
+            // Restoring autonomous mode on the way out gives the keyboard back to its own effect
+            // engine, which repaints all 120 keys within a frame and erases the picture before
+            // anyone can look at it. Measured: --zones over a running Wave appeared to do nothing
+            // at all, because this line ran microseconds after the colours landed.
+            //
+            // Callers that really do want the device animating again say so with
+            // ReleaseToDeviceEffects, or install an effect, which hands ownership over on purpose.
+            _lamps?.Dispose();
+            _mcu?.Dispose();
+            _lamps = null;
+            _mcu = null;
+        }
+    }
+}

--- a/src/OmenCoreApp/Services/KeyboardLighting/DojoPerKeyBackend.cs
+++ b/src/OmenCoreApp/Services/KeyboardLighting/DojoPerKeyBackend.cs
@@ -48,6 +48,14 @@ namespace OmenCore.Services.KeyboardLighting
         private IReadOnlyList<HidLampArray.LampInfo> _lampMap = Array.Empty<HidLampArray.LampInfo>();
         private ushort[] _lampZone = Array.Empty<ushort>();
 
+        /// <summary>Which keyboard this is, and so which LED bytes make up each key. Null when the
+        /// board is not in the catalogue, which costs per-key Fn survival and nothing else.</summary>
+        private KeyboardLayout? _layout;
+
+        /// <summary>lamp id -> the mi_03 colour map positions that light the same key, resolved
+        /// through the lamp's HID usage. Empty when <see cref="_layout"/> is null.</summary>
+        private Dictionary<ushort, int[]> _lampToLeds = new();
+
         private Color[] _lastZoneColors = Enumerable.Repeat(Color.Black, ZoneCountConst).ToArray();
         private byte _brightness = 255;
         private bool _hostOwnsLamps;
@@ -161,10 +169,23 @@ namespace OmenCore.Services.KeyboardLighting
                     _logging.Info($"[DojoPerKey] Uniform fill over lamps {first}-{last} (mi_04 fallback): " +
                                   $"{(result.BackendReportedSuccess ? "accepted" : "REFUSED")}");
                 }
+                else if (_mcu != null && _lampToLeds.Count > 0)
+                {
+                    // Mixed zones through the mi_03 map, so the bands survive the Fn overlay.
+                    // Painting mi_04 instead needs host control, and host control is exactly what
+                    // stops the MCU redrawing - the zones would vanish on the first Fn press.
+                    var perLamp = new Dictionary<ushort, Color>(_lampMap.Count);
+                    for (int i = 0; i < _lampMap.Count; i++)
+                        perLamp[_lampMap[i].LampId] = normalized[_lampZone[i]];
+
+                    result.BackendReportedSuccess = SetKeyColors(perLamp);
+                    _logging.Info($"[DojoPerKey] {ZoneCountConst} zones over the mi_03 colour map: " +
+                                  $"{(result.BackendReportedSuccess ? "accepted" : "REFUSED")}");
+                }
                 else if (_lamps != null && _lampMap.Count > 0)
                 {
-                    // Mixed zones: set mi_03 base with zone 0's colour as Fn fallback, then
-                    // mi_04 for the actual per-zone picture.
+                    // No layout for this board, so lamp ids cannot become colour-map positions.
+                    // Uniform mi_03 base as the Fn fallback, per-zone picture on mi_04 above it.
                     _mcu?.SetStaticColor(normalized[0].R, normalized[0].G, normalized[0].B);
                     TakeHostControl();
 
@@ -178,7 +199,8 @@ namespace OmenCore.Services.KeyboardLighting
                     result.BackendReportedSuccess = _lamps.SetLamps(lamps);
                     _logging.Info($"[DojoPerKey] {lamps.Count} lamps in " +
                                   $"{(lamps.Count + HidLampArray.MaxLampsPerUpdate - 1) / HidLampArray.MaxLampsPerUpdate} " +
-                                  $"batches: {(result.BackendReportedSuccess ? "accepted" : "REFUSED")}");
+                                  $"batches (no layout; will NOT survive Fn): " +
+                                  $"{(result.BackendReportedSuccess ? "accepted" : "REFUSED")}");
                 }
                 else
                 {
@@ -372,21 +394,47 @@ namespace OmenCore.Services.KeyboardLighting
         /// Colour individual keys, addressed by lamp id. Ids come from <see cref="GetKeyMap"/>;
         /// each carries the HID usage of the key it sits under.
         ///
-        /// Uses mi_04 for individual addressing, but first writes an mi_03 base layer so the MCU
-        /// has something to restore after the Fn overlay. The mi_03 base is a uniform fill with
-        /// the most common colour — not a perfect match, but not a black keyboard.
+        /// Goes to mi_03 as a full per-key colour map whenever the layout is known, because that
+        /// map is the MCU's own state and is what it redraws from when the Fn overlay clears. The
+        /// picture then survives Fn with no host involvement at all.
+        ///
+        /// The earlier version painted mi_04 and took host control, which suppressed the mi_03 map
+        /// it had just written; pressing Fn left the keyboard on the overlay frame until something
+        /// repainted it. Host control and a durable picture are mutually exclusive on this device —
+        /// taking it is what stops the MCU drawing. So this path must not take it.
+        ///
+        /// mi_04 is the fallback for an unknown board only, where there is no way to turn a lamp id
+        /// into a colour-map position. That path cannot survive Fn, and says so.
         ///
         /// Accepted, not verified - there is no colour readback to check it against.
         /// </summary>
         public bool SetKeyColors(IReadOnlyDictionary<ushort, Color> keyColors)
         {
-            if (_lamps == null || keyColors.Count == 0) return false;
+            if (keyColors.Count == 0) return false;
 
-            if (_mcu != null && keyColors.Count > 0)
+            if (_mcu != null && _lampToLeds.Count > 0 && _layout != null)
             {
-                var dominant = MostCommonColor(keyColors.Values);
-                _mcu.SetStaticColor(dominant.R, dominant.G, dominant.B);
+                // Every LED of a key takes the key's colour. Callers wanting the legends of a
+                // dual-legend key coloured separately address the positions with SetLedColors.
+                var leds = new Dictionary<int, Color>(keyColors.Count * 2);
+                int placed = 0;
+                foreach (var (lampId, color) in keyColors)
+                {
+                    if (!_lampToLeds.TryGetValue(lampId, out var positions)) continue;
+                    foreach (int position in positions) leds[position] = color;
+                    placed++;
+                }
+
+                bool mapped = SetLedColors(leds, MostCommonColor(keyColors.Values));
+                _logging.Info($"[DojoPerKey] {placed} of {keyColors.Count} keys into the mi_03 colour map " +
+                              $"({_layout.Id}): {(mapped ? "accepted" : "REFUSED")}");
+                if (mapped) return true;
+
+                _logging.Warn("[DojoPerKey] mi_03 colour map refused; falling back to mi_04, which " +
+                              "will not survive the Fn overlay.");
             }
+
+            if (_lamps == null) return false;
 
             TakeHostControl();
 
@@ -395,9 +443,62 @@ namespace OmenCore.Services.KeyboardLighting
                 .ToList();
 
             bool ok = _lamps.SetLamps(lamps);
-            _logging.Info($"[DojoPerKey] {lamps.Count} lamps at intensity {_brightness}: " +
-                          $"{(ok ? "accepted" : "REFUSED")}");
+            _logging.Info($"[DojoPerKey] {lamps.Count} lamps at intensity {_brightness} over mi_04 " +
+                          $"(no layout for this board; will NOT survive Fn): {(ok ? "accepted" : "REFUSED")}");
             return ok;
+        }
+
+        /// <summary>
+        /// The detected keyboard, or null when the board is unknown. A UI enumerating keys to
+        /// colour reads it from here — each <see cref="KeyboardKey"/> carries the colour-map
+        /// positions that light it, which is what <see cref="SetLedColors"/> takes.
+        /// </summary>
+        public KeyboardLayout? Layout => _layout;
+
+        /// <summary>
+        /// Colour INDIVIDUAL LEDs, addressed by colour-map position rather than by key.
+        ///
+        /// A key is not one LED. Dual-legend keys have two, Space has five, backspace six, and the
+        /// map is per-LED natively — so the legends of one key can take different colours, which
+        /// is what the keyboard already does for the Fn overlay. <see cref="KeyboardKey.Leds"/>
+        /// lists the positions of a key, in the order HP's table declares them.
+        ///
+        /// WHICH LED IS WHICH ON THE KEY IS NOT KNOWN FROM DATA. The layout tables give every LED
+        /// of a key the key's own rectangle, so the order is a byte order and not a geometry, and
+        /// it is not consistent between rows: on Esc position 0 is the LED under the legend and 1
+        /// is below it, while on the number row the digit takes the lower position and the shifted
+        /// glyph the higher. A UI that labels them should say "LED 1 of 2", not "top" and "bottom",
+        /// unless someone has looked at that key on that keyboard.
+        ///
+        /// <paramref name="background"/> fills every position the caller did not name, so a partial
+        /// update does not black out the rest of the keyboard.
+        ///
+        /// Goes to mi_03 without taking host control, so the picture survives the Fn overlay.
+        /// Accepted, not verified — there is no colour readback on this device.
+        /// </summary>
+        public bool SetLedColors(IReadOnlyDictionary<int, Color> ledColors, Color background)
+        {
+            if (_mcu == null) return false;
+
+            var r = new byte[DojoKeyboardMcu.ColorMapLength];
+            var g = new byte[DojoKeyboardMcu.ColorMapLength];
+            var b = new byte[DojoKeyboardMcu.ColorMapLength];
+            Array.Fill(r, background.R);
+            Array.Fill(g, background.G);
+            Array.Fill(b, background.B);
+
+            foreach (var (position, color) in ledColors)
+            {
+                if (position < 0 || position >= DojoKeyboardMcu.ColorMapLength) continue;
+                r[position] = color.R;
+                g[position] = color.G;
+                b[position] = color.B;
+            }
+
+            // The MCU only draws its own map while it owns the display, so release first. Taking
+            // host control here is what broke the Fn overlay: it suppresses the map being written.
+            ReleaseHostControlIfHeld();
+            return _mcu.SetStaticColorMap(r, g, b);
         }
 
         private static Color MostCommonColor(IEnumerable<Color> colors)
@@ -624,7 +725,58 @@ namespace OmenCore.Services.KeyboardLighting
 
             _lampMap = byId.Values.ToList();
             _lampZone = AssignZones(_lampMap);
+            BuildKeyBridge();
         }
+
+        /// <summary>
+        /// Work out which keyboard this is, then map each lamp to the colour-map positions that
+        /// light the same key.
+        ///
+        /// Detection is by board id, which also fixes the firmware cycle — the same model ships on
+        /// both sides of a cycle boundary with different LED maps, so the model name alone is not
+        /// enough. An unknown board leaves the bridge empty rather than guessing: the wrong layout
+        /// lights the wrong keys and looks like a working feature.
+        /// </summary>
+        private void BuildKeyBridge()
+        {
+            var catalog = KeyboardLayoutCatalog.Instance;
+            string board = OmenBoard.Product;
+
+            _layout = SelectedLayoutId != null ? catalog.ById(SelectedLayoutId) : catalog.ForBoard(board);
+            _lampToLeds = new Dictionary<ushort, int[]>();
+
+            if (_layout == null)
+            {
+                _logging.Warn($"[DojoPerKey] Board '{board}' is not in the keyboard layout catalogue. " +
+                              "Per-key colour will not survive the Fn overlay until a layout is " +
+                              "chosen manually.");
+                return;
+            }
+
+            int unmapped = 0;
+            foreach (var lamp in _lampMap)
+            {
+                string? keyName = HidUsageKeyNames.Name(lamp.KeyUsage);
+                var key = keyName == null ? null : _layout.ByName(keyName);
+                if (key == null) { unmapped++; continue; }
+
+                _lampToLeds[lamp.LampId] = key.Leds;
+            }
+
+            _logging.Info($"[DojoPerKey] Layout {_layout.Id} ({_layout.Leds} LEDs, {_layout.Keys.Count} keys" +
+                          $"{(_layout.Verified ? "" : ", UNVERIFIED on this hardware")}) for board '{board}'; " +
+                          $"{_lampToLeds.Count} of {_lampMap.Count} lamps bridged to colour-map positions" +
+                          $"{(unmapped > 0 ? $", {unmapped} without a usable HID usage (vendor keys)" : "")}.");
+        }
+
+        /// <summary>
+        /// Force a layout instead of detecting one, for a board the catalogue does not know or gets
+        /// wrong. Null returns to detection. Takes effect on the next connect.
+        ///
+        /// Only Dojo/Global has been confirmed on hardware; everything else in the catalogue is
+        /// derived and unverified, which is the reason this override exists at all.
+        /// </summary>
+        public static string? SelectedLayoutId { get; set; }
 
         /// <summary>
         /// Zone each lamp by where it physically sits, left to right.

--- a/src/OmenCoreApp/Services/KeyboardLighting/HidPerKeyBackend.cs
+++ b/src/OmenCoreApp/Services/KeyboardLighting/HidPerKeyBackend.cs
@@ -20,11 +20,11 @@ namespace OmenCore.Services.KeyboardLighting
     ///   0x0538 – OMEN 16 (2023) Intel/AMD internal keyboard
     ///   0x0547 – OMEN 16 (2024) internal keyboard
     ///   0x0549 – OMEN 17 (2024) internal keyboard
-    ///   0x054E – OMEN MAX 16 (2025) ah0xxx – pending field verification
-    ///   0x054F – OMEN MAX 16 (2025) ak0xxx – pending field verification
     ///
-    /// Unrecognized HP HID devices (VID 0x03F0) are logged at Info level so field
-    /// reports can supply the correct PID for addition to the list above.
+    /// The internal keyboard is not always under HP's own vendor ID - on OMEN MAX 16 ak0xxx
+    /// it is Darfon 0x0D62:0x54BF - so the scan covers the ODM vendor IDs too and logs every
+    /// candidate with its output report length. A device is only opened if it is listed in
+    /// KnownPerKeyPids AND has a 65-byte output report; scanning is not using.
     ///
     /// Current capability: zone-mapped static colors (maps 4 WMI zone colors across
     /// the full key matrix). Full per-key editor addressing is a follow-up once PIDs
@@ -42,18 +42,45 @@ namespace OmenCore.Services.KeyboardLighting
         // HP Inc. USB vendor ID
         private const int HP_VID = 0x03F0;
 
-        // Known OMEN per-key laptop keyboard controller PIDs.
-        // Sources: OpenRGB device database, OmenHubLighter decompilation, community reports.
-        // PIDs marked [probable] are inferred from adjacent model generations and need
-        // confirmation from a field log on actual hardware.
-        private static readonly Dictionary<int, string> KnownPerKeyPids = new()
+        /// <summary>
+        /// Vendor IDs worth scanning. Restricting this to HP_VID made whole models invisible:
+        /// on OMEN MAX 16 ak0xxx (board 8D87) the internal keyboard enumerates under Darfon
+        /// (0x0D62), HP's keyboard ODM, and nothing at all under 0x03F0 except a HyperX
+        /// wireless receiver and, if docked, a Thunderbolt dock. Scanning is not using: a
+        /// device still has to appear in <see cref="KnownPerKeyPids"/> before anything is
+        /// written to it. This list only decides what gets *looked at and logged*.
+        /// </summary>
+        private static readonly Dictionary<int, string> ScannedVendorIds = new()
         {
-            { 0x0538, "OMEN 16 (2023) Intel/AMD keyboard" },
-            { 0x053A, "OMEN Sequoia / external gaming keyboard" },
-            { 0x0547, "OMEN 16 (2024) keyboard" },
-            { 0x0549, "OMEN 17 (2024) keyboard" },
-            { 0x054E, "OMEN MAX 16 (2025) ah0xxx keyboard [probable - needs field confirmation]" },
-            { 0x054F, "OMEN MAX 16 (2025) ak0xxx keyboard [probable - needs field confirmation]" },
+            { HP_VID, "HP" },
+            { 0x0D62, "Darfon (HP keyboard ODM)" },
+        };
+
+        // Known OMEN per-key laptop keyboard controller PIDs, keyed by (VID, PID).
+        // Sources: OpenRGB device database, OmenHubLighter decompilation, community reports.
+        // A device is only opened and written to if it appears here AND its output report
+        // length matches PACKET_SIZE - see the report-length check in InitializeAsync.
+        private static readonly Dictionary<(int Vid, int Pid), string> KnownPerKeyPids = new()
+        {
+            { (HP_VID, 0x0538), "OMEN 16 (2023) Intel/AMD keyboard" },
+            { (HP_VID, 0x053A), "OMEN Sequoia / external gaming keyboard" },
+            { (HP_VID, 0x0547), "OMEN 16 (2024) keyboard" },
+            { (HP_VID, 0x0549), "OMEN 17 (2024) keyboard" },
+
+            // NOT listed, deliberately, and the reason is worth keeping:
+            //
+            //   0x03F0:0x054E / 0x054F were guesses at the OMEN MAX 16 keyboards, inferred from
+            //   adjacent generations. Measured on an ak0xxx (8D87): neither exists. The internal
+            //   keyboard is 0x0D62:0x54BF "HP Gaming Keyboard II", on the board's own USB
+            //   controller with a null serial and RemovalPolicy = ExpectNoRemoval, exposing two
+            //   vendor collections at exactly 65-byte output reports (MI_00 and MI_03) - the
+            //   right shape for PACKET_SIZE. What is NOT established is whether it speaks the
+            //   command set below (CMD_BYTE 0x0F / SUB_* from the 0x03F0 family), and adding it
+            //   here would send those bytes to it on every start to find out.
+            //
+            // Add it once someone has confirmed the protocol on hardware they are willing to
+            // power-cycle - not before. A wrong PID that does nothing is a much cheaper mistake
+            // than a right PID with a wrong protocol.
         };
 
         // HID packet layout.
@@ -97,45 +124,60 @@ namespace OmenCore.Services.KeyboardLighting
         {
             try
             {
-                _logging.Info("[HidPerKey] Scanning for HP OMEN per-key keyboard (VID 0x03F0)...");
+                var vendorList = string.Join(", ", ScannedVendorIds.Select(v => $"0x{v.Key:X4} {v.Value}"));
+                _logging.Info($"[HidPerKey] Scanning for OMEN per-key keyboard ({vendorList})...");
 
-                var allHpHidDevices = DeviceList.Local
+                var scannedDevices = DeviceList.Local
                     .GetHidDevices()
-                    .Where(d => d.VendorID == HP_VID)
+                    .Where(d => ScannedVendorIds.ContainsKey(d.VendorID))
                     .ToList();
 
-                if (allHpHidDevices.Count == 0)
+                if (scannedDevices.Count == 0)
                 {
-                    _logging.Info("[HidPerKey] No HP HID devices found (VID 0x03F0)");
+                    _logging.Info($"[HidPerKey] No candidate HID devices found ({vendorList})");
                     _initialized = false;
                     return Task.FromResult(false);
                 }
 
-                _logging.Info($"[HidPerKey] Found {allHpHidDevices.Count} HP HID device(s):");
+                _logging.Info($"[HidPerKey] Found {scannedDevices.Count} candidate HID device(s):");
 
                 HidDevice? candidate = null;
-                foreach (var d in allHpHidDevices)
+                foreach (var d in scannedDevices)
                 {
+                    var vid  = d.VendorID;
                     var pid  = d.ProductID;
                     var name = SafeGetProductName(d);
 
-                    if (KnownPerKeyPids.TryGetValue(pid, out var knownName))
+                    // A composite keyboard exposes several collections under one PID - a keyboard
+                    // collection, a consumer-control one, a mouse one, and the vendor collection
+                    // that carries lighting. Only the last has an output report the size of a
+                    // per-key packet, so this is what distinguishes it. Selecting on PID alone
+                    // took whichever collection Windows happened to enumerate first.
+                    var outputLength = SafeGetMaxOutputReportLength(d);
+                    var usable = outputLength == PACKET_SIZE;
+
+                    if (KnownPerKeyPids.TryGetValue((vid, pid), out var knownName) && usable)
                     {
-                        _logging.Info($"[HidPerKey]   OK PID 0x{pid:X4} - {knownName} ('{name}')");
-                        candidate ??= d; // prefer first recognized device
+                        _logging.Info($"[HidPerKey]   OK {vid:X4}:{pid:X4} out={outputLength} - {knownName} ('{name}')");
+                        candidate ??= d;
                     }
                     else
                     {
-                        // Log every unrecognized HP device so field reports can supply the correct PID.
-                        _logging.Info($"[HidPerKey]   ? PID 0x{pid:X4} - '{name}' (not in per-key PID list; " +
-                            "if this is an OMEN MAX 16 keyboard, report this PID for inclusion)");
+                        // Log every candidate with its report length. The lengths are the part
+                        // that makes a field report actionable: a device with out=65 is a
+                        // plausible lighting endpoint, one with out=0 never is.
+                        var why = usable
+                            ? "not in the per-key device list"
+                            : $"output report {outputLength} != {PACKET_SIZE}, not a lighting endpoint";
+                        _logging.Info($"[HidPerKey]   ? {vid:X4}:{pid:X4} out={outputLength} - '{name}' ({why})");
                     }
                 }
 
                 if (candidate == null)
                 {
-                    _logging.Info("[HidPerKey] No recognized OMEN per-key keyboard PID found. " +
-                        "If your OMEN MAX 16 is connected, please report the PID(s) logged above.");
+                    _logging.Info("[HidPerKey] No confirmed OMEN per-key keyboard found; zone lighting " +
+                        "will fall back to WMI, which on some models reaches only the light bar. " +
+                        "Please report the VID:PID and out= values logged above.");
                     _initialized = false;
                     return Task.FromResult(false);
                 }
@@ -432,6 +474,25 @@ namespace OmenCore.Services.KeyboardLighting
             {
                 _logging.Warn($"[HidPerKey] Reopen failed: {ex.Message}");
                 _stream = null;
+            }
+        }
+
+        /// <summary>
+        /// Output report length, or -1 if the device will not report it. Some collections
+        /// throw here rather than answering, and an unreadable length must not read as 0 -
+        /// 0 is a meaningful value meaning "no output reports at all".
+        /// </summary>
+        private int SafeGetMaxOutputReportLength(HidDevice d)
+        {
+            try
+            {
+                return d.GetMaxOutputReportLength();
+            }
+            catch (Exception ex)
+            {
+                _logging.Debug($"[HidPerKey] Could not read output report length for " +
+                               $"{d.VendorID:X4}:{d.ProductID:X4}: {ex.Message}");
+                return -1;
             }
         }
 

--- a/src/OmenCoreApp/Services/KeyboardLighting/HidUsageKeyNames.cs
+++ b/src/OmenCoreApp/Services/KeyboardLighting/HidUsageKeyNames.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+
+namespace OmenCore.Services.KeyboardLighting
+{
+    /// <summary>
+    /// HID keyboard usage -> HP's key name, the join between the two interfaces this keyboard has.
+    ///
+    /// mi_04 (LampArray) reports, for every lamp, the HID usage of the key it sits under. mi_03
+    /// (the MCU colour map) is indexed by LED position and grouped by HP's key names. Neither
+    /// mentions the other, so a lamp id becomes an LED position only through the key it lights:
+    ///
+    ///     lamp id -> LampInfo.KeyUsage -> this table -> HP key name -> KeyboardKey.Leds
+    ///
+    /// That matters because only the mi_03 map survives the Fn overlay. Anything painted on mi_04
+    /// alone is gone the moment the MCU redraws its base layer.
+    ///
+    /// Usages are from the standard HID Keyboard/Keypad page (0x07), which is what the device
+    /// actually reports — measured on 8D87, e.g. 0x29 on the lamp under Esc and 0x2C on all five
+    /// under Space.
+    ///
+    /// NOT EVERY KEY HAS ONE. The vendor keys — Omen, Calculator, Settings, Power, Fn, Copilot —
+    /// report no usable usage (the capture shows 0x00 or 0x03 filler), so they cannot be reached
+    /// this way and are absent here deliberately. A caller that needs them must address them by
+    /// name. Names follow the layout tables, so a name missing from a given layout simply does not
+    /// resolve; that is expected, not an error.
+    /// </summary>
+    internal static class HidUsageKeyNames
+    {
+        private static readonly Dictionary<byte, string> Map = Build();
+
+        /// <summary>HP's key name for a HID usage, or null when the usage has no key on this map.</summary>
+        public static string? Name(byte usage) => Map.TryGetValue(usage, out var name) ? name : null;
+
+        private static Dictionary<byte, string> Build()
+        {
+            var map = new Dictionary<byte, string>();
+
+            // 0x04..0x1D: A-Z, in alphabetical order.
+            for (byte usage = 0x04; usage <= 0x1D; usage++)
+                map[usage] = "Key" + (char)('A' + (usage - 0x04));
+
+            // 0x1E..0x26: 1-9. 0 is 0x27, after 9 rather than before 1.
+            for (byte usage = 0x1E; usage <= 0x26; usage++)
+                map[usage] = "Key" + (char)('1' + (usage - 0x1E));
+            map[0x27] = "Key0";
+
+            // 0x3A..0x45: F1-F12.
+            for (byte usage = 0x3A; usage <= 0x45; usage++)
+                map[usage] = "KeyF" + (usage - 0x3A + 1);
+
+            // 0x59..0x61: keypad 1-9, again with 0 following at 0x62.
+            for (byte usage = 0x59; usage <= 0x61; usage++)
+                map[usage] = "KeyNum" + (char)('1' + (usage - 0x59));
+            map[0x62] = "KeyNum0";
+
+            map[0x28] = "KeyEnter";
+            map[0x29] = "KeyEsc";
+            map[0x2A] = "KeyBack";
+            map[0x2B] = "KeyTab";
+            map[0x2C] = "KeySpace";
+            map[0x2D] = "KeyHyphen";
+            map[0x2E] = "KeyEqual";
+            map[0x2F] = "KeyBracketsL";
+            map[0x30] = "KeyBracketsR";
+            map[0x31] = "KeyBackslash";
+            map[0x33] = "KeyColon";      // ';' unshifted - HP names it for the shifted legend
+            map[0x34] = "KeyQuote";
+            map[0x35] = "KeyTilde";      // '`' unshifted, likewise
+            map[0x36] = "KeyComma";
+            map[0x37] = "KeyDot";
+            map[0x38] = "KeySlash";
+            map[0x39] = "KeyCaps";
+            map[0x4C] = "KeyDel";
+            map[0x4F] = "KeyArrRight";
+            map[0x50] = "KeyArrLeft";
+            map[0x51] = "KeyArrDown";
+            map[0x52] = "KeyArrUP";      // HP's own casing; do not "fix" it, it is a lookup key
+            map[0x53] = "KeyNumPad";     // Num Lock
+            map[0x54] = "KeyNumSlash";
+            map[0x55] = "KeyNumStar";
+            map[0x56] = "KeyNumDash";
+            map[0x57] = "KeyNumPlus";
+            map[0x58] = "KeyNumEnter";
+            map[0x63] = "KeyNumDel";     // keypad '.'
+            map[0xE0] = "KeyCtrlL";
+            map[0xE1] = "KeyShiftL";
+            map[0xE2] = "KeyAltL";
+            map[0xE3] = "KeyWin";
+            map[0xE4] = "KeyCtrlR";
+            map[0xE5] = "KeyShiftR";
+            map[0xE6] = "KeyAltR";
+
+            return map;
+        }
+    }
+}

--- a/src/OmenCoreApp/Services/KeyboardLighting/KeyboardLayoutCatalog.cs
+++ b/src/OmenCoreApp/Services/KeyboardLighting/KeyboardLayoutCatalog.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OmenCore.Services.KeyboardLighting
+{
+    /// <summary>
+    /// Which LED byte belongs to which key, for every per-key OMEN keyboard, plus which of those
+    /// keyboards a given board has.
+    ///
+    /// The MCU's static colour map is one byte per LED, NOT one per key: a key with two printed
+    /// legends has two LEDs, Space has five, the backspace key six. So "make W blue" is meaningless
+    /// without a grouping, and the grouping is board-specific. This is that grouping.
+    ///
+    /// The data is derived from OGH's own embedded layout tables — key name, rectangle and LED
+    /// indices, nothing else — by omen-max-16/tools/static/emit-omencore-layouts.py. Regenerate it
+    /// there rather than editing <c>KeyboardLayouts.json</c> by hand.
+    ///
+    /// ONLY ONE LAYOUT HAS BEEN SEEN ON HARDWARE: Dojo/Global, board 8D87, cycle 25C1. Every other
+    /// entry is derived from the same tables by the same rule and nobody has watched it light up.
+    /// <see cref="KeyboardLayout.Verified"/> says which is which, and callers that surface a layout
+    /// to a user should surface that flag too — a keyboard that lights the wrong key is worse than
+    /// one that admits it does not know.
+    /// </summary>
+    public sealed class KeyboardLayoutCatalog
+    {
+        // Matched by suffix rather than spelled out in full: the resource is prefixed with the
+        // project's ROOT NAMESPACE (OmenCoreApp), not the namespace this class is in (OmenCore),
+        // and the two differ. A hardcoded full name compiles, ships, and then throws on the first
+        // per-key apply.
+        private const string ResourceSuffix = ".KeyboardLayouts.json";
+
+        private readonly Dictionary<string, KeyboardLayout> _layouts;
+        private readonly Dictionary<string, BoardEntry> _boards;
+
+        private static readonly Lazy<KeyboardLayoutCatalog> Shared = new(Load);
+
+        /// <summary>The catalogue, parsed once.</summary>
+        public static KeyboardLayoutCatalog Instance => Shared.Value;
+
+        private KeyboardLayoutCatalog(Dictionary<string, KeyboardLayout> layouts,
+                                      Dictionary<string, BoardEntry> boards)
+        {
+            _layouts = layouts;
+            _boards = boards;
+        }
+
+        /// <summary>Every layout, for a picker. Verified ones first, then alphabetical.</summary>
+        public IReadOnlyList<KeyboardLayout> All =>
+            _layouts.Values.OrderByDescending(l => l.Verified).ThenBy(l => l.Id).ToList();
+
+        /// <summary>One layout by id, e.g. "Dojo/Global". Null when the id is not in the table.</summary>
+        public KeyboardLayout? ById(string id) =>
+            id != null && _layouts.TryGetValue(id, out var layout) ? layout : null;
+
+        /// <summary>
+        /// The layout for a board id (Win32_BaseBoard.Product, e.g. "8D87") and keyboard language.
+        ///
+        /// The board id alone picks the keyboard AND the firmware cycle, which matters: a device
+        /// ships across a cycle boundary — Dojo and Vibrance each have both 25C1 and 26C1 SSIDs —
+        /// and the two firmwares blank different LED positions. So this cannot be keyed by model
+        /// name, and a near-miss is not a safe guess.
+        ///
+        /// <paramref name="language"/> comes from the MCU's own GetDeviceInfo response. A layout
+        /// with no table for that language falls back to Global, which is what OGH does.
+        ///
+        /// Returns null when the board is unknown — the caller should then ask the user rather
+        /// than assume, because guessing the wrong keyboard lights the wrong keys silently.
+        /// </summary>
+        public KeyboardLayout? ForBoard(string? boardId, string? language = null)
+        {
+            if (string.IsNullOrWhiteSpace(boardId)) return null;
+            if (!_boards.TryGetValue(boardId.Trim().ToUpperInvariant(), out var board)) return null;
+
+            if (!string.IsNullOrWhiteSpace(language) &&
+                _layouts.TryGetValue($"{board.Layout}/{language}", out var localised))
+                return localised;
+
+            return ById($"{board.Layout}/Global");
+        }
+
+        /// <summary>What the catalogue knows about a board id, for logging and for a UI that wants
+        /// to say which keyboard it thinks this is. Null when unknown.</summary>
+        public BoardEntry? BoardInfo(string? boardId) =>
+            !string.IsNullOrWhiteSpace(boardId) &&
+            _boards.TryGetValue(boardId.Trim().ToUpperInvariant(), out var board) ? board : null;
+
+        private static KeyboardLayoutCatalog Load()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            string name = assembly.GetManifestResourceNames()
+                              .FirstOrDefault(n => n.EndsWith(ResourceSuffix, StringComparison.Ordinal))
+                          ?? throw new InvalidOperationException(
+                              $"No embedded resource ending in {ResourceSuffix}. It is generated by " +
+                              "omen-max-16/tools/static/emit-omencore-layouts.py and must be listed " +
+                              "as an EmbeddedResource in the csproj.");
+
+            using var stream = assembly.GetManifestResourceStream(name)!;
+
+            var file = JsonSerializer.Deserialize<CatalogFile>(stream, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+            }) ?? throw new InvalidOperationException($"{name} did not parse.");
+
+            return new KeyboardLayoutCatalog(
+                file.Layouts ?? new Dictionary<string, KeyboardLayout>(),
+                file.Boards ?? new Dictionary<string, BoardEntry>());
+        }
+
+        private sealed class CatalogFile
+        {
+            [JsonPropertyName("layouts")] public Dictionary<string, KeyboardLayout>? Layouts { get; set; }
+            [JsonPropertyName("boards")] public Dictionary<string, BoardEntry>? Boards { get; set; }
+        }
+    }
+
+    /// <summary>One keyboard: how many LED bytes its colour map has, and what the keys are.</summary>
+    public sealed class KeyboardLayout
+    {
+        [JsonPropertyName("id")] public string Id { get; set; } = "";
+
+        /// <summary>Length of the MCU colour map, padding excluded.</summary>
+        [JsonPropertyName("leds")] public int Leds { get; set; }
+
+        /// <summary>Left, top, right, bottom over every key, in the source table's own units.
+        /// Divide by this to get relative coordinates; the absolute values mean nothing.</summary>
+        [JsonPropertyName("bounds")] public double[] Bounds { get; set; } = Array.Empty<double>();
+
+        /// <summary>False for every layout except the one board this was measured on. Show it.</summary>
+        [JsonPropertyName("verified")] public bool Verified { get; set; }
+
+        [JsonPropertyName("keys")] public List<KeyboardKey> Keys { get; set; } = new();
+
+        private Dictionary<string, KeyboardKey>? _byName;
+
+        /// <summary>One key by HP's name, e.g. "KeySpace".</summary>
+        public KeyboardKey? ByName(string name)
+        {
+            _byName ??= Keys.ToDictionary(k => k.Name, StringComparer.OrdinalIgnoreCase);
+            return name != null && _byName.TryGetValue(name, out var key) ? key : null;
+        }
+    }
+
+    /// <summary>
+    /// One physical key: its name, where it sits, and which LED bytes light it.
+    ///
+    /// <see cref="Rect"/> is the KEY's rectangle, and every LED of the key repeats it — the source
+    /// tables carry no sub-key geometry at all. So this says which key an LED belongs to and never
+    /// where on the key it sits. Intra-key order is only knowable by lighting one and looking, and
+    /// it is not consistent between rows. Colouring a whole key needs none of that; colouring one
+    /// printed legend of a dual-legend key does, and this data cannot supply it.
+    /// </summary>
+    public sealed class KeyboardKey
+    {
+        [JsonPropertyName("name")] public string Name { get; set; } = "";
+
+        /// <summary>X, Y, width, height in the layout's own units — see <see cref="KeyboardLayout.Bounds"/>.</summary>
+        [JsonPropertyName("rect")] public double[] Rect { get; set; } = Array.Empty<double>();
+
+        /// <summary>Indices into the MCU colour map. Usually contiguous, but do not assume it.</summary>
+        [JsonPropertyName("leds")] public int[] Leds { get; set; } = Array.Empty<int>();
+
+        /// <summary>The legend OGH prints, where the source table carries one. Built-in keyboards
+        /// ship no labels; the external keyboard does.</summary>
+        [JsonPropertyName("label")] public string? Label { get; set; }
+    }
+
+    /// <summary>What board id maps to which keyboard.</summary>
+    public sealed class BoardEntry
+    {
+        [JsonPropertyName("device")] public string Device { get; set; } = "";
+        [JsonPropertyName("display")] public string Display { get; set; } = "";
+
+        /// <summary>HP's firmware cycle for this SSID, e.g. "25C1". Decides which of a device's
+        /// layout variants applies, and is already folded into <see cref="Layout"/>.</summary>
+        [JsonPropertyName("cycle")] public string Cycle { get; set; } = "";
+
+        /// <summary>Layout id without the language suffix.</summary>
+        [JsonPropertyName("layout")] public string Layout { get; set; } = "";
+    }
+}

--- a/src/OmenCoreApp/Services/KeyboardLighting/KeyboardLayouts.json
+++ b/src/OmenCoreApp/Services/KeyboardLighting/KeyboardLayouts.json
@@ -1,0 +1,26055 @@
+{
+ "generated_by": "omen-max-16 tools/static/emit-omencore-layouts.py",
+ "layouts": {
+  "Accessory/Arabic": {
+   "id": "Accessory/Arabic",
+   "leds": 142,
+   "bounds": [304,166,964,426],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [340,166,26,26],
+     "leds": [0],
+     "label": "ESC"
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [340,203,26,26],
+     "leds": [1],
+     "label": "`"
+    },
+    {
+     "name": "KeyTab",
+     "rect": [340,231,43,26],
+     "leds": [2]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [340,259,52,26],
+     "leds": [3],
+     "label": "CAPS"
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [340,287,61,26],
+     "leds": [4]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [340,315,36,26],
+     "leds": [5],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyF12",
+     "rect": [733,166,26,26],
+     "leds": [6],
+     "label": "F12"
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [677,203,26,26],
+     "leds": [7],
+     "label": "="
+    },
+    {
+     "name": "KeyF9",
+     "rect": [649,166,26,26],
+     "leds": [8],
+     "label": "F9"
+    },
+    {
+     "name": "Key9",
+     "rect": [593,203,26,26],
+     "leds": [9],
+     "label": "9"
+    },
+    {
+     "name": "KeyO",
+     "rect": [610,231,26,26],
+     "leds": [10],
+     "label": "O"
+    },
+    {
+     "name": "KeyL",
+     "rect": [618,259,26,26],
+     "leds": [11],
+     "label": "L"
+    },
+    {
+     "name": "KeyComma",
+     "rect": [600,287,26,26],
+     "leds": [12],
+     "label": ","
+    },
+    {
+     "name": "KeyWinR",
+     "rect": [696,315,26,26],
+     "leds": [13,14]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [765,336,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [396,166,26,26],
+     "leds": [16],
+     "label": "F1"
+    },
+    {
+     "name": "Key1",
+     "rect": [368,203,26,26],
+     "leds": [17],
+     "label": "1"
+    },
+    {
+     "name": "KeyQ",
+     "rect": [385,231,26,26],
+     "leds": [18],
+     "label": "Q"
+    },
+    {
+     "name": "KeyA",
+     "rect": [394,259,26,26],
+     "leds": [19,20],
+     "label": "k45"
+    },
+    {
+     "name": "KeyWinL",
+     "rect": [377,315,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,166,26,26],
+     "leds": [22,23],
+     "label": "PRT\rSC"
+    },
+    {
+     "name": "KeyF10",
+     "rect": [677,166,26,26],
+     "leds": [24],
+     "label": "F10"
+    },
+    {
+     "name": "Key0",
+     "rect": [621,203,26,26],
+     "leds": [25],
+     "label": "0"
+    },
+    {
+     "name": "KeyP",
+     "rect": [638,231,26,26],
+     "leds": [26],
+     "label": "P"
+    },
+    {
+     "name": "KeyColon",
+     "rect": [647,259,26,26],
+     "leds": [27],
+     "label": ";"
+    },
+    {
+     "name": "KeyDot",
+     "rect": [628,287,26,26],
+     "leds": [28,29],
+     "label": "."
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [703,259,57,26],
+     "leds": [30]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [793,336,26,26],
+     "leds": [31]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,166,26,26],
+     "leds": [32],
+     "label": "F2"
+    },
+    {
+     "name": "Key2",
+     "rect": [396,203,26,26],
+     "leds": [33],
+     "label": "2"
+    },
+    {
+     "name": "KeyW",
+     "rect": [413,231,26,26],
+     "leds": [34],
+     "label": "W"
+    },
+    {
+     "name": "KeyS",
+     "rect": [422,259,26,26],
+     "leds": [35],
+     "label": "S"
+    },
+    {
+     "name": "KeyZ",
+     "rect": [403,287,26,26],
+     "leds": [36],
+     "label": "Z"
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [405,315,36,26],
+     "leds": [37],
+     "label": "ALT"
+    },
+    {
+     "name": "KeyScLock",
+     "rect": [793,166,26,26],
+     "leds": [38],
+     "label": "SC\rLOCK"
+    },
+    {
+     "name": "KeyBack",
+     "rect": [705,203,54,26],
+     "leds": [39]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [705,166,26,26],
+     "leds": [40],
+     "label": "F11"
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [649,203,26,26],
+     "leds": [41],
+     "label": "-"
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [666,231,26,26],
+     "leds": [42],
+     "label": "["
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [675,259,26,26],
+     "leds": [43],
+     "label": "'"
+    },
+    {
+     "name": "KeySlash",
+     "rect": [656,287,26,26],
+     "leds": [44,45,46],
+     "label": "k56"
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [821,336,26,26],
+     "leds": [47]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [452,166,26,26],
+     "leds": [48],
+     "label": "F3"
+    },
+    {
+     "name": "Key3",
+     "rect": [424,203,26,26],
+     "leds": [49],
+     "label": "3"
+    },
+    {
+     "name": "KeyE",
+     "rect": [441,231,26,26],
+     "leds": [50],
+     "label": "E"
+    },
+    {
+     "name": "KeyD",
+     "rect": [450,259,26,26],
+     "leds": [51],
+     "label": "D"
+    },
+    {
+     "name": "KeyX",
+     "rect": [431,287,26,26],
+     "leds": [52,53],
+     "label": "X"
+    },
+    {
+     "name": "KeyPause",
+     "rect": [821,166,26,26],
+     "leds": [54],
+     "label": "PAUSE"
+    },
+    {
+     "name": "KeyDel",
+     "rect": [765,231,26,26],
+     "leds": [55,56],
+     "label": "DELETE"
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [854,231,26,26],
+     "leds": [57],
+     "label": "7"
+    },
+    {
+     "name": "KeyP1",
+     "rect": [304,203,26,26],
+     "leds": [58,59],
+     "label": "P1"
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [854,203,26,26],
+     "leds": [60],
+     "label": "NUM\rLOCK"
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [910,259,26,26],
+     "leds": [61,62,63],
+     "label": "6"
+    },
+    {
+     "name": "KeyF4",
+     "rect": [480,166,26,26],
+     "leds": [64],
+     "label": "F4"
+    },
+    {
+     "name": "Key4",
+     "rect": [452,203,26,26],
+     "leds": [65],
+     "label": "4"
+    },
+    {
+     "name": "KeyR",
+     "rect": [469,231,26,26],
+     "leds": [66],
+     "label": "R"
+    },
+    {
+     "name": "KeyF",
+     "rect": [478,259,26,26],
+     "leds": [67],
+     "label": "F"
+    },
+    {
+     "name": "KeyC",
+     "rect": [459,287,26,26],
+     "leds": [68],
+     "label": "C"
+    },
+    {
+     "name": "KeySpace",
+     "rect": [443,315,185,46],
+     "leds": [69]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [765,203,26,26],
+     "leds": [70],
+     "label": "INSERT"
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [793,231,26,26],
+     "leds": [71,72],
+     "label": "END"
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [882,231,26,26],
+     "leds": [73],
+     "label": "8"
+    },
+    {
+     "name": "KeyP2",
+     "rect": [304,231,26,26],
+     "leds": [74,75],
+     "label": "P2"
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [882,203,26,26],
+     "leds": [76],
+     "label": "/"
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [854,287,26,26],
+     "leds": [77,78,79],
+     "label": "1"
+    },
+    {
+     "name": "KeyF5",
+     "rect": [522,166,26,26],
+     "leds": [80],
+     "label": "F5"
+    },
+    {
+     "name": "Key5",
+     "rect": [480,203,26,26],
+     "leds": [81],
+     "label": "5"
+    },
+    {
+     "name": "KeyT",
+     "rect": [497,231,26,26],
+     "leds": [82],
+     "label": "T"
+    },
+    {
+     "name": "KeyG",
+     "rect": [506,259,26,26],
+     "leds": [83],
+     "label": "G"
+    },
+    {
+     "name": "KeyV",
+     "rect": [487,287,26,26],
+     "leds": [84,85],
+     "label": "V"
+    },
+    {
+     "name": "KeyHome",
+     "rect": [793,203,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [821,231,26,26],
+     "leds": [87],
+     "label": "PG\rDN"
+    },
+    {
+     "name": "KeyStop",
+     "rect": [882,166,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [910,231,26,26],
+     "leds": [89],
+     "label": "9"
+    },
+    {
+     "name": "KeyP3",
+     "rect": [304,259,26,26],
+     "leds": [90,91],
+     "label": "P3"
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [910,203,26,26],
+     "leds": [92],
+     "label": "*"
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [882,287,26,26],
+     "leds": [93,94,95],
+     "label": "2"
+    },
+    {
+     "name": "KeyF6",
+     "rect": [550,166,26,26],
+     "leds": [96],
+     "label": "F6"
+    },
+    {
+     "name": "Key6",
+     "rect": [508,203,26,26],
+     "leds": [97],
+     "label": "6"
+    },
+    {
+     "name": "KeyY",
+     "rect": [526,231,26,26],
+     "leds": [98],
+     "label": "Y"
+    },
+    {
+     "name": "KeyH",
+     "rect": [534,259,26,26],
+     "leds": [99],
+     "label": "H"
+    },
+    {
+     "name": "KeyB",
+     "rect": [515,287,26,26],
+     "leds": [100,101],
+     "label": "B"
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [821,203,26,26],
+     "leds": [102],
+     "label": "PG\rUP"
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [684,287,76,26],
+     "leds": [103]
+    },
+    {
+     "name": "KeyPreTrack",
+     "rect": [910,166,26,26],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [304,287,26,26],
+     "leds": [106,107],
+     "label": "P4"
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [938,203,26,26],
+     "leds": [108],
+     "label": "-"
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [910,287,26,26],
+     "leds": [109,110,111],
+     "label": "3"
+    },
+    {
+     "name": "KeyF7",
+     "rect": [578,166,26,26],
+     "leds": [112],
+     "label": "F7"
+    },
+    {
+     "name": "Key7",
+     "rect": [537,203,26,26],
+     "leds": [113],
+     "label": "7"
+    },
+    {
+     "name": "KeyU",
+     "rect": [554,231,26,26],
+     "leds": [114],
+     "label": "U"
+    },
+    {
+     "name": "KeyJ",
+     "rect": [562,259,26,26],
+     "leds": [115],
+     "label": "J"
+    },
+    {
+     "name": "KeyN",
+     "rect": [543,287,26,26],
+     "leds": [116],
+     "label": "N"
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [630,315,36,26],
+     "leds": [117],
+     "label": "ALT\r GR"
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [694,231,26,26],
+     "leds": [118],
+     "label": "]"
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [724,315,36,26],
+     "leds": [119],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyPlay",
+     "rect": [854,166,26,26],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [854,259,26,26],
+     "leds": [121],
+     "label": "4"
+    },
+    {
+     "name": "KeyP5",
+     "rect": [304,315,26,26],
+     "leds": [122,123],
+     "label": "P5"
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [938,231,26,54],
+     "leds": [124],
+     "label": "+"
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [854,315,54,26],
+     "leds": [125,126,127],
+     "label": "0"
+    },
+    {
+     "name": "KeyF8",
+     "rect": [607,166,26,26],
+     "leds": [128],
+     "label": "F8"
+    },
+    {
+     "name": "Key8",
+     "rect": [565,203,26,26],
+     "leds": [129],
+     "label": "8"
+    },
+    {
+     "name": "KeyI",
+     "rect": [582,231,26,26],
+     "leds": [130],
+     "label": "I"
+    },
+    {
+     "name": "KeyK",
+     "rect": [590,259,26,26],
+     "leds": [131],
+     "label": "K"
+    },
+    {
+     "name": "KeyM",
+     "rect": [572,287,26,26],
+     "leds": [132],
+     "label": "M"
+    },
+    {
+     "name": "KeyFn",
+     "rect": [668,315,26,26],
+     "leds": [133],
+     "label": "FN"
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [722,231,37,26],
+     "leds": [134],
+     "label": "\\"
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [793,307,26,26],
+     "leds": [135]
+    },
+    {
+     "name": "KeyNextTrack",
+     "rect": [938,166,26,26],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [882,259,26,26],
+     "leds": [137,138,139],
+     "label": "5"
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [938,287,26,54],
+     "leds": [140],
+     "label": "ENTER"
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [910,315,26,26],
+     "leds": [141],
+     "label": "."
+    }
+   ]
+  },
+  "Accessory/BrazilianPortuguese": {
+   "id": "Accessory/BrazilianPortuguese",
+   "leds": 142,
+   "bounds": [304,166,964,426],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [340,166,26,26],
+     "leds": [0],
+     "label": "ESC"
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [340,203,26,26],
+     "leds": [1],
+     "label": "\""
+    },
+    {
+     "name": "KeyTab",
+     "rect": [340,231,43,26],
+     "leds": [2]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [340,259,52,26],
+     "leds": [3],
+     "label": "CAPS"
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [340,287,61,26],
+     "leds": [4]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [340,315,36,26],
+     "leds": [5],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyF12",
+     "rect": [733,166,26,26],
+     "leds": [6],
+     "label": "F12"
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [677,203,26,26],
+     "leds": [7],
+     "label": "="
+    },
+    {
+     "name": "KeyF9",
+     "rect": [649,166,26,26],
+     "leds": [8],
+     "label": "F9"
+    },
+    {
+     "name": "Key9",
+     "rect": [593,203,26,26],
+     "leds": [9],
+     "label": "9"
+    },
+    {
+     "name": "KeyO",
+     "rect": [610,231,26,26],
+     "leds": [10],
+     "label": "O"
+    },
+    {
+     "name": "KeyL",
+     "rect": [618,259,26,26],
+     "leds": [11],
+     "label": "L"
+    },
+    {
+     "name": "KeyComma",
+     "rect": [600,287,26,26],
+     "leds": [12],
+     "label": ","
+    },
+    {
+     "name": "KeyWinR",
+     "rect": [696,315,26,26],
+     "leds": [13,14]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [765,336,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [396,166,26,26],
+     "leds": [16],
+     "label": "F1"
+    },
+    {
+     "name": "Key1",
+     "rect": [368,203,26,26],
+     "leds": [17],
+     "label": "1"
+    },
+    {
+     "name": "KeyQ",
+     "rect": [385,231,26,26],
+     "leds": [18],
+     "label": "Q"
+    },
+    {
+     "name": "KeyA",
+     "rect": [394,259,26,26],
+     "leds": [19,20],
+     "label": "k45"
+    },
+    {
+     "name": "KeyWinL",
+     "rect": [377,315,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,166,26,26],
+     "leds": [22,23],
+     "label": "PRT\rSC"
+    },
+    {
+     "name": "KeyF10",
+     "rect": [677,166,26,26],
+     "leds": [24],
+     "label": "F10"
+    },
+    {
+     "name": "Key0",
+     "rect": [621,203,26,26],
+     "leds": [25],
+     "label": "0"
+    },
+    {
+     "name": "KeyP",
+     "rect": [638,231,26,26],
+     "leds": [26],
+     "label": "P"
+    },
+    {
+     "name": "KeyColon",
+     "rect": [647,259,26,26],
+     "leds": [27],
+     "label": "\u00e7"
+    },
+    {
+     "name": "KeyDot",
+     "rect": [628,287,26,26],
+     "leds": [28,29],
+     "label": "."
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [703,259,57,26],
+     "leds": [30]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [793,336,26,26],
+     "leds": [31]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,166,26,26],
+     "leds": [32],
+     "label": "F2"
+    },
+    {
+     "name": "Key2",
+     "rect": [396,203,26,26],
+     "leds": [33],
+     "label": "2"
+    },
+    {
+     "name": "KeyW",
+     "rect": [413,231,26,26],
+     "leds": [34],
+     "label": "W"
+    },
+    {
+     "name": "KeyS",
+     "rect": [422,259,26,26],
+     "leds": [35],
+     "label": "S"
+    },
+    {
+     "name": "KeyZ",
+     "rect": [403,287,26,26],
+     "leds": [36],
+     "label": "Z"
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [405,315,36,26],
+     "leds": [37],
+     "label": "ALT"
+    },
+    {
+     "name": "KeyScLock",
+     "rect": [793,166,26,26],
+     "leds": [38],
+     "label": "SC\rLOCK"
+    },
+    {
+     "name": "KeyBack",
+     "rect": [705,203,54,26],
+     "leds": [39]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [705,166,26,26],
+     "leds": [40],
+     "label": "F11"
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [649,203,26,26],
+     "leds": [41],
+     "label": "-"
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [666,231,26,26],
+     "leds": [42],
+     "label": "'"
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [675,259,26,26],
+     "leds": [43],
+     "label": "~"
+    },
+    {
+     "name": "KeySlash",
+     "rect": [656,287,26,26],
+     "leds": [44,45,46],
+     "label": "k56"
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [821,336,26,26],
+     "leds": [47]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [452,166,26,26],
+     "leds": [48],
+     "label": "F3"
+    },
+    {
+     "name": "Key3",
+     "rect": [424,203,26,26],
+     "leds": [49],
+     "label": "3"
+    },
+    {
+     "name": "KeyE",
+     "rect": [441,231,26,26],
+     "leds": [50],
+     "label": "E"
+    },
+    {
+     "name": "KeyD",
+     "rect": [450,259,26,26],
+     "leds": [51],
+     "label": "D"
+    },
+    {
+     "name": "KeyX",
+     "rect": [431,287,26,26],
+     "leds": [52,53],
+     "label": "X"
+    },
+    {
+     "name": "KeyPause",
+     "rect": [821,166,26,26],
+     "leds": [54],
+     "label": "PAUSE"
+    },
+    {
+     "name": "KeyDel",
+     "rect": [765,231,26,26],
+     "leds": [55,56],
+     "label": "DELETE"
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [854,231,26,26],
+     "leds": [57],
+     "label": "7"
+    },
+    {
+     "name": "KeyP1",
+     "rect": [304,203,26,26],
+     "leds": [58,59],
+     "label": "P1"
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [854,203,26,26],
+     "leds": [60],
+     "label": "NUM\rLOCK"
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [910,259,26,26],
+     "leds": [61,62,63],
+     "label": "6"
+    },
+    {
+     "name": "KeyF4",
+     "rect": [480,166,26,26],
+     "leds": [64],
+     "label": "F4"
+    },
+    {
+     "name": "Key4",
+     "rect": [452,203,26,26],
+     "leds": [65],
+     "label": "4"
+    },
+    {
+     "name": "KeyR",
+     "rect": [469,231,26,26],
+     "leds": [66],
+     "label": "R"
+    },
+    {
+     "name": "KeyF",
+     "rect": [478,259,26,26],
+     "leds": [67],
+     "label": "F"
+    },
+    {
+     "name": "KeyC",
+     "rect": [459,287,26,26],
+     "leds": [68],
+     "label": "C"
+    },
+    {
+     "name": "KeySpace",
+     "rect": [443,315,185,46],
+     "leds": [69]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [765,203,26,26],
+     "leds": [70],
+     "label": "INSERT"
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [793,231,26,26],
+     "leds": [71,72],
+     "label": "END"
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [882,231,26,26],
+     "leds": [73],
+     "label": "8"
+    },
+    {
+     "name": "KeyP2",
+     "rect": [304,231,26,26],
+     "leds": [74,75],
+     "label": "P2"
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [882,203,26,26],
+     "leds": [76],
+     "label": "/"
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [854,287,26,26],
+     "leds": [77,78,79],
+     "label": "1"
+    },
+    {
+     "name": "KeyF5",
+     "rect": [522,166,26,26],
+     "leds": [80],
+     "label": "F5"
+    },
+    {
+     "name": "Key5",
+     "rect": [480,203,26,26],
+     "leds": [81],
+     "label": "5"
+    },
+    {
+     "name": "KeyT",
+     "rect": [497,231,26,26],
+     "leds": [82],
+     "label": "T"
+    },
+    {
+     "name": "KeyG",
+     "rect": [506,259,26,26],
+     "leds": [83],
+     "label": "G"
+    },
+    {
+     "name": "KeyV",
+     "rect": [487,287,26,26],
+     "leds": [84,85],
+     "label": "V"
+    },
+    {
+     "name": "KeyHome",
+     "rect": [793,203,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [821,231,26,26],
+     "leds": [87],
+     "label": "PG\rDN"
+    },
+    {
+     "name": "KeyStop",
+     "rect": [882,166,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [910,231,26,26],
+     "leds": [89],
+     "label": "9"
+    },
+    {
+     "name": "KeyP3",
+     "rect": [304,259,26,26],
+     "leds": [90,91],
+     "label": "P3"
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [910,203,26,26],
+     "leds": [92],
+     "label": "*"
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [882,287,26,26],
+     "leds": [93,94,95],
+     "label": "2"
+    },
+    {
+     "name": "KeyF6",
+     "rect": [550,166,26,26],
+     "leds": [96],
+     "label": "F6"
+    },
+    {
+     "name": "Key6",
+     "rect": [508,203,26,26],
+     "leds": [97],
+     "label": "6"
+    },
+    {
+     "name": "KeyY",
+     "rect": [526,231,26,26],
+     "leds": [98],
+     "label": "Y"
+    },
+    {
+     "name": "KeyH",
+     "rect": [534,259,26,26],
+     "leds": [99],
+     "label": "H"
+    },
+    {
+     "name": "KeyB",
+     "rect": [515,287,26,26],
+     "leds": [100,101],
+     "label": "B"
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [821,203,26,26],
+     "leds": [102],
+     "label": "PG\rUP"
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [684,287,76,26],
+     "leds": [103]
+    },
+    {
+     "name": "KeyPreTrack",
+     "rect": [910,166,26,26],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [304,287,26,26],
+     "leds": [106,107],
+     "label": "P4"
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [938,203,26,26],
+     "leds": [108],
+     "label": "-"
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [910,287,26,26],
+     "leds": [109,110,111],
+     "label": "3"
+    },
+    {
+     "name": "KeyF7",
+     "rect": [578,166,26,26],
+     "leds": [112],
+     "label": "F7"
+    },
+    {
+     "name": "Key7",
+     "rect": [537,203,26,26],
+     "leds": [113],
+     "label": "7"
+    },
+    {
+     "name": "KeyU",
+     "rect": [554,231,26,26],
+     "leds": [114],
+     "label": "U"
+    },
+    {
+     "name": "KeyJ",
+     "rect": [562,259,26,26],
+     "leds": [115],
+     "label": "J"
+    },
+    {
+     "name": "KeyN",
+     "rect": [543,287,26,26],
+     "leds": [116],
+     "label": "N"
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [630,315,36,26],
+     "leds": [117],
+     "label": "ALT\r GR"
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [694,231,26,26],
+     "leds": [118],
+     "label": "["
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [724,315,36,26],
+     "leds": [119],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyPlay",
+     "rect": [854,166,26,26],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [854,259,26,26],
+     "leds": [121],
+     "label": "4"
+    },
+    {
+     "name": "KeyP5",
+     "rect": [304,315,26,26],
+     "leds": [122,123],
+     "label": "P5"
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [938,231,26,54],
+     "leds": [124],
+     "label": "+"
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [854,315,54,26],
+     "leds": [125,126,127],
+     "label": "0"
+    },
+    {
+     "name": "KeyF8",
+     "rect": [607,166,26,26],
+     "leds": [128],
+     "label": "F8"
+    },
+    {
+     "name": "Key8",
+     "rect": [565,203,26,26],
+     "leds": [129],
+     "label": "8"
+    },
+    {
+     "name": "KeyI",
+     "rect": [582,231,26,26],
+     "leds": [130],
+     "label": "I"
+    },
+    {
+     "name": "KeyK",
+     "rect": [590,259,26,26],
+     "leds": [131],
+     "label": "K"
+    },
+    {
+     "name": "KeyM",
+     "rect": [572,287,26,26],
+     "leds": [132],
+     "label": "M"
+    },
+    {
+     "name": "KeyFn",
+     "rect": [668,315,26,26],
+     "leds": [133],
+     "label": "FN"
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [722,231,37,26],
+     "leds": [134],
+     "label": "]"
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [793,307,26,26],
+     "leds": [135]
+    },
+    {
+     "name": "KeyNextTrack",
+     "rect": [938,166,26,26],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [882,259,26,26],
+     "leds": [137,138,139],
+     "label": "5"
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [938,287,26,54],
+     "leds": [140],
+     "label": "ENTER"
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [910,315,26,26],
+     "leds": [141],
+     "label": "."
+    }
+   ]
+  },
+  "Accessory/French": {
+   "id": "Accessory/French",
+   "leds": 142,
+   "bounds": [304,166,964,426],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [340,166,26,26],
+     "leds": [0],
+     "label": "ESC"
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [340,203,26,26],
+     "leds": [1],
+     "label": "2"
+    },
+    {
+     "name": "KeyTab",
+     "rect": [340,231,43,26],
+     "leds": [2]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [340,259,52,26],
+     "leds": [3]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [340,287,61,26],
+     "leds": [4]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [340,315,36,26],
+     "leds": [5],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyF12",
+     "rect": [733,166,26,26],
+     "leds": [6],
+     "label": "F12"
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [677,203,26,26],
+     "leds": [7],
+     "label": "="
+    },
+    {
+     "name": "KeyF9",
+     "rect": [649,166,26,26],
+     "leds": [8],
+     "label": "F9"
+    },
+    {
+     "name": "Key9",
+     "rect": [593,203,26,26],
+     "leds": [9],
+     "label": "9"
+    },
+    {
+     "name": "KeyO",
+     "rect": [610,231,26,26],
+     "leds": [10],
+     "label": "O"
+    },
+    {
+     "name": "KeyL",
+     "rect": [618,259,26,26],
+     "leds": [11],
+     "label": "L"
+    },
+    {
+     "name": "KeyComma",
+     "rect": [600,287,26,26],
+     "leds": [12],
+     "label": ";"
+    },
+    {
+     "name": "KeyWinR",
+     "rect": [696,315,26,26],
+     "leds": [13,14],
+     "label": "<"
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [765,336,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [396,166,26,26],
+     "leds": [16],
+     "label": "F1"
+    },
+    {
+     "name": "Key1",
+     "rect": [368,203,26,26],
+     "leds": [17],
+     "label": "1"
+    },
+    {
+     "name": "KeyQ",
+     "rect": [385,231,26,26],
+     "leds": [18],
+     "label": "Q"
+    },
+    {
+     "name": "KeyA",
+     "rect": [394,259,26,26],
+     "leds": [19,20],
+     "label": "k45"
+    },
+    {
+     "name": "KeyWinL",
+     "rect": [377,315,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,166,26,26],
+     "leds": [22,23],
+     "label": "IMPR\r\u00c9CRAN"
+    },
+    {
+     "name": "KeyF10",
+     "rect": [677,166,26,26],
+     "leds": [24],
+     "label": "F10"
+    },
+    {
+     "name": "Key0",
+     "rect": [621,203,26,26],
+     "leds": [25],
+     "label": "0"
+    },
+    {
+     "name": "KeyP",
+     "rect": [638,231,26,26],
+     "leds": [26],
+     "label": "P"
+    },
+    {
+     "name": "KeyColon",
+     "rect": [647,259,26,26],
+     "leds": [27],
+     "label": "M"
+    },
+    {
+     "name": "KeyDot",
+     "rect": [628,287,26,26],
+     "leds": [28,29],
+     "label": ":"
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [703,259,57,26],
+     "leds": [30]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [793,336,26,26],
+     "leds": [31]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,166,26,26],
+     "leds": [32],
+     "label": "F2"
+    },
+    {
+     "name": "Key2",
+     "rect": [396,203,26,26],
+     "leds": [33],
+     "label": "2"
+    },
+    {
+     "name": "KeyW",
+     "rect": [413,231,26,26],
+     "leds": [34],
+     "label": "W"
+    },
+    {
+     "name": "KeyS",
+     "rect": [422,259,26,26],
+     "leds": [35],
+     "label": "S"
+    },
+    {
+     "name": "KeyZ",
+     "rect": [403,287,26,26],
+     "leds": [36],
+     "label": "Z"
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [405,315,36,26],
+     "leds": [37],
+     "label": "ALT"
+    },
+    {
+     "name": "KeyScLock",
+     "rect": [793,166,26,26],
+     "leds": [38],
+     "label": "ARR\u00caT\rD\u00c9FIL"
+    },
+    {
+     "name": "KeyBack",
+     "rect": [705,203,54,26],
+     "leds": [39]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [705,166,26,26],
+     "leds": [40],
+     "label": "F11"
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [649,203,26,26],
+     "leds": [41],
+     "label": ")"
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [666,231,26,26],
+     "leds": [42],
+     "label": "^"
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [675,259,26,26],
+     "leds": [43],
+     "label": "\u00d9"
+    },
+    {
+     "name": "KeySlash",
+     "rect": [656,287,26,26],
+     "leds": [44,45,46],
+     "label": "k56"
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [821,336,26,26],
+     "leds": [47]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [452,166,26,26],
+     "leds": [48],
+     "label": "F3"
+    },
+    {
+     "name": "Key3",
+     "rect": [424,203,26,26],
+     "leds": [49],
+     "label": "3"
+    },
+    {
+     "name": "KeyE",
+     "rect": [441,231,26,26],
+     "leds": [50],
+     "label": "E"
+    },
+    {
+     "name": "KeyD",
+     "rect": [450,259,26,26],
+     "leds": [51],
+     "label": "D"
+    },
+    {
+     "name": "KeyX",
+     "rect": [431,287,26,26],
+     "leds": [52,53],
+     "label": "X"
+    },
+    {
+     "name": "KeyPause",
+     "rect": [821,166,26,26],
+     "leds": [54],
+     "label": "PAUSE"
+    },
+    {
+     "name": "KeyDel",
+     "rect": [765,231,26,26],
+     "leds": [55,56],
+     "label": "SUPPR"
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [854,231,26,26],
+     "leds": [57],
+     "label": "7"
+    },
+    {
+     "name": "KeyP1",
+     "rect": [304,203,26,26],
+     "leds": [58,59],
+     "label": "P1"
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [854,203,26,26],
+     "leds": [60],
+     "label": "VER\rNUM"
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [910,259,26,26],
+     "leds": [61,62,63],
+     "label": "6"
+    },
+    {
+     "name": "KeyF4",
+     "rect": [480,166,26,26],
+     "leds": [64],
+     "label": "F4"
+    },
+    {
+     "name": "Key4",
+     "rect": [452,203,26,26],
+     "leds": [65],
+     "label": "4"
+    },
+    {
+     "name": "KeyR",
+     "rect": [469,231,26,26],
+     "leds": [66],
+     "label": "R"
+    },
+    {
+     "name": "KeyF",
+     "rect": [478,259,26,26],
+     "leds": [67],
+     "label": "F"
+    },
+    {
+     "name": "KeyC",
+     "rect": [459,287,26,26],
+     "leds": [68],
+     "label": "C"
+    },
+    {
+     "name": "KeySpace",
+     "rect": [443,315,185,46],
+     "leds": [69]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [765,203,26,26],
+     "leds": [70],
+     "label": "INSER"
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [793,231,26,26],
+     "leds": [71,72],
+     "label": "FIN"
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [882,231,26,26],
+     "leds": [73],
+     "label": "8"
+    },
+    {
+     "name": "KeyP2",
+     "rect": [304,231,26,26],
+     "leds": [74,75],
+     "label": "P2"
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [882,203,26,26],
+     "leds": [76],
+     "label": "/"
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [854,287,26,26],
+     "leds": [77,78,79],
+     "label": "1"
+    },
+    {
+     "name": "KeyF5",
+     "rect": [522,166,26,26],
+     "leds": [80],
+     "label": "F5"
+    },
+    {
+     "name": "Key5",
+     "rect": [480,203,26,26],
+     "leds": [81],
+     "label": "5"
+    },
+    {
+     "name": "KeyT",
+     "rect": [497,231,26,26],
+     "leds": [82],
+     "label": "T"
+    },
+    {
+     "name": "KeyG",
+     "rect": [506,259,26,26],
+     "leds": [83],
+     "label": "G"
+    },
+    {
+     "name": "KeyV",
+     "rect": [487,287,26,26],
+     "leds": [84,85],
+     "label": "V"
+    },
+    {
+     "name": "KeyHome",
+     "rect": [793,203,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [821,231,26,26],
+     "leds": [87],
+     "label": "PG\rDN"
+    },
+    {
+     "name": "KeyStop",
+     "rect": [882,166,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [910,231,26,26],
+     "leds": [89],
+     "label": "9"
+    },
+    {
+     "name": "KeyP3",
+     "rect": [304,259,26,26],
+     "leds": [90,91],
+     "label": "P3"
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [910,203,26,26],
+     "leds": [92],
+     "label": "*"
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [882,287,26,26],
+     "leds": [93,94,95],
+     "label": "2"
+    },
+    {
+     "name": "KeyF6",
+     "rect": [550,166,26,26],
+     "leds": [96],
+     "label": "F6"
+    },
+    {
+     "name": "Key6",
+     "rect": [508,203,26,26],
+     "leds": [97],
+     "label": "6"
+    },
+    {
+     "name": "KeyY",
+     "rect": [526,231,26,26],
+     "leds": [98],
+     "label": "Y"
+    },
+    {
+     "name": "KeyH",
+     "rect": [534,259,26,26],
+     "leds": [99],
+     "label": "H"
+    },
+    {
+     "name": "KeyB",
+     "rect": [515,287,26,26],
+     "leds": [100,101],
+     "label": "B"
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [821,203,26,26],
+     "leds": [102],
+     "label": "PG\rUP"
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [684,287,76,26],
+     "leds": [103]
+    },
+    {
+     "name": "KeyPreTrack",
+     "rect": [910,166,26,26],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [304,287,26,26],
+     "leds": [106,107],
+     "label": "P4"
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [938,203,26,26],
+     "leds": [108],
+     "label": "-"
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [910,287,26,26],
+     "leds": [109,110,111],
+     "label": "3"
+    },
+    {
+     "name": "KeyF7",
+     "rect": [578,166,26,26],
+     "leds": [112],
+     "label": "F7"
+    },
+    {
+     "name": "Key7",
+     "rect": [537,203,26,26],
+     "leds": [113],
+     "label": "7"
+    },
+    {
+     "name": "KeyU",
+     "rect": [554,231,26,26],
+     "leds": [114],
+     "label": "U"
+    },
+    {
+     "name": "KeyJ",
+     "rect": [562,259,26,26],
+     "leds": [115],
+     "label": "J"
+    },
+    {
+     "name": "KeyN",
+     "rect": [543,287,26,26],
+     "leds": [116],
+     "label": "N"
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [630,315,36,26],
+     "leds": [117],
+     "label": "ALT\r GR"
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [694,231,26,26],
+     "leds": [118],
+     "label": "$"
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [724,315,36,26],
+     "leds": [119],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyPlay",
+     "rect": [854,166,26,26],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [854,259,26,26],
+     "leds": [121],
+     "label": "4"
+    },
+    {
+     "name": "KeyP5",
+     "rect": [304,315,26,26],
+     "leds": [122,123],
+     "label": "P5"
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [938,231,26,54],
+     "leds": [124],
+     "label": "+"
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [854,315,54,26],
+     "leds": [125,126,127],
+     "label": "0"
+    },
+    {
+     "name": "KeyF8",
+     "rect": [607,166,26,26],
+     "leds": [128],
+     "label": "F8"
+    },
+    {
+     "name": "Key8",
+     "rect": [565,203,26,26],
+     "leds": [129],
+     "label": "8"
+    },
+    {
+     "name": "KeyI",
+     "rect": [582,231,26,26],
+     "leds": [130],
+     "label": "I"
+    },
+    {
+     "name": "KeyK",
+     "rect": [590,259,26,26],
+     "leds": [131],
+     "label": "K"
+    },
+    {
+     "name": "KeyM",
+     "rect": [572,287,26,26],
+     "leds": [132],
+     "label": ","
+    },
+    {
+     "name": "KeyFn",
+     "rect": [668,315,26,26],
+     "leds": [133],
+     "label": "FN"
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [722,231,37,26],
+     "leds": [134],
+     "label": "*"
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [793,307,26,26],
+     "leds": [135]
+    },
+    {
+     "name": "KeyNextTrack",
+     "rect": [938,166,26,26],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [882,259,26,26],
+     "leds": [137,138,139],
+     "label": "5"
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [938,287,26,54],
+     "leds": [140]
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [910,315,26,26],
+     "leds": [141],
+     "label": "."
+    }
+   ]
+  },
+  "Accessory/German": {
+   "id": "Accessory/German",
+   "leds": 142,
+   "bounds": [304,166,964,426],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [340,166,26,26],
+     "leds": [0],
+     "label": "ESC"
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [340,203,26,26],
+     "leds": [1],
+     "label": "^"
+    },
+    {
+     "name": "KeyTab",
+     "rect": [340,231,43,26],
+     "leds": [2]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [340,259,52,26],
+     "leds": [3],
+     "label": "CAPS"
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [340,287,61,26],
+     "leds": [4]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [340,315,36,26],
+     "leds": [5],
+     "label": "STRG"
+    },
+    {
+     "name": "KeyF12",
+     "rect": [733,166,26,26],
+     "leds": [6],
+     "label": "F12"
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [677,203,26,26],
+     "leds": [7],
+     "label": "'"
+    },
+    {
+     "name": "KeyF9",
+     "rect": [649,166,26,26],
+     "leds": [8],
+     "label": "F9"
+    },
+    {
+     "name": "Key9",
+     "rect": [593,203,26,26],
+     "leds": [9],
+     "label": "9"
+    },
+    {
+     "name": "KeyO",
+     "rect": [610,231,26,26],
+     "leds": [10],
+     "label": "O"
+    },
+    {
+     "name": "KeyL",
+     "rect": [618,259,26,26],
+     "leds": [11],
+     "label": "L"
+    },
+    {
+     "name": "KeyComma",
+     "rect": [600,287,26,26],
+     "leds": [12],
+     "label": ";"
+    },
+    {
+     "name": "KeyWinR",
+     "rect": [696,315,26,26],
+     "leds": [13,14],
+     "label": "<"
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [765,336,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [396,166,26,26],
+     "leds": [16],
+     "label": "F1"
+    },
+    {
+     "name": "Key1",
+     "rect": [368,203,26,26],
+     "leds": [17],
+     "label": "1"
+    },
+    {
+     "name": "KeyQ",
+     "rect": [385,231,26,26],
+     "leds": [18],
+     "label": "Q"
+    },
+    {
+     "name": "KeyA",
+     "rect": [394,259,26,26],
+     "leds": [19,20],
+     "label": "k45"
+    },
+    {
+     "name": "KeyWinL",
+     "rect": [377,315,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,166,26,26],
+     "leds": [22,23],
+     "label": "DRUCK"
+    },
+    {
+     "name": "KeyF10",
+     "rect": [677,166,26,26],
+     "leds": [24],
+     "label": "F10"
+    },
+    {
+     "name": "Key0",
+     "rect": [621,203,26,26],
+     "leds": [25],
+     "label": "0"
+    },
+    {
+     "name": "KeyP",
+     "rect": [638,231,26,26],
+     "leds": [26],
+     "label": "P"
+    },
+    {
+     "name": "KeyColon",
+     "rect": [647,259,26,26],
+     "leds": [27],
+     "label": "\u00d6"
+    },
+    {
+     "name": "KeyDot",
+     "rect": [628,287,26,26],
+     "leds": [28,29],
+     "label": ":"
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [703,259,57,26],
+     "leds": [30]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [793,336,26,26],
+     "leds": [31]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,166,26,26],
+     "leds": [32],
+     "label": "F2"
+    },
+    {
+     "name": "Key2",
+     "rect": [396,203,26,26],
+     "leds": [33],
+     "label": "2"
+    },
+    {
+     "name": "KeyW",
+     "rect": [413,231,26,26],
+     "leds": [34],
+     "label": "W"
+    },
+    {
+     "name": "KeyS",
+     "rect": [422,259,26,26],
+     "leds": [35],
+     "label": "S"
+    },
+    {
+     "name": "KeyZ",
+     "rect": [403,287,26,26],
+     "leds": [36],
+     "label": "Z"
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [405,315,36,26],
+     "leds": [37],
+     "label": "ALT"
+    },
+    {
+     "name": "KeyScLock",
+     "rect": [793,166,26,26],
+     "leds": [38],
+     "label": "ROLLEN"
+    },
+    {
+     "name": "KeyBack",
+     "rect": [705,203,54,26],
+     "leds": [39]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [705,166,26,26],
+     "leds": [40],
+     "label": "F11"
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [649,203,26,26],
+     "leds": [41],
+     "label": "?"
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [666,231,26,26],
+     "leds": [42],
+     "label": "\u00dc"
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [675,259,26,26],
+     "leds": [43],
+     "label": "\u00c4"
+    },
+    {
+     "name": "KeySlash",
+     "rect": [656,287,26,26],
+     "leds": [44,45,46],
+     "label": "k56"
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [821,336,26,26],
+     "leds": [47]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [452,166,26,26],
+     "leds": [48],
+     "label": "F3"
+    },
+    {
+     "name": "Key3",
+     "rect": [424,203,26,26],
+     "leds": [49],
+     "label": "3"
+    },
+    {
+     "name": "KeyE",
+     "rect": [441,231,26,26],
+     "leds": [50],
+     "label": "E"
+    },
+    {
+     "name": "KeyD",
+     "rect": [450,259,26,26],
+     "leds": [51],
+     "label": "D"
+    },
+    {
+     "name": "KeyX",
+     "rect": [431,287,26,26],
+     "leds": [52,53],
+     "label": "X"
+    },
+    {
+     "name": "KeyPause",
+     "rect": [821,166,26,26],
+     "leds": [54],
+     "label": "PAUSE"
+    },
+    {
+     "name": "KeyDel",
+     "rect": [765,231,26,26],
+     "leds": [55,56],
+     "label": "ENTF"
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [854,231,26,26],
+     "leds": [57],
+     "label": "7"
+    },
+    {
+     "name": "KeyP1",
+     "rect": [304,203,26,26],
+     "leds": [58,59],
+     "label": "P1"
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [854,203,26,26],
+     "leds": [60],
+     "label": "num\u2193"
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [910,259,26,26],
+     "leds": [61,62,63],
+     "label": "6"
+    },
+    {
+     "name": "KeyF4",
+     "rect": [480,166,26,26],
+     "leds": [64],
+     "label": "F4"
+    },
+    {
+     "name": "Key4",
+     "rect": [452,203,26,26],
+     "leds": [65],
+     "label": "4"
+    },
+    {
+     "name": "KeyR",
+     "rect": [469,231,26,26],
+     "leds": [66],
+     "label": "R"
+    },
+    {
+     "name": "KeyF",
+     "rect": [478,259,26,26],
+     "leds": [67],
+     "label": "F"
+    },
+    {
+     "name": "KeyC",
+     "rect": [459,287,26,26],
+     "leds": [68],
+     "label": "C"
+    },
+    {
+     "name": "KeySpace",
+     "rect": [443,315,185,46],
+     "leds": [69]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [765,203,26,26],
+     "leds": [70],
+     "label": "EINFG"
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [793,231,26,26],
+     "leds": [71,72],
+     "label": "ENDE"
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [882,231,26,26],
+     "leds": [73],
+     "label": "8"
+    },
+    {
+     "name": "KeyP2",
+     "rect": [304,231,26,26],
+     "leds": [74,75],
+     "label": "P2"
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [882,203,26,26],
+     "leds": [76],
+     "label": "\u00f7"
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [854,287,26,26],
+     "leds": [77,78,79],
+     "label": "1"
+    },
+    {
+     "name": "KeyF5",
+     "rect": [522,166,26,26],
+     "leds": [80],
+     "label": "F5"
+    },
+    {
+     "name": "Key5",
+     "rect": [480,203,26,26],
+     "leds": [81],
+     "label": "5"
+    },
+    {
+     "name": "KeyT",
+     "rect": [497,231,26,26],
+     "leds": [82],
+     "label": "T"
+    },
+    {
+     "name": "KeyG",
+     "rect": [506,259,26,26],
+     "leds": [83],
+     "label": "G"
+    },
+    {
+     "name": "KeyV",
+     "rect": [487,287,26,26],
+     "leds": [84,85],
+     "label": "V"
+    },
+    {
+     "name": "KeyHome",
+     "rect": [793,203,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [821,231,26,26],
+     "leds": [87],
+     "label": "BILD\u2193"
+    },
+    {
+     "name": "KeyStop",
+     "rect": [882,166,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [910,231,26,26],
+     "leds": [89],
+     "label": "9"
+    },
+    {
+     "name": "KeyP3",
+     "rect": [304,259,26,26],
+     "leds": [90,91],
+     "label": "P3"
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [910,203,26,26],
+     "leds": [92],
+     "label": "x"
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [882,287,26,26],
+     "leds": [93,94,95],
+     "label": "2"
+    },
+    {
+     "name": "KeyF6",
+     "rect": [550,166,26,26],
+     "leds": [96],
+     "label": "F6"
+    },
+    {
+     "name": "Key6",
+     "rect": [508,203,26,26],
+     "leds": [97],
+     "label": "6"
+    },
+    {
+     "name": "KeyY",
+     "rect": [526,231,26,26],
+     "leds": [98],
+     "label": "Y"
+    },
+    {
+     "name": "KeyH",
+     "rect": [534,259,26,26],
+     "leds": [99],
+     "label": "H"
+    },
+    {
+     "name": "KeyB",
+     "rect": [515,287,26,26],
+     "leds": [100,101],
+     "label": "B"
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [821,203,26,26],
+     "leds": [102],
+     "label": "BILD\u2191"
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [684,287,76,26],
+     "leds": [103]
+    },
+    {
+     "name": "KeyPreTrack",
+     "rect": [910,166,26,26],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [304,287,26,26],
+     "leds": [106,107],
+     "label": "P4"
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [938,203,26,26],
+     "leds": [108],
+     "label": "-"
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [910,287,26,26],
+     "leds": [109,110,111],
+     "label": "3"
+    },
+    {
+     "name": "KeyF7",
+     "rect": [578,166,26,26],
+     "leds": [112],
+     "label": "F7"
+    },
+    {
+     "name": "Key7",
+     "rect": [537,203,26,26],
+     "leds": [113],
+     "label": "7"
+    },
+    {
+     "name": "KeyU",
+     "rect": [554,231,26,26],
+     "leds": [114],
+     "label": "U"
+    },
+    {
+     "name": "KeyJ",
+     "rect": [562,259,26,26],
+     "leds": [115],
+     "label": "J"
+    },
+    {
+     "name": "KeyN",
+     "rect": [543,287,26,26],
+     "leds": [116],
+     "label": "N"
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [630,315,36,26],
+     "leds": [117],
+     "label": "ALT\r GR"
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [694,231,26,26],
+     "leds": [118],
+     "label": "+"
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [724,315,36,26],
+     "leds": [119],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyPlay",
+     "rect": [854,166,26,26],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [854,259,26,26],
+     "leds": [121],
+     "label": "4"
+    },
+    {
+     "name": "KeyP5",
+     "rect": [304,315,26,26],
+     "leds": [122,123],
+     "label": "P5"
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [938,231,26,54],
+     "leds": [124],
+     "label": "+"
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [854,315,54,26],
+     "leds": [125,126,127],
+     "label": "0"
+    },
+    {
+     "name": "KeyF8",
+     "rect": [607,166,26,26],
+     "leds": [128],
+     "label": "F8"
+    },
+    {
+     "name": "Key8",
+     "rect": [565,203,26,26],
+     "leds": [129],
+     "label": "8"
+    },
+    {
+     "name": "KeyI",
+     "rect": [582,231,26,26],
+     "leds": [130],
+     "label": "I"
+    },
+    {
+     "name": "KeyK",
+     "rect": [590,259,26,26],
+     "leds": [131],
+     "label": "K"
+    },
+    {
+     "name": "KeyM",
+     "rect": [572,287,26,26],
+     "leds": [132],
+     "label": "M"
+    },
+    {
+     "name": "KeyFn",
+     "rect": [668,315,26,26],
+     "leds": [133],
+     "label": "FN"
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [722,231,37,26],
+     "leds": [134],
+     "label": "#"
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [793,307,26,26],
+     "leds": [135]
+    },
+    {
+     "name": "KeyNextTrack",
+     "rect": [938,166,26,26],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [882,259,26,26],
+     "leds": [137,138,139],
+     "label": "5"
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [938,287,26,54],
+     "leds": [140],
+     "label": "ENTER"
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [910,315,26,26],
+     "leds": [141],
+     "label": "."
+    }
+   ]
+  },
+  "Accessory/Global": {
+   "id": "Accessory/Global",
+   "leds": 142,
+   "bounds": [304,166,964,426],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [340,166,26,26],
+     "leds": [0],
+     "label": "ESC"
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [340,203,26,26],
+     "leds": [1],
+     "label": "`"
+    },
+    {
+     "name": "KeyTab",
+     "rect": [340,231,43,26],
+     "leds": [2],
+     "label": "TAB"
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [340,259,52,26],
+     "leds": [3],
+     "label": "CAPS"
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [340,287,61,26],
+     "leds": [4],
+     "label": "SHIFT"
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [340,315,36,26],
+     "leds": [5],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyF12",
+     "rect": [733,166,26,26],
+     "leds": [6],
+     "label": "F12"
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [677,203,26,26],
+     "leds": [7],
+     "label": "="
+    },
+    {
+     "name": "KeyF9",
+     "rect": [649,166,26,26],
+     "leds": [8],
+     "label": "F9"
+    },
+    {
+     "name": "Key9",
+     "rect": [593,203,26,26],
+     "leds": [9],
+     "label": "9"
+    },
+    {
+     "name": "KeyO",
+     "rect": [610,231,26,26],
+     "leds": [10],
+     "label": "O"
+    },
+    {
+     "name": "KeyL",
+     "rect": [618,259,26,26],
+     "leds": [11],
+     "label": "L"
+    },
+    {
+     "name": "KeyComma",
+     "rect": [600,287,26,26],
+     "leds": [12],
+     "label": ","
+    },
+    {
+     "name": "KeyWinR",
+     "rect": [696,315,26,26],
+     "leds": [13,14]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [765,336,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [396,166,26,26],
+     "leds": [16],
+     "label": "F1"
+    },
+    {
+     "name": "Key1",
+     "rect": [368,203,26,26],
+     "leds": [17],
+     "label": "1"
+    },
+    {
+     "name": "KeyQ",
+     "rect": [385,231,26,26],
+     "leds": [18],
+     "label": "Q"
+    },
+    {
+     "name": "KeyA",
+     "rect": [394,259,26,26],
+     "leds": [19,20],
+     "label": "k45"
+    },
+    {
+     "name": "KeyWinL",
+     "rect": [377,315,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,166,26,26],
+     "leds": [22,23],
+     "label": "PRT\rSC"
+    },
+    {
+     "name": "KeyF10",
+     "rect": [677,166,26,26],
+     "leds": [24],
+     "label": "F10"
+    },
+    {
+     "name": "Key0",
+     "rect": [621,203,26,26],
+     "leds": [25],
+     "label": "0"
+    },
+    {
+     "name": "KeyP",
+     "rect": [638,231,26,26],
+     "leds": [26],
+     "label": "P"
+    },
+    {
+     "name": "KeyColon",
+     "rect": [647,259,26,26],
+     "leds": [27],
+     "label": ";"
+    },
+    {
+     "name": "KeyDot",
+     "rect": [628,287,26,26],
+     "leds": [28,29],
+     "label": "."
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [703,259,57,26],
+     "leds": [30],
+     "label": "ENTER"
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [793,336,26,26],
+     "leds": [31]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,166,26,26],
+     "leds": [32],
+     "label": "F2"
+    },
+    {
+     "name": "Key2",
+     "rect": [396,203,26,26],
+     "leds": [33],
+     "label": "2"
+    },
+    {
+     "name": "KeyW",
+     "rect": [413,231,26,26],
+     "leds": [34],
+     "label": "W"
+    },
+    {
+     "name": "KeyS",
+     "rect": [422,259,26,26],
+     "leds": [35],
+     "label": "S"
+    },
+    {
+     "name": "KeyZ",
+     "rect": [403,287,26,26],
+     "leds": [36],
+     "label": "Z"
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [405,315,36,26],
+     "leds": [37],
+     "label": "ALT"
+    },
+    {
+     "name": "KeyScLock",
+     "rect": [793,166,26,26],
+     "leds": [38],
+     "label": "SC\rLOCK"
+    },
+    {
+     "name": "KeyBack",
+     "rect": [705,203,54,26],
+     "leds": [39],
+     "label": "BACKSPACE"
+    },
+    {
+     "name": "KeyF11",
+     "rect": [705,166,26,26],
+     "leds": [40],
+     "label": "F11"
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [649,203,26,26],
+     "leds": [41],
+     "label": "-"
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [666,231,26,26],
+     "leds": [42],
+     "label": "["
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [675,259,26,26],
+     "leds": [43],
+     "label": "'"
+    },
+    {
+     "name": "KeySlash",
+     "rect": [656,287,26,26],
+     "leds": [44,45,46],
+     "label": "k56"
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [821,336,26,26],
+     "leds": [47]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [452,166,26,26],
+     "leds": [48],
+     "label": "F3"
+    },
+    {
+     "name": "Key3",
+     "rect": [424,203,26,26],
+     "leds": [49],
+     "label": "3"
+    },
+    {
+     "name": "KeyE",
+     "rect": [441,231,26,26],
+     "leds": [50],
+     "label": "E"
+    },
+    {
+     "name": "KeyD",
+     "rect": [450,259,26,26],
+     "leds": [51],
+     "label": "D"
+    },
+    {
+     "name": "KeyX",
+     "rect": [431,287,26,26],
+     "leds": [52,53],
+     "label": "X"
+    },
+    {
+     "name": "KeyPause",
+     "rect": [821,166,26,26],
+     "leds": [54],
+     "label": "PAUSE"
+    },
+    {
+     "name": "KeyDel",
+     "rect": [765,231,26,26],
+     "leds": [55,56],
+     "label": "DELETE"
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [854,231,26,26],
+     "leds": [57],
+     "label": "7"
+    },
+    {
+     "name": "KeyP1",
+     "rect": [304,203,26,26],
+     "leds": [58,59],
+     "label": "P1"
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [854,203,26,26],
+     "leds": [60],
+     "label": "NUM\rLOCK"
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [910,259,26,26],
+     "leds": [61,62,63],
+     "label": "6"
+    },
+    {
+     "name": "KeyF4",
+     "rect": [480,166,26,26],
+     "leds": [64],
+     "label": "F4"
+    },
+    {
+     "name": "Key4",
+     "rect": [452,203,26,26],
+     "leds": [65],
+     "label": "4"
+    },
+    {
+     "name": "KeyR",
+     "rect": [469,231,26,26],
+     "leds": [66],
+     "label": "R"
+    },
+    {
+     "name": "KeyF",
+     "rect": [478,259,26,26],
+     "leds": [67],
+     "label": "F"
+    },
+    {
+     "name": "KeyC",
+     "rect": [459,287,26,26],
+     "leds": [68],
+     "label": "C"
+    },
+    {
+     "name": "KeySpace",
+     "rect": [443,315,185,46],
+     "leds": [69]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [765,203,26,26],
+     "leds": [70],
+     "label": "INSERT"
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [793,231,26,26],
+     "leds": [71,72],
+     "label": "END"
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [882,231,26,26],
+     "leds": [73],
+     "label": "8"
+    },
+    {
+     "name": "KeyP2",
+     "rect": [304,231,26,26],
+     "leds": [74,75],
+     "label": "P2"
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [882,203,26,26],
+     "leds": [76],
+     "label": "/"
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [854,287,26,26],
+     "leds": [77,78,79],
+     "label": "1"
+    },
+    {
+     "name": "KeyF5",
+     "rect": [522,166,26,26],
+     "leds": [80],
+     "label": "F5"
+    },
+    {
+     "name": "Key5",
+     "rect": [480,203,26,26],
+     "leds": [81],
+     "label": "5"
+    },
+    {
+     "name": "KeyT",
+     "rect": [497,231,26,26],
+     "leds": [82],
+     "label": "T"
+    },
+    {
+     "name": "KeyG",
+     "rect": [506,259,26,26],
+     "leds": [83],
+     "label": "G"
+    },
+    {
+     "name": "KeyV",
+     "rect": [487,287,26,26],
+     "leds": [84,85],
+     "label": "V"
+    },
+    {
+     "name": "KeyHome",
+     "rect": [793,203,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [821,231,26,26],
+     "leds": [87],
+     "label": "PG\rDN"
+    },
+    {
+     "name": "KeyStop",
+     "rect": [882,166,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [910,231,26,26],
+     "leds": [89],
+     "label": "9"
+    },
+    {
+     "name": "KeyP3",
+     "rect": [304,259,26,26],
+     "leds": [90,91],
+     "label": "P3"
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [910,203,26,26],
+     "leds": [92],
+     "label": "*"
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [882,287,26,26],
+     "leds": [93,94,95],
+     "label": "2"
+    },
+    {
+     "name": "KeyF6",
+     "rect": [550,166,26,26],
+     "leds": [96],
+     "label": "F6"
+    },
+    {
+     "name": "Key6",
+     "rect": [508,203,26,26],
+     "leds": [97],
+     "label": "6"
+    },
+    {
+     "name": "KeyY",
+     "rect": [526,231,26,26],
+     "leds": [98],
+     "label": "Y"
+    },
+    {
+     "name": "KeyH",
+     "rect": [534,259,26,26],
+     "leds": [99],
+     "label": "H"
+    },
+    {
+     "name": "KeyB",
+     "rect": [515,287,26,26],
+     "leds": [100,101],
+     "label": "B"
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [821,203,26,26],
+     "leds": [102],
+     "label": "PG\rUP"
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [684,287,76,26],
+     "leds": [103],
+     "label": "SHIFT"
+    },
+    {
+     "name": "KeyPreTrack",
+     "rect": [910,166,26,26],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [304,287,26,26],
+     "leds": [106,107],
+     "label": "P4"
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [938,203,26,26],
+     "leds": [108],
+     "label": "-"
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [910,287,26,26],
+     "leds": [109,110,111],
+     "label": "3"
+    },
+    {
+     "name": "KeyF7",
+     "rect": [578,166,26,26],
+     "leds": [112],
+     "label": "F7"
+    },
+    {
+     "name": "Key7",
+     "rect": [537,203,26,26],
+     "leds": [113],
+     "label": "7"
+    },
+    {
+     "name": "KeyU",
+     "rect": [554,231,26,26],
+     "leds": [114],
+     "label": "U"
+    },
+    {
+     "name": "KeyJ",
+     "rect": [562,259,26,26],
+     "leds": [115],
+     "label": "J"
+    },
+    {
+     "name": "KeyN",
+     "rect": [543,287,26,26],
+     "leds": [116],
+     "label": "N"
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [630,315,36,26],
+     "leds": [117],
+     "label": "ALT"
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [694,231,26,26],
+     "leds": [118],
+     "label": "]"
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [724,315,36,26],
+     "leds": [119],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyPlay",
+     "rect": [854,166,26,26],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [854,259,26,26],
+     "leds": [121],
+     "label": "4"
+    },
+    {
+     "name": "KeyP5",
+     "rect": [304,315,26,26],
+     "leds": [122,123],
+     "label": "P5"
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [938,231,26,54],
+     "leds": [124],
+     "label": "+"
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [854,315,54,26],
+     "leds": [125,126,127],
+     "label": "0"
+    },
+    {
+     "name": "KeyF8",
+     "rect": [607,166,26,26],
+     "leds": [128],
+     "label": "F8"
+    },
+    {
+     "name": "Key8",
+     "rect": [565,203,26,26],
+     "leds": [129],
+     "label": "8"
+    },
+    {
+     "name": "KeyI",
+     "rect": [582,231,26,26],
+     "leds": [130],
+     "label": "I"
+    },
+    {
+     "name": "KeyK",
+     "rect": [590,259,26,26],
+     "leds": [131],
+     "label": "K"
+    },
+    {
+     "name": "KeyM",
+     "rect": [572,287,26,26],
+     "leds": [132],
+     "label": "M"
+    },
+    {
+     "name": "KeyFn",
+     "rect": [668,315,26,26],
+     "leds": [133],
+     "label": "FN"
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [722,231,37,26],
+     "leds": [134],
+     "label": "\\"
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [793,307,26,26],
+     "leds": [135]
+    },
+    {
+     "name": "KeyNextTrack",
+     "rect": [938,166,26,26],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [882,259,26,26],
+     "leds": [137,138,139],
+     "label": "5"
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [938,287,26,54],
+     "leds": [140],
+     "label": "ENTER"
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [910,315,26,26],
+     "leds": [141],
+     "label": "."
+    }
+   ]
+  },
+  "Accessory/Hebrew": {
+   "id": "Accessory/Hebrew",
+   "leds": 142,
+   "bounds": [304,166,964,426],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [340,166,26,26],
+     "leds": [0],
+     "label": "ESC"
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [340,203,26,26],
+     "leds": [1],
+     "label": "`"
+    },
+    {
+     "name": "KeyTab",
+     "rect": [340,231,43,26],
+     "leds": [2]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [340,259,52,26],
+     "leds": [3],
+     "label": "CAPS"
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [340,287,61,26],
+     "leds": [4]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [340,315,36,26],
+     "leds": [5],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyF12",
+     "rect": [733,166,26,26],
+     "leds": [6],
+     "label": "F12"
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [677,203,26,26],
+     "leds": [7],
+     "label": "="
+    },
+    {
+     "name": "KeyF9",
+     "rect": [649,166,26,26],
+     "leds": [8],
+     "label": "F9"
+    },
+    {
+     "name": "Key9",
+     "rect": [593,203,26,26],
+     "leds": [9],
+     "label": "9"
+    },
+    {
+     "name": "KeyO",
+     "rect": [610,231,26,26],
+     "leds": [10],
+     "label": "O"
+    },
+    {
+     "name": "KeyL",
+     "rect": [618,259,26,26],
+     "leds": [11],
+     "label": "L"
+    },
+    {
+     "name": "KeyComma",
+     "rect": [600,287,26,26],
+     "leds": [12],
+     "label": ","
+    },
+    {
+     "name": "KeyWinR",
+     "rect": [696,315,26,26],
+     "leds": [13,14],
+     "label": "|"
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [765,336,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [396,166,26,26],
+     "leds": [16],
+     "label": "F1"
+    },
+    {
+     "name": "Key1",
+     "rect": [368,203,26,26],
+     "leds": [17],
+     "label": "1"
+    },
+    {
+     "name": "KeyQ",
+     "rect": [385,231,26,26],
+     "leds": [18],
+     "label": "Q"
+    },
+    {
+     "name": "KeyA",
+     "rect": [394,259,26,26],
+     "leds": [19,20],
+     "label": "k45"
+    },
+    {
+     "name": "KeyWinL",
+     "rect": [377,315,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,166,26,26],
+     "leds": [22,23],
+     "label": "PRT\rSC"
+    },
+    {
+     "name": "KeyF10",
+     "rect": [677,166,26,26],
+     "leds": [24],
+     "label": "F10"
+    },
+    {
+     "name": "Key0",
+     "rect": [621,203,26,26],
+     "leds": [25],
+     "label": "0"
+    },
+    {
+     "name": "KeyP",
+     "rect": [638,231,26,26],
+     "leds": [26],
+     "label": "P"
+    },
+    {
+     "name": "KeyColon",
+     "rect": [647,259,26,26],
+     "leds": [27],
+     "label": ";"
+    },
+    {
+     "name": "KeyDot",
+     "rect": [628,287,26,26],
+     "leds": [28,29],
+     "label": "."
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [703,259,57,26],
+     "leds": [30]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [793,336,26,26],
+     "leds": [31]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,166,26,26],
+     "leds": [32],
+     "label": "F2"
+    },
+    {
+     "name": "Key2",
+     "rect": [396,203,26,26],
+     "leds": [33],
+     "label": "2"
+    },
+    {
+     "name": "KeyW",
+     "rect": [413,231,26,26],
+     "leds": [34],
+     "label": "W"
+    },
+    {
+     "name": "KeyS",
+     "rect": [422,259,26,26],
+     "leds": [35],
+     "label": "S"
+    },
+    {
+     "name": "KeyZ",
+     "rect": [403,287,26,26],
+     "leds": [36],
+     "label": "Z"
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [405,315,36,26],
+     "leds": [37],
+     "label": "ALT"
+    },
+    {
+     "name": "KeyScLock",
+     "rect": [793,166,26,26],
+     "leds": [38],
+     "label": "SC\rLOCK"
+    },
+    {
+     "name": "KeyBack",
+     "rect": [705,203,54,26],
+     "leds": [39]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [705,166,26,26],
+     "leds": [40],
+     "label": "F11"
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [649,203,26,26],
+     "leds": [41],
+     "label": "-"
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [666,231,26,26],
+     "leds": [42],
+     "label": "["
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [675,259,26,26],
+     "leds": [43],
+     "label": "'"
+    },
+    {
+     "name": "KeySlash",
+     "rect": [656,287,26,26],
+     "leds": [44,45,46],
+     "label": "k56"
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [821,336,26,26],
+     "leds": [47]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [452,166,26,26],
+     "leds": [48],
+     "label": "F3"
+    },
+    {
+     "name": "Key3",
+     "rect": [424,203,26,26],
+     "leds": [49],
+     "label": "3"
+    },
+    {
+     "name": "KeyE",
+     "rect": [441,231,26,26],
+     "leds": [50],
+     "label": "E"
+    },
+    {
+     "name": "KeyD",
+     "rect": [450,259,26,26],
+     "leds": [51],
+     "label": "D"
+    },
+    {
+     "name": "KeyX",
+     "rect": [431,287,26,26],
+     "leds": [52,53],
+     "label": "X"
+    },
+    {
+     "name": "KeyPause",
+     "rect": [821,166,26,26],
+     "leds": [54],
+     "label": "PAUSE"
+    },
+    {
+     "name": "KeyDel",
+     "rect": [765,231,26,26],
+     "leds": [55,56],
+     "label": "DELETE"
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [854,231,26,26],
+     "leds": [57],
+     "label": "7"
+    },
+    {
+     "name": "KeyP1",
+     "rect": [304,203,26,26],
+     "leds": [58,59],
+     "label": "P1"
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [854,203,26,26],
+     "leds": [60],
+     "label": "NUM\rLOCK"
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [910,259,26,26],
+     "leds": [61,62,63],
+     "label": "6"
+    },
+    {
+     "name": "KeyF4",
+     "rect": [480,166,26,26],
+     "leds": [64],
+     "label": "F4"
+    },
+    {
+     "name": "Key4",
+     "rect": [452,203,26,26],
+     "leds": [65],
+     "label": "4"
+    },
+    {
+     "name": "KeyR",
+     "rect": [469,231,26,26],
+     "leds": [66],
+     "label": "R"
+    },
+    {
+     "name": "KeyF",
+     "rect": [478,259,26,26],
+     "leds": [67],
+     "label": "F"
+    },
+    {
+     "name": "KeyC",
+     "rect": [459,287,26,26],
+     "leds": [68],
+     "label": "C"
+    },
+    {
+     "name": "KeySpace",
+     "rect": [443,315,185,46],
+     "leds": [69]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [765,203,26,26],
+     "leds": [70],
+     "label": "INSERT"
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [793,231,26,26],
+     "leds": [71,72],
+     "label": "END"
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [882,231,26,26],
+     "leds": [73],
+     "label": "8"
+    },
+    {
+     "name": "KeyP2",
+     "rect": [304,231,26,26],
+     "leds": [74,75],
+     "label": "P2"
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [882,203,26,26],
+     "leds": [76],
+     "label": "/"
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [854,287,26,26],
+     "leds": [77,78,79],
+     "label": "1"
+    },
+    {
+     "name": "KeyF5",
+     "rect": [522,166,26,26],
+     "leds": [80],
+     "label": "F5"
+    },
+    {
+     "name": "Key5",
+     "rect": [480,203,26,26],
+     "leds": [81],
+     "label": "5"
+    },
+    {
+     "name": "KeyT",
+     "rect": [497,231,26,26],
+     "leds": [82],
+     "label": "T"
+    },
+    {
+     "name": "KeyG",
+     "rect": [506,259,26,26],
+     "leds": [83],
+     "label": "G"
+    },
+    {
+     "name": "KeyV",
+     "rect": [487,287,26,26],
+     "leds": [84,85],
+     "label": "V"
+    },
+    {
+     "name": "KeyHome",
+     "rect": [793,203,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [821,231,26,26],
+     "leds": [87],
+     "label": "PG\rDN"
+    },
+    {
+     "name": "KeyStop",
+     "rect": [882,166,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [910,231,26,26],
+     "leds": [89],
+     "label": "9"
+    },
+    {
+     "name": "KeyP3",
+     "rect": [304,259,26,26],
+     "leds": [90,91],
+     "label": "P3"
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [910,203,26,26],
+     "leds": [92],
+     "label": "*"
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [882,287,26,26],
+     "leds": [93,94,95],
+     "label": "2"
+    },
+    {
+     "name": "KeyF6",
+     "rect": [550,166,26,26],
+     "leds": [96],
+     "label": "F6"
+    },
+    {
+     "name": "Key6",
+     "rect": [508,203,26,26],
+     "leds": [97],
+     "label": "6"
+    },
+    {
+     "name": "KeyY",
+     "rect": [526,231,26,26],
+     "leds": [98],
+     "label": "Y"
+    },
+    {
+     "name": "KeyH",
+     "rect": [534,259,26,26],
+     "leds": [99],
+     "label": "H"
+    },
+    {
+     "name": "KeyB",
+     "rect": [515,287,26,26],
+     "leds": [100,101],
+     "label": "B"
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [821,203,26,26],
+     "leds": [102],
+     "label": "PG\rUP"
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [684,287,76,26],
+     "leds": [103]
+    },
+    {
+     "name": "KeyPreTrack",
+     "rect": [910,166,26,26],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [304,287,26,26],
+     "leds": [106,107],
+     "label": "P4"
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [938,203,26,26],
+     "leds": [108],
+     "label": "-"
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [910,287,26,26],
+     "leds": [109,110,111],
+     "label": "3"
+    },
+    {
+     "name": "KeyF7",
+     "rect": [578,166,26,26],
+     "leds": [112],
+     "label": "F7"
+    },
+    {
+     "name": "Key7",
+     "rect": [537,203,26,26],
+     "leds": [113],
+     "label": "7"
+    },
+    {
+     "name": "KeyU",
+     "rect": [554,231,26,26],
+     "leds": [114],
+     "label": "U"
+    },
+    {
+     "name": "KeyJ",
+     "rect": [562,259,26,26],
+     "leds": [115],
+     "label": "J"
+    },
+    {
+     "name": "KeyN",
+     "rect": [543,287,26,26],
+     "leds": [116],
+     "label": "N"
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [630,315,36,26],
+     "leds": [117],
+     "label": "ALT\r GR"
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [694,231,26,26],
+     "leds": [118],
+     "label": "]"
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [724,315,36,26],
+     "leds": [119],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyPlay",
+     "rect": [854,166,26,26],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [854,259,26,26],
+     "leds": [121],
+     "label": "4"
+    },
+    {
+     "name": "KeyP5",
+     "rect": [304,315,26,26],
+     "leds": [122,123],
+     "label": "P5"
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [938,231,26,54],
+     "leds": [124],
+     "label": "+"
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [854,315,54,26],
+     "leds": [125,126,127],
+     "label": "0"
+    },
+    {
+     "name": "KeyF8",
+     "rect": [607,166,26,26],
+     "leds": [128],
+     "label": "F8"
+    },
+    {
+     "name": "Key8",
+     "rect": [565,203,26,26],
+     "leds": [129],
+     "label": "8"
+    },
+    {
+     "name": "KeyI",
+     "rect": [582,231,26,26],
+     "leds": [130],
+     "label": "I"
+    },
+    {
+     "name": "KeyK",
+     "rect": [590,259,26,26],
+     "leds": [131],
+     "label": "K"
+    },
+    {
+     "name": "KeyM",
+     "rect": [572,287,26,26],
+     "leds": [132],
+     "label": "M"
+    },
+    {
+     "name": "KeyFn",
+     "rect": [668,315,26,26],
+     "leds": [133],
+     "label": "FN"
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [722,231,37,26],
+     "leds": [134],
+     "label": "\\"
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [793,307,26,26],
+     "leds": [135]
+    },
+    {
+     "name": "KeyNextTrack",
+     "rect": [938,166,26,26],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [882,259,26,26],
+     "leds": [137,138,139],
+     "label": "5"
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [938,287,26,54],
+     "leds": [140]
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [910,315,26,26],
+     "leds": [141],
+     "label": "."
+    }
+   ]
+  },
+  "Accessory/Italian": {
+   "id": "Accessory/Italian",
+   "leds": 142,
+   "bounds": [304,166,964,426],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [340,166,26,26],
+     "leds": [0],
+     "label": "ESC"
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [340,203,26,26],
+     "leds": [1],
+     "label": "\\"
+    },
+    {
+     "name": "KeyTab",
+     "rect": [340,231,43,26],
+     "leds": [2]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [340,259,52,26],
+     "leds": [3],
+     "label": "CAPS"
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [340,287,61,26],
+     "leds": [4]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [340,315,36,26],
+     "leds": [5],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyF12",
+     "rect": [733,166,26,26],
+     "leds": [6],
+     "label": "F12"
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [677,203,26,26],
+     "leds": [7],
+     "label": "\u00cc"
+    },
+    {
+     "name": "KeyF9",
+     "rect": [649,166,26,26],
+     "leds": [8],
+     "label": "F9"
+    },
+    {
+     "name": "Key9",
+     "rect": [593,203,26,26],
+     "leds": [9],
+     "label": "9"
+    },
+    {
+     "name": "KeyO",
+     "rect": [610,231,26,26],
+     "leds": [10],
+     "label": "O"
+    },
+    {
+     "name": "KeyL",
+     "rect": [618,259,26,26],
+     "leds": [11],
+     "label": "L"
+    },
+    {
+     "name": "KeyComma",
+     "rect": [600,287,26,26],
+     "leds": [12],
+     "label": ","
+    },
+    {
+     "name": "KeyWinR",
+     "rect": [696,315,26,26],
+     "leds": [13,14],
+     "label": "<"
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [765,336,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [396,166,26,26],
+     "leds": [16],
+     "label": "F1"
+    },
+    {
+     "name": "Key1",
+     "rect": [368,203,26,26],
+     "leds": [17],
+     "label": "1"
+    },
+    {
+     "name": "KeyQ",
+     "rect": [385,231,26,26],
+     "leds": [18],
+     "label": "Q"
+    },
+    {
+     "name": "KeyA",
+     "rect": [394,259,26,26],
+     "leds": [19,20],
+     "label": "k45"
+    },
+    {
+     "name": "KeyWinL",
+     "rect": [377,315,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,166,26,26],
+     "leds": [22,23],
+     "label": "STAMP"
+    },
+    {
+     "name": "KeyF10",
+     "rect": [677,166,26,26],
+     "leds": [24],
+     "label": "F10"
+    },
+    {
+     "name": "Key0",
+     "rect": [621,203,26,26],
+     "leds": [25],
+     "label": "0"
+    },
+    {
+     "name": "KeyP",
+     "rect": [638,231,26,26],
+     "leds": [26],
+     "label": "P"
+    },
+    {
+     "name": "KeyColon",
+     "rect": [647,259,26,26],
+     "leds": [27],
+     "label": "\u00d2"
+    },
+    {
+     "name": "KeyDot",
+     "rect": [628,287,26,26],
+     "leds": [28,29],
+     "label": "."
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [703,259,57,26],
+     "leds": [30]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [793,336,26,26],
+     "leds": [31]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,166,26,26],
+     "leds": [32],
+     "label": "F2"
+    },
+    {
+     "name": "Key2",
+     "rect": [396,203,26,26],
+     "leds": [33],
+     "label": "2"
+    },
+    {
+     "name": "KeyW",
+     "rect": [413,231,26,26],
+     "leds": [34],
+     "label": "W"
+    },
+    {
+     "name": "KeyS",
+     "rect": [422,259,26,26],
+     "leds": [35],
+     "label": "S"
+    },
+    {
+     "name": "KeyZ",
+     "rect": [403,287,26,26],
+     "leds": [36],
+     "label": "Z"
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [405,315,36,26],
+     "leds": [37],
+     "label": "ALT"
+    },
+    {
+     "name": "KeyScLock",
+     "rect": [793,166,26,26],
+     "leds": [38],
+     "label": "BLOC\rSCORR"
+    },
+    {
+     "name": "KeyBack",
+     "rect": [705,203,54,26],
+     "leds": [39]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [705,166,26,26],
+     "leds": [40],
+     "label": "F11"
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [649,203,26,26],
+     "leds": [41],
+     "label": "-"
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [666,231,26,26],
+     "leds": [42],
+     "label": "\u00c8"
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [675,259,26,26],
+     "leds": [43],
+     "label": "\u00c0"
+    },
+    {
+     "name": "KeySlash",
+     "rect": [656,287,26,26],
+     "leds": [44,45,46],
+     "label": "k56"
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [821,336,26,26],
+     "leds": [47]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [452,166,26,26],
+     "leds": [48],
+     "label": "F3"
+    },
+    {
+     "name": "Key3",
+     "rect": [424,203,26,26],
+     "leds": [49],
+     "label": "3"
+    },
+    {
+     "name": "KeyE",
+     "rect": [441,231,26,26],
+     "leds": [50],
+     "label": "E"
+    },
+    {
+     "name": "KeyD",
+     "rect": [450,259,26,26],
+     "leds": [51],
+     "label": "D"
+    },
+    {
+     "name": "KeyX",
+     "rect": [431,287,26,26],
+     "leds": [52,53],
+     "label": "X"
+    },
+    {
+     "name": "KeyPause",
+     "rect": [821,166,26,26],
+     "leds": [54],
+     "label": "PAUSA"
+    },
+    {
+     "name": "KeyDel",
+     "rect": [765,231,26,26],
+     "leds": [55,56],
+     "label": "CANC"
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [854,231,26,26],
+     "leds": [57],
+     "label": "7"
+    },
+    {
+     "name": "KeyP1",
+     "rect": [304,203,26,26],
+     "leds": [58,59],
+     "label": "P1"
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [854,203,26,26],
+     "leds": [60],
+     "label": "BLOC\rNUM"
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [910,259,26,26],
+     "leds": [61,62,63],
+     "label": "6"
+    },
+    {
+     "name": "KeyF4",
+     "rect": [480,166,26,26],
+     "leds": [64],
+     "label": "F4"
+    },
+    {
+     "name": "Key4",
+     "rect": [452,203,26,26],
+     "leds": [65],
+     "label": "4"
+    },
+    {
+     "name": "KeyR",
+     "rect": [469,231,26,26],
+     "leds": [66],
+     "label": "R"
+    },
+    {
+     "name": "KeyF",
+     "rect": [478,259,26,26],
+     "leds": [67],
+     "label": "F"
+    },
+    {
+     "name": "KeyC",
+     "rect": [459,287,26,26],
+     "leds": [68],
+     "label": "C"
+    },
+    {
+     "name": "KeySpace",
+     "rect": [443,315,185,46],
+     "leds": [69]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [765,203,26,26],
+     "leds": [70],
+     "label": "INSERT"
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [793,231,26,26],
+     "leds": [71,72],
+     "label": "FINE"
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [882,231,26,26],
+     "leds": [73],
+     "label": "8"
+    },
+    {
+     "name": "KeyP2",
+     "rect": [304,231,26,26],
+     "leds": [74,75],
+     "label": "P2"
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [882,203,26,26],
+     "leds": [76],
+     "label": "/"
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [854,287,26,26],
+     "leds": [77,78,79],
+     "label": "1"
+    },
+    {
+     "name": "KeyF5",
+     "rect": [522,166,26,26],
+     "leds": [80],
+     "label": "F5"
+    },
+    {
+     "name": "Key5",
+     "rect": [480,203,26,26],
+     "leds": [81],
+     "label": "5"
+    },
+    {
+     "name": "KeyT",
+     "rect": [497,231,26,26],
+     "leds": [82],
+     "label": "T"
+    },
+    {
+     "name": "KeyG",
+     "rect": [506,259,26,26],
+     "leds": [83],
+     "label": "G"
+    },
+    {
+     "name": "KeyV",
+     "rect": [487,287,26,26],
+     "leds": [84,85],
+     "label": "V"
+    },
+    {
+     "name": "KeyHome",
+     "rect": [793,203,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [821,231,26,26],
+     "leds": [87],
+     "label": "PAG\u2193"
+    },
+    {
+     "name": "KeyStop",
+     "rect": [882,166,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [910,231,26,26],
+     "leds": [89],
+     "label": "9"
+    },
+    {
+     "name": "KeyP3",
+     "rect": [304,259,26,26],
+     "leds": [90,91],
+     "label": "P3"
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [910,203,26,26],
+     "leds": [92],
+     "label": "*"
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [882,287,26,26],
+     "leds": [93,94,95],
+     "label": "2"
+    },
+    {
+     "name": "KeyF6",
+     "rect": [550,166,26,26],
+     "leds": [96],
+     "label": "F6"
+    },
+    {
+     "name": "Key6",
+     "rect": [508,203,26,26],
+     "leds": [97],
+     "label": "6"
+    },
+    {
+     "name": "KeyY",
+     "rect": [526,231,26,26],
+     "leds": [98],
+     "label": "Y"
+    },
+    {
+     "name": "KeyH",
+     "rect": [534,259,26,26],
+     "leds": [99],
+     "label": "H"
+    },
+    {
+     "name": "KeyB",
+     "rect": [515,287,26,26],
+     "leds": [100,101],
+     "label": "B"
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [821,203,26,26],
+     "leds": [102],
+     "label": "PAG\u2191 "
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [684,287,76,26],
+     "leds": [103]
+    },
+    {
+     "name": "KeyPreTrack",
+     "rect": [910,166,26,26],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [304,287,26,26],
+     "leds": [106,107],
+     "label": "P4"
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [938,203,26,26],
+     "leds": [108],
+     "label": "'"
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [910,287,26,26],
+     "leds": [109,110,111],
+     "label": "3"
+    },
+    {
+     "name": "KeyF7",
+     "rect": [578,166,26,26],
+     "leds": [112],
+     "label": "F7"
+    },
+    {
+     "name": "Key7",
+     "rect": [537,203,26,26],
+     "leds": [113],
+     "label": "7"
+    },
+    {
+     "name": "KeyU",
+     "rect": [554,231,26,26],
+     "leds": [114],
+     "label": "U"
+    },
+    {
+     "name": "KeyJ",
+     "rect": [562,259,26,26],
+     "leds": [115],
+     "label": "J"
+    },
+    {
+     "name": "KeyN",
+     "rect": [543,287,26,26],
+     "leds": [116],
+     "label": "N"
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [630,315,36,26],
+     "leds": [117],
+     "label": "ALT\r GR"
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [694,231,26,26],
+     "leds": [118],
+     "label": "+"
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [724,315,36,26],
+     "leds": [119],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyPlay",
+     "rect": [854,166,26,26],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [854,259,26,26],
+     "leds": [121],
+     "label": "4"
+    },
+    {
+     "name": "KeyP5",
+     "rect": [304,315,26,26],
+     "leds": [122,123],
+     "label": "P5"
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [938,231,26,54],
+     "leds": [124],
+     "label": "+"
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [854,315,54,26],
+     "leds": [125,126,127],
+     "label": "0"
+    },
+    {
+     "name": "KeyF8",
+     "rect": [607,166,26,26],
+     "leds": [128],
+     "label": "F8"
+    },
+    {
+     "name": "Key8",
+     "rect": [565,203,26,26],
+     "leds": [129],
+     "label": "8"
+    },
+    {
+     "name": "KeyI",
+     "rect": [582,231,26,26],
+     "leds": [130],
+     "label": "I"
+    },
+    {
+     "name": "KeyK",
+     "rect": [590,259,26,26],
+     "leds": [131],
+     "label": "K"
+    },
+    {
+     "name": "KeyM",
+     "rect": [572,287,26,26],
+     "leds": [132],
+     "label": "M"
+    },
+    {
+     "name": "KeyFn",
+     "rect": [668,315,26,26],
+     "leds": [133],
+     "label": "FN"
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [722,231,37,26],
+     "leds": [134],
+     "label": "\u00d9"
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [793,307,26,26],
+     "leds": [135]
+    },
+    {
+     "name": "KeyNextTrack",
+     "rect": [938,166,26,26],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [882,259,26,26],
+     "leds": [137,138,139],
+     "label": "5"
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [938,287,26,54],
+     "leds": [140]
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [910,315,26,26],
+     "leds": [141],
+     "label": "."
+    }
+   ]
+  },
+  "Accessory/LatinAmerica": {
+   "id": "Accessory/LatinAmerica",
+   "leds": 142,
+   "bounds": [304,166,964,426],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [340,166,26,26],
+     "leds": [0],
+     "label": "ESC"
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [340,203,26,26],
+     "leds": [1],
+     "label": "|"
+    },
+    {
+     "name": "KeyTab",
+     "rect": [340,231,43,26],
+     "leds": [2]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [340,259,52,26],
+     "leds": [3],
+     "label": "BLOQ\rMAY\u00daS"
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [340,287,61,26],
+     "leds": [4]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [340,315,36,26],
+     "leds": [5],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyF12",
+     "rect": [733,166,26,26],
+     "leds": [6],
+     "label": "F12"
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [677,203,26,26],
+     "leds": [7],
+     "label": "\u00bf"
+    },
+    {
+     "name": "KeyF9",
+     "rect": [649,166,26,26],
+     "leds": [8],
+     "label": "F9"
+    },
+    {
+     "name": "Key9",
+     "rect": [593,203,26,26],
+     "leds": [9],
+     "label": "9"
+    },
+    {
+     "name": "KeyO",
+     "rect": [610,231,26,26],
+     "leds": [10],
+     "label": "O"
+    },
+    {
+     "name": "KeyL",
+     "rect": [618,259,26,26],
+     "leds": [11],
+     "label": "L"
+    },
+    {
+     "name": "KeyComma",
+     "rect": [600,287,26,26],
+     "leds": [12],
+     "label": ","
+    },
+    {
+     "name": "KeyWinR",
+     "rect": [696,315,26,26],
+     "leds": [13,14],
+     "label": "<"
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [765,336,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [396,166,26,26],
+     "leds": [16],
+     "label": "F1"
+    },
+    {
+     "name": "Key1",
+     "rect": [368,203,26,26],
+     "leds": [17],
+     "label": "1"
+    },
+    {
+     "name": "KeyQ",
+     "rect": [385,231,26,26],
+     "leds": [18],
+     "label": "Q"
+    },
+    {
+     "name": "KeyA",
+     "rect": [394,259,26,26],
+     "leds": [19,20],
+     "label": "k45"
+    },
+    {
+     "name": "KeyWinL",
+     "rect": [377,315,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,166,26,26],
+     "leds": [22,23],
+     "label": "IMP\rPNT"
+    },
+    {
+     "name": "KeyF10",
+     "rect": [677,166,26,26],
+     "leds": [24],
+     "label": "F10"
+    },
+    {
+     "name": "Key0",
+     "rect": [621,203,26,26],
+     "leds": [25],
+     "label": "0"
+    },
+    {
+     "name": "KeyP",
+     "rect": [638,231,26,26],
+     "leds": [26],
+     "label": "P"
+    },
+    {
+     "name": "KeyColon",
+     "rect": [647,259,26,26],
+     "leds": [27],
+     "label": "\u00d1"
+    },
+    {
+     "name": "KeyDot",
+     "rect": [628,287,26,26],
+     "leds": [28,29],
+     "label": "."
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [703,259,57,26],
+     "leds": [30]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [793,336,26,26],
+     "leds": [31]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,166,26,26],
+     "leds": [32],
+     "label": "F2"
+    },
+    {
+     "name": "Key2",
+     "rect": [396,203,26,26],
+     "leds": [33],
+     "label": "2"
+    },
+    {
+     "name": "KeyW",
+     "rect": [413,231,26,26],
+     "leds": [34],
+     "label": "W"
+    },
+    {
+     "name": "KeyS",
+     "rect": [422,259,26,26],
+     "leds": [35],
+     "label": "S"
+    },
+    {
+     "name": "KeyZ",
+     "rect": [403,287,26,26],
+     "leds": [36],
+     "label": "Z"
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [405,315,36,26],
+     "leds": [37],
+     "label": "ALT"
+    },
+    {
+     "name": "KeyScLock",
+     "rect": [793,166,26,26],
+     "leds": [38],
+     "label": "SC\rLOCK"
+    },
+    {
+     "name": "KeyBack",
+     "rect": [705,203,54,26],
+     "leds": [39]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [705,166,26,26],
+     "leds": [40],
+     "label": "F11"
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [649,203,26,26],
+     "leds": [41],
+     "label": "'"
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [666,231,26,26],
+     "leds": [42],
+     "label": "'"
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [675,259,26,26],
+     "leds": [43],
+     "label": "{"
+    },
+    {
+     "name": "KeySlash",
+     "rect": [656,287,26,26],
+     "leds": [44,45,46],
+     "label": "k56"
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [821,336,26,26],
+     "leds": [47]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [452,166,26,26],
+     "leds": [48],
+     "label": "F3"
+    },
+    {
+     "name": "Key3",
+     "rect": [424,203,26,26],
+     "leds": [49],
+     "label": "3"
+    },
+    {
+     "name": "KeyE",
+     "rect": [441,231,26,26],
+     "leds": [50],
+     "label": "E"
+    },
+    {
+     "name": "KeyD",
+     "rect": [450,259,26,26],
+     "leds": [51],
+     "label": "D"
+    },
+    {
+     "name": "KeyX",
+     "rect": [431,287,26,26],
+     "leds": [52,53],
+     "label": "X"
+    },
+    {
+     "name": "KeyPause",
+     "rect": [821,166,26,26],
+     "leds": [54],
+     "label": "PAUSA"
+    },
+    {
+     "name": "KeyDel",
+     "rect": [765,231,26,26],
+     "leds": [55,56],
+     "label": "SUPR"
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [854,231,26,26],
+     "leds": [57],
+     "label": "7"
+    },
+    {
+     "name": "KeyP1",
+     "rect": [304,203,26,26],
+     "leds": [58,59],
+     "label": "P1"
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [854,203,26,26],
+     "leds": [60],
+     "label": "NUM\rLOCK"
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [910,259,26,26],
+     "leds": [61,62,63],
+     "label": "6"
+    },
+    {
+     "name": "KeyF4",
+     "rect": [480,166,26,26],
+     "leds": [64],
+     "label": "F4"
+    },
+    {
+     "name": "Key4",
+     "rect": [452,203,26,26],
+     "leds": [65],
+     "label": "4"
+    },
+    {
+     "name": "KeyR",
+     "rect": [469,231,26,26],
+     "leds": [66],
+     "label": "R"
+    },
+    {
+     "name": "KeyF",
+     "rect": [478,259,26,26],
+     "leds": [67],
+     "label": "F"
+    },
+    {
+     "name": "KeyC",
+     "rect": [459,287,26,26],
+     "leds": [68],
+     "label": "C"
+    },
+    {
+     "name": "KeySpace",
+     "rect": [443,315,185,46],
+     "leds": [69]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [765,203,26,26],
+     "leds": [70],
+     "label": "INS"
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [793,231,26,26],
+     "leds": [71,72],
+     "label": "END"
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [882,231,26,26],
+     "leds": [73],
+     "label": "8"
+    },
+    {
+     "name": "KeyP2",
+     "rect": [304,231,26,26],
+     "leds": [74,75],
+     "label": "P2"
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [882,203,26,26],
+     "leds": [76],
+     "label": "/"
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [854,287,26,26],
+     "leds": [77,78,79],
+     "label": "1"
+    },
+    {
+     "name": "KeyF5",
+     "rect": [522,166,26,26],
+     "leds": [80],
+     "label": "F5"
+    },
+    {
+     "name": "Key5",
+     "rect": [480,203,26,26],
+     "leds": [81],
+     "label": "5"
+    },
+    {
+     "name": "KeyT",
+     "rect": [497,231,26,26],
+     "leds": [82],
+     "label": "T"
+    },
+    {
+     "name": "KeyG",
+     "rect": [506,259,26,26],
+     "leds": [83],
+     "label": "G"
+    },
+    {
+     "name": "KeyV",
+     "rect": [487,287,26,26],
+     "leds": [84,85],
+     "label": "V"
+    },
+    {
+     "name": "KeyHome",
+     "rect": [793,203,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [821,231,26,26],
+     "leds": [87],
+     "label": "AVP\u00c1G"
+    },
+    {
+     "name": "KeyStop",
+     "rect": [882,166,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [910,231,26,26],
+     "leds": [89],
+     "label": "9"
+    },
+    {
+     "name": "KeyP3",
+     "rect": [304,259,26,26],
+     "leds": [90,91],
+     "label": "P3"
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [910,203,26,26],
+     "leds": [92],
+     "label": "*"
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [882,287,26,26],
+     "leds": [93,94,95],
+     "label": "2"
+    },
+    {
+     "name": "KeyF6",
+     "rect": [550,166,26,26],
+     "leds": [96],
+     "label": "F6"
+    },
+    {
+     "name": "Key6",
+     "rect": [508,203,26,26],
+     "leds": [97],
+     "label": "6"
+    },
+    {
+     "name": "KeyY",
+     "rect": [526,231,26,26],
+     "leds": [98],
+     "label": "Y"
+    },
+    {
+     "name": "KeyH",
+     "rect": [534,259,26,26],
+     "leds": [99],
+     "label": "H"
+    },
+    {
+     "name": "KeyB",
+     "rect": [515,287,26,26],
+     "leds": [100,101],
+     "label": "B"
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [821,203,26,26],
+     "leds": [102],
+     "label": "REP\u00c1G"
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [684,287,76,26],
+     "leds": [103]
+    },
+    {
+     "name": "KeyPreTrack",
+     "rect": [910,166,26,26],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [304,287,26,26],
+     "leds": [106,107],
+     "label": "P4"
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [938,203,26,26],
+     "leds": [108],
+     "label": "-"
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [910,287,26,26],
+     "leds": [109,110,111],
+     "label": "3"
+    },
+    {
+     "name": "KeyF7",
+     "rect": [578,166,26,26],
+     "leds": [112],
+     "label": "F7"
+    },
+    {
+     "name": "Key7",
+     "rect": [537,203,26,26],
+     "leds": [113],
+     "label": "7"
+    },
+    {
+     "name": "KeyU",
+     "rect": [554,231,26,26],
+     "leds": [114],
+     "label": "U"
+    },
+    {
+     "name": "KeyJ",
+     "rect": [562,259,26,26],
+     "leds": [115],
+     "label": "J"
+    },
+    {
+     "name": "KeyN",
+     "rect": [543,287,26,26],
+     "leds": [116],
+     "label": "N"
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [630,315,36,26],
+     "leds": [117],
+     "label": "ALT\r GR"
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [694,231,26,26],
+     "leds": [118],
+     "label": "+"
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [724,315,36,26],
+     "leds": [119],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyPlay",
+     "rect": [854,166,26,26],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [854,259,26,26],
+     "leds": [121],
+     "label": "4"
+    },
+    {
+     "name": "KeyP5",
+     "rect": [304,315,26,26],
+     "leds": [122,123],
+     "label": "P5"
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [938,231,26,54],
+     "leds": [124],
+     "label": "+"
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [854,315,54,26],
+     "leds": [125,126,127],
+     "label": "0"
+    },
+    {
+     "name": "KeyF8",
+     "rect": [607,166,26,26],
+     "leds": [128],
+     "label": "F8"
+    },
+    {
+     "name": "Key8",
+     "rect": [565,203,26,26],
+     "leds": [129],
+     "label": "8"
+    },
+    {
+     "name": "KeyI",
+     "rect": [582,231,26,26],
+     "leds": [130],
+     "label": "I"
+    },
+    {
+     "name": "KeyK",
+     "rect": [590,259,26,26],
+     "leds": [131],
+     "label": "K"
+    },
+    {
+     "name": "KeyM",
+     "rect": [572,287,26,26],
+     "leds": [132],
+     "label": "M"
+    },
+    {
+     "name": "KeyFn",
+     "rect": [668,315,26,26],
+     "leds": [133],
+     "label": "FN"
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [722,231,37,26],
+     "leds": [134],
+     "label": "}"
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [793,307,26,26],
+     "leds": [135]
+    },
+    {
+     "name": "KeyNextTrack",
+     "rect": [938,166,26,26],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [882,259,26,26],
+     "leds": [137,138,139],
+     "label": "5"
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [938,287,26,54],
+     "leds": [140]
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [910,315,26,26],
+     "leds": [141],
+     "label": "."
+    }
+   ]
+  },
+  "Accessory/Nordic": {
+   "id": "Accessory/Nordic",
+   "leds": 142,
+   "bounds": [304,166,964,426],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [340,166,26,26],
+     "leds": [0],
+     "label": "ESC"
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [340,203,26,26],
+     "leds": [1],
+     "label": "\u00a7"
+    },
+    {
+     "name": "KeyTab",
+     "rect": [340,231,43,26],
+     "leds": [2]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [340,259,52,26],
+     "leds": [3],
+     "label": "CAPS"
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [340,287,61,26],
+     "leds": [4]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [340,315,36,26],
+     "leds": [5],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyF12",
+     "rect": [733,166,26,26],
+     "leds": [6],
+     "label": "F12"
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [677,203,26,26],
+     "leds": [7],
+     "label": "`"
+    },
+    {
+     "name": "KeyF9",
+     "rect": [649,166,26,26],
+     "leds": [8],
+     "label": "F9"
+    },
+    {
+     "name": "Key9",
+     "rect": [593,203,26,26],
+     "leds": [9],
+     "label": "9"
+    },
+    {
+     "name": "KeyO",
+     "rect": [610,231,26,26],
+     "leds": [10],
+     "label": "O"
+    },
+    {
+     "name": "KeyL",
+     "rect": [618,259,26,26],
+     "leds": [11],
+     "label": "L"
+    },
+    {
+     "name": "KeyComma",
+     "rect": [600,287,26,26],
+     "leds": [12],
+     "label": ","
+    },
+    {
+     "name": "KeyWinR",
+     "rect": [696,315,26,26],
+     "leds": [13,14],
+     "label": "<"
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [765,336,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [396,166,26,26],
+     "leds": [16],
+     "label": "F1"
+    },
+    {
+     "name": "Key1",
+     "rect": [368,203,26,26],
+     "leds": [17],
+     "label": "1"
+    },
+    {
+     "name": "KeyQ",
+     "rect": [385,231,26,26],
+     "leds": [18],
+     "label": "Q"
+    },
+    {
+     "name": "KeyA",
+     "rect": [394,259,26,26],
+     "leds": [19,20],
+     "label": "k45"
+    },
+    {
+     "name": "KeyWinL",
+     "rect": [377,315,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,166,26,26],
+     "leds": [22,23],
+     "label": "PRT\rSC"
+    },
+    {
+     "name": "KeyF10",
+     "rect": [677,166,26,26],
+     "leds": [24],
+     "label": "F10"
+    },
+    {
+     "name": "Key0",
+     "rect": [621,203,26,26],
+     "leds": [25],
+     "label": "0"
+    },
+    {
+     "name": "KeyP",
+     "rect": [638,231,26,26],
+     "leds": [26],
+     "label": "P"
+    },
+    {
+     "name": "KeyColon",
+     "rect": [647,259,26,26],
+     "leds": [27],
+     "label": "\u00d6"
+    },
+    {
+     "name": "KeyDot",
+     "rect": [628,287,26,26],
+     "leds": [28,29],
+     "label": "."
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [703,259,57,26],
+     "leds": [30]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [793,336,26,26],
+     "leds": [31]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,166,26,26],
+     "leds": [32],
+     "label": "F2"
+    },
+    {
+     "name": "Key2",
+     "rect": [396,203,26,26],
+     "leds": [33],
+     "label": "2"
+    },
+    {
+     "name": "KeyW",
+     "rect": [413,231,26,26],
+     "leds": [34],
+     "label": "W"
+    },
+    {
+     "name": "KeyS",
+     "rect": [422,259,26,26],
+     "leds": [35],
+     "label": "S"
+    },
+    {
+     "name": "KeyZ",
+     "rect": [403,287,26,26],
+     "leds": [36],
+     "label": "Z"
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [405,315,36,26],
+     "leds": [37],
+     "label": "ALT"
+    },
+    {
+     "name": "KeyScLock",
+     "rect": [793,166,26,26],
+     "leds": [38],
+     "label": "SC\rLOCK"
+    },
+    {
+     "name": "KeyBack",
+     "rect": [705,203,54,26],
+     "leds": [39]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [705,166,26,26],
+     "leds": [40],
+     "label": "F11"
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [649,203,26,26],
+     "leds": [41],
+     "label": "+"
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [666,231,26,26],
+     "leds": [42],
+     "label": "\u00c5"
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [675,259,26,26],
+     "leds": [43],
+     "label": "\u00c4"
+    },
+    {
+     "name": "KeySlash",
+     "rect": [656,287,26,26],
+     "leds": [44,45,46],
+     "label": "k56"
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [821,336,26,26],
+     "leds": [47]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [452,166,26,26],
+     "leds": [48],
+     "label": "F3"
+    },
+    {
+     "name": "Key3",
+     "rect": [424,203,26,26],
+     "leds": [49],
+     "label": "3"
+    },
+    {
+     "name": "KeyE",
+     "rect": [441,231,26,26],
+     "leds": [50],
+     "label": "E"
+    },
+    {
+     "name": "KeyD",
+     "rect": [450,259,26,26],
+     "leds": [51],
+     "label": "D"
+    },
+    {
+     "name": "KeyX",
+     "rect": [431,287,26,26],
+     "leds": [52,53],
+     "label": "X"
+    },
+    {
+     "name": "KeyPause",
+     "rect": [821,166,26,26],
+     "leds": [54],
+     "label": "PAUSE"
+    },
+    {
+     "name": "KeyDel",
+     "rect": [765,231,26,26],
+     "leds": [55,56],
+     "label": "DELETE"
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [854,231,26,26],
+     "leds": [57],
+     "label": "7"
+    },
+    {
+     "name": "KeyP1",
+     "rect": [304,203,26,26],
+     "leds": [58,59],
+     "label": "P1"
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [854,203,26,26],
+     "leds": [60],
+     "label": "NUM\rLOCK"
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [910,259,26,26],
+     "leds": [61,62,63],
+     "label": "6"
+    },
+    {
+     "name": "KeyF4",
+     "rect": [480,166,26,26],
+     "leds": [64],
+     "label": "F4"
+    },
+    {
+     "name": "Key4",
+     "rect": [452,203,26,26],
+     "leds": [65],
+     "label": "4"
+    },
+    {
+     "name": "KeyR",
+     "rect": [469,231,26,26],
+     "leds": [66],
+     "label": "R"
+    },
+    {
+     "name": "KeyF",
+     "rect": [478,259,26,26],
+     "leds": [67],
+     "label": "F"
+    },
+    {
+     "name": "KeyC",
+     "rect": [459,287,26,26],
+     "leds": [68],
+     "label": "C"
+    },
+    {
+     "name": "KeySpace",
+     "rect": [443,315,185,46],
+     "leds": [69]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [765,203,26,26],
+     "leds": [70],
+     "label": "INSERT"
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [793,231,26,26],
+     "leds": [71,72],
+     "label": "END"
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [882,231,26,26],
+     "leds": [73],
+     "label": "8"
+    },
+    {
+     "name": "KeyP2",
+     "rect": [304,231,26,26],
+     "leds": [74,75],
+     "label": "P2"
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [882,203,26,26],
+     "leds": [76],
+     "label": "/"
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [854,287,26,26],
+     "leds": [77,78,79],
+     "label": "1"
+    },
+    {
+     "name": "KeyF5",
+     "rect": [522,166,26,26],
+     "leds": [80],
+     "label": "F5"
+    },
+    {
+     "name": "Key5",
+     "rect": [480,203,26,26],
+     "leds": [81],
+     "label": "5"
+    },
+    {
+     "name": "KeyT",
+     "rect": [497,231,26,26],
+     "leds": [82],
+     "label": "T"
+    },
+    {
+     "name": "KeyG",
+     "rect": [506,259,26,26],
+     "leds": [83],
+     "label": "G"
+    },
+    {
+     "name": "KeyV",
+     "rect": [487,287,26,26],
+     "leds": [84,85],
+     "label": "V"
+    },
+    {
+     "name": "KeyHome",
+     "rect": [793,203,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [821,231,26,26],
+     "leds": [87],
+     "label": "PG\rDN"
+    },
+    {
+     "name": "KeyStop",
+     "rect": [882,166,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [910,231,26,26],
+     "leds": [89],
+     "label": "9"
+    },
+    {
+     "name": "KeyP3",
+     "rect": [304,259,26,26],
+     "leds": [90,91],
+     "label": "P3"
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [910,203,26,26],
+     "leds": [92],
+     "label": "*"
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [882,287,26,26],
+     "leds": [93,94,95],
+     "label": "2"
+    },
+    {
+     "name": "KeyF6",
+     "rect": [550,166,26,26],
+     "leds": [96],
+     "label": "F6"
+    },
+    {
+     "name": "Key6",
+     "rect": [508,203,26,26],
+     "leds": [97],
+     "label": "6"
+    },
+    {
+     "name": "KeyY",
+     "rect": [526,231,26,26],
+     "leds": [98],
+     "label": "Y"
+    },
+    {
+     "name": "KeyH",
+     "rect": [534,259,26,26],
+     "leds": [99],
+     "label": "H"
+    },
+    {
+     "name": "KeyB",
+     "rect": [515,287,26,26],
+     "leds": [100,101],
+     "label": "B"
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [821,203,26,26],
+     "leds": [102],
+     "label": "PG\rUP"
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [684,287,76,26],
+     "leds": [103]
+    },
+    {
+     "name": "KeyPreTrack",
+     "rect": [910,166,26,26],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [304,287,26,26],
+     "leds": [106,107],
+     "label": "P4"
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [938,203,26,26],
+     "leds": [108],
+     "label": "-"
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [910,287,26,26],
+     "leds": [109,110,111],
+     "label": "3"
+    },
+    {
+     "name": "KeyF7",
+     "rect": [578,166,26,26],
+     "leds": [112],
+     "label": "F7"
+    },
+    {
+     "name": "Key7",
+     "rect": [537,203,26,26],
+     "leds": [113],
+     "label": "7"
+    },
+    {
+     "name": "KeyU",
+     "rect": [554,231,26,26],
+     "leds": [114],
+     "label": "U"
+    },
+    {
+     "name": "KeyJ",
+     "rect": [562,259,26,26],
+     "leds": [115],
+     "label": "J"
+    },
+    {
+     "name": "KeyN",
+     "rect": [543,287,26,26],
+     "leds": [116],
+     "label": "N"
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [630,315,36,26],
+     "leds": [117],
+     "label": "ALT\r GR"
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [694,231,26,26],
+     "leds": [118],
+     "label": "^"
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [724,315,36,26],
+     "leds": [119],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyPlay",
+     "rect": [854,166,26,26],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [854,259,26,26],
+     "leds": [121],
+     "label": "4"
+    },
+    {
+     "name": "KeyP5",
+     "rect": [304,315,26,26],
+     "leds": [122,123],
+     "label": "P5"
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [938,231,26,54],
+     "leds": [124],
+     "label": "+"
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [854,315,54,26],
+     "leds": [125,126,127],
+     "label": "0"
+    },
+    {
+     "name": "KeyF8",
+     "rect": [607,166,26,26],
+     "leds": [128],
+     "label": "F8"
+    },
+    {
+     "name": "Key8",
+     "rect": [565,203,26,26],
+     "leds": [129],
+     "label": "8"
+    },
+    {
+     "name": "KeyI",
+     "rect": [582,231,26,26],
+     "leds": [130],
+     "label": "I"
+    },
+    {
+     "name": "KeyK",
+     "rect": [590,259,26,26],
+     "leds": [131],
+     "label": "K"
+    },
+    {
+     "name": "KeyM",
+     "rect": [572,287,26,26],
+     "leds": [132],
+     "label": "M"
+    },
+    {
+     "name": "KeyFn",
+     "rect": [668,315,26,26],
+     "leds": [133],
+     "label": "FN"
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [722,231,37,26],
+     "leds": [134],
+     "label": "*"
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [793,307,26,26],
+     "leds": [135]
+    },
+    {
+     "name": "KeyNextTrack",
+     "rect": [938,166,26,26],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [882,259,26,26],
+     "leds": [137,138,139],
+     "label": "5"
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [938,287,26,54],
+     "leds": [140]
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [910,315,26,26],
+     "leds": [141],
+     "label": "."
+    }
+   ]
+  },
+  "Accessory/Portuguese": {
+   "id": "Accessory/Portuguese",
+   "leds": 142,
+   "bounds": [304,166,964,426],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [340,166,26,26],
+     "leds": [0],
+     "label": "ESC"
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [340,203,26,26],
+     "leds": [1],
+     "label": "\\"
+    },
+    {
+     "name": "KeyTab",
+     "rect": [340,231,43,26],
+     "leds": [2]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [340,259,52,26],
+     "leds": [3],
+     "label": "CAPS"
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [340,287,61,26],
+     "leds": [4]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [340,315,36,26],
+     "leds": [5],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyF12",
+     "rect": [733,166,26,26],
+     "leds": [6],
+     "label": "F12"
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [677,203,26,26],
+     "leds": [7],
+     "label": "<<"
+    },
+    {
+     "name": "KeyF9",
+     "rect": [649,166,26,26],
+     "leds": [8],
+     "label": "F9"
+    },
+    {
+     "name": "Key9",
+     "rect": [593,203,26,26],
+     "leds": [9],
+     "label": "9"
+    },
+    {
+     "name": "KeyO",
+     "rect": [610,231,26,26],
+     "leds": [10],
+     "label": "O"
+    },
+    {
+     "name": "KeyL",
+     "rect": [618,259,26,26],
+     "leds": [11],
+     "label": "L"
+    },
+    {
+     "name": "KeyComma",
+     "rect": [600,287,26,26],
+     "leds": [12],
+     "label": ","
+    },
+    {
+     "name": "KeyWinR",
+     "rect": [696,315,26,26],
+     "leds": [13,14],
+     "label": "<"
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [765,336,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [396,166,26,26],
+     "leds": [16],
+     "label": "F1"
+    },
+    {
+     "name": "Key1",
+     "rect": [368,203,26,26],
+     "leds": [17],
+     "label": "1"
+    },
+    {
+     "name": "KeyQ",
+     "rect": [385,231,26,26],
+     "leds": [18],
+     "label": "Q"
+    },
+    {
+     "name": "KeyA",
+     "rect": [394,259,26,26],
+     "leds": [19,20],
+     "label": "k45"
+    },
+    {
+     "name": "KeyWinL",
+     "rect": [377,315,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,166,26,26],
+     "leds": [22,23],
+     "label": "PRT\rSC"
+    },
+    {
+     "name": "KeyF10",
+     "rect": [677,166,26,26],
+     "leds": [24],
+     "label": "F10"
+    },
+    {
+     "name": "Key0",
+     "rect": [621,203,26,26],
+     "leds": [25],
+     "label": "0"
+    },
+    {
+     "name": "KeyP",
+     "rect": [638,231,26,26],
+     "leds": [26],
+     "label": "P"
+    },
+    {
+     "name": "KeyColon",
+     "rect": [647,259,26,26],
+     "leds": [27],
+     "label": "\u00c7"
+    },
+    {
+     "name": "KeyDot",
+     "rect": [628,287,26,26],
+     "leds": [28,29],
+     "label": "."
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [703,259,57,26],
+     "leds": [30]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [793,336,26,26],
+     "leds": [31]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,166,26,26],
+     "leds": [32],
+     "label": "F2"
+    },
+    {
+     "name": "Key2",
+     "rect": [396,203,26,26],
+     "leds": [33],
+     "label": "2"
+    },
+    {
+     "name": "KeyW",
+     "rect": [413,231,26,26],
+     "leds": [34],
+     "label": "W"
+    },
+    {
+     "name": "KeyS",
+     "rect": [422,259,26,26],
+     "leds": [35],
+     "label": "S"
+    },
+    {
+     "name": "KeyZ",
+     "rect": [403,287,26,26],
+     "leds": [36],
+     "label": "Z"
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [405,315,36,26],
+     "leds": [37],
+     "label": "ALT"
+    },
+    {
+     "name": "KeyScLock",
+     "rect": [793,166,26,26],
+     "leds": [38],
+     "label": "SC\rLOCK"
+    },
+    {
+     "name": "KeyBack",
+     "rect": [705,203,54,26],
+     "leds": [39]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [705,166,26,26],
+     "leds": [40],
+     "label": "F11"
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [649,203,26,26],
+     "leds": [41],
+     "label": "-"
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [666,231,26,26],
+     "leds": [42],
+     "label": "+"
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [675,259,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [656,287,26,26],
+     "leds": [44,45,46],
+     "label": "k56"
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [821,336,26,26],
+     "leds": [47]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [452,166,26,26],
+     "leds": [48],
+     "label": "F3"
+    },
+    {
+     "name": "Key3",
+     "rect": [424,203,26,26],
+     "leds": [49],
+     "label": "3"
+    },
+    {
+     "name": "KeyE",
+     "rect": [441,231,26,26],
+     "leds": [50],
+     "label": "E"
+    },
+    {
+     "name": "KeyD",
+     "rect": [450,259,26,26],
+     "leds": [51],
+     "label": "D"
+    },
+    {
+     "name": "KeyX",
+     "rect": [431,287,26,26],
+     "leds": [52,53],
+     "label": "X"
+    },
+    {
+     "name": "KeyPause",
+     "rect": [821,166,26,26],
+     "leds": [54],
+     "label": "PAUSE"
+    },
+    {
+     "name": "KeyDel",
+     "rect": [765,231,26,26],
+     "leds": [55,56],
+     "label": "DELETE"
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [854,231,26,26],
+     "leds": [57],
+     "label": "7"
+    },
+    {
+     "name": "KeyP1",
+     "rect": [304,203,26,26],
+     "leds": [58,59],
+     "label": "P1"
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [854,203,26,26],
+     "leds": [60],
+     "label": "NUM\rLOCK"
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [910,259,26,26],
+     "leds": [61,62,63],
+     "label": "6"
+    },
+    {
+     "name": "KeyF4",
+     "rect": [480,166,26,26],
+     "leds": [64],
+     "label": "F4"
+    },
+    {
+     "name": "Key4",
+     "rect": [452,203,26,26],
+     "leds": [65],
+     "label": "4"
+    },
+    {
+     "name": "KeyR",
+     "rect": [469,231,26,26],
+     "leds": [66],
+     "label": "R"
+    },
+    {
+     "name": "KeyF",
+     "rect": [478,259,26,26],
+     "leds": [67],
+     "label": "F"
+    },
+    {
+     "name": "KeyC",
+     "rect": [459,287,26,26],
+     "leds": [68],
+     "label": "C"
+    },
+    {
+     "name": "KeySpace",
+     "rect": [443,315,185,46],
+     "leds": [69]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [765,203,26,26],
+     "leds": [70],
+     "label": "INSERT"
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [793,231,26,26],
+     "leds": [71,72],
+     "label": "END"
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [882,231,26,26],
+     "leds": [73],
+     "label": "8"
+    },
+    {
+     "name": "KeyP2",
+     "rect": [304,231,26,26],
+     "leds": [74,75],
+     "label": "P2"
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [882,203,26,26],
+     "leds": [76],
+     "label": "/"
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [854,287,26,26],
+     "leds": [77,78,79],
+     "label": "1"
+    },
+    {
+     "name": "KeyF5",
+     "rect": [522,166,26,26],
+     "leds": [80],
+     "label": "F5"
+    },
+    {
+     "name": "Key5",
+     "rect": [480,203,26,26],
+     "leds": [81],
+     "label": "5"
+    },
+    {
+     "name": "KeyT",
+     "rect": [497,231,26,26],
+     "leds": [82],
+     "label": "T"
+    },
+    {
+     "name": "KeyG",
+     "rect": [506,259,26,26],
+     "leds": [83],
+     "label": "G"
+    },
+    {
+     "name": "KeyV",
+     "rect": [487,287,26,26],
+     "leds": [84,85],
+     "label": "V"
+    },
+    {
+     "name": "KeyHome",
+     "rect": [793,203,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [821,231,26,26],
+     "leds": [87],
+     "label": "PG\rDN"
+    },
+    {
+     "name": "KeyStop",
+     "rect": [882,166,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [910,231,26,26],
+     "leds": [89],
+     "label": "9"
+    },
+    {
+     "name": "KeyP3",
+     "rect": [304,259,26,26],
+     "leds": [90,91],
+     "label": "P3"
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [910,203,26,26],
+     "leds": [92],
+     "label": "*"
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [882,287,26,26],
+     "leds": [93,94,95],
+     "label": "2"
+    },
+    {
+     "name": "KeyF6",
+     "rect": [550,166,26,26],
+     "leds": [96],
+     "label": "F6"
+    },
+    {
+     "name": "Key6",
+     "rect": [508,203,26,26],
+     "leds": [97],
+     "label": "6"
+    },
+    {
+     "name": "KeyY",
+     "rect": [526,231,26,26],
+     "leds": [98],
+     "label": "Y"
+    },
+    {
+     "name": "KeyH",
+     "rect": [534,259,26,26],
+     "leds": [99],
+     "label": "H"
+    },
+    {
+     "name": "KeyB",
+     "rect": [515,287,26,26],
+     "leds": [100,101],
+     "label": "B"
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [821,203,26,26],
+     "leds": [102],
+     "label": "PG\rUP"
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [684,287,76,26],
+     "leds": [103]
+    },
+    {
+     "name": "KeyPreTrack",
+     "rect": [910,166,26,26],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [304,287,26,26],
+     "leds": [106,107],
+     "label": "P4"
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [938,203,26,26],
+     "leds": [108],
+     "label": "'"
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [910,287,26,26],
+     "leds": [109,110,111],
+     "label": "3"
+    },
+    {
+     "name": "KeyF7",
+     "rect": [578,166,26,26],
+     "leds": [112],
+     "label": "F7"
+    },
+    {
+     "name": "Key7",
+     "rect": [537,203,26,26],
+     "leds": [113],
+     "label": "7"
+    },
+    {
+     "name": "KeyU",
+     "rect": [554,231,26,26],
+     "leds": [114],
+     "label": "U"
+    },
+    {
+     "name": "KeyJ",
+     "rect": [562,259,26,26],
+     "leds": [115],
+     "label": "J"
+    },
+    {
+     "name": "KeyN",
+     "rect": [543,287,26,26],
+     "leds": [116],
+     "label": "N"
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [630,315,36,26],
+     "leds": [117],
+     "label": "ALT\r GR"
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [694,231,26,26],
+     "leds": [118],
+     "label": "`"
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [724,315,36,26],
+     "leds": [119],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyPlay",
+     "rect": [854,166,26,26],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [854,259,26,26],
+     "leds": [121],
+     "label": "4"
+    },
+    {
+     "name": "KeyP5",
+     "rect": [304,315,26,26],
+     "leds": [122,123],
+     "label": "P5"
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [938,231,26,54],
+     "leds": [124],
+     "label": "+"
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [854,315,54,26],
+     "leds": [125,126,127],
+     "label": "0"
+    },
+    {
+     "name": "KeyF8",
+     "rect": [607,166,26,26],
+     "leds": [128],
+     "label": "F8"
+    },
+    {
+     "name": "Key8",
+     "rect": [565,203,26,26],
+     "leds": [129],
+     "label": "8"
+    },
+    {
+     "name": "KeyI",
+     "rect": [582,231,26,26],
+     "leds": [130],
+     "label": "I"
+    },
+    {
+     "name": "KeyK",
+     "rect": [590,259,26,26],
+     "leds": [131],
+     "label": "K"
+    },
+    {
+     "name": "KeyM",
+     "rect": [572,287,26,26],
+     "leds": [132],
+     "label": "M"
+    },
+    {
+     "name": "KeyFn",
+     "rect": [668,315,26,26],
+     "leds": [133],
+     "label": "FN"
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [722,231,37,26],
+     "leds": [134],
+     "label": "~"
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [793,307,26,26],
+     "leds": [135]
+    },
+    {
+     "name": "KeyNextTrack",
+     "rect": [938,166,26,26],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [882,259,26,26],
+     "leds": [137,138,139],
+     "label": "5"
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [938,287,26,54],
+     "leds": [140]
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [910,315,26,26],
+     "leds": [141],
+     "label": "."
+    }
+   ]
+  },
+  "Accessory/Russian": {
+   "id": "Accessory/Russian",
+   "leds": 142,
+   "bounds": [304,166,964,426],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [340,166,26,26],
+     "leds": [0],
+     "label": "ESC"
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [340,203,26,26],
+     "leds": [1],
+     "label": "`"
+    },
+    {
+     "name": "KeyTab",
+     "rect": [340,231,43,26],
+     "leds": [2]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [340,259,52,26],
+     "leds": [3],
+     "label": "CAPS"
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [340,287,61,26],
+     "leds": [4]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [340,315,36,26],
+     "leds": [5],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyF12",
+     "rect": [733,166,26,26],
+     "leds": [6],
+     "label": "F12"
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [677,203,26,26],
+     "leds": [7],
+     "label": "="
+    },
+    {
+     "name": "KeyF9",
+     "rect": [649,166,26,26],
+     "leds": [8],
+     "label": "F9"
+    },
+    {
+     "name": "Key9",
+     "rect": [593,203,26,26],
+     "leds": [9],
+     "label": "9"
+    },
+    {
+     "name": "KeyO",
+     "rect": [610,231,26,26],
+     "leds": [10],
+     "label": "O"
+    },
+    {
+     "name": "KeyL",
+     "rect": [618,259,26,26],
+     "leds": [11],
+     "label": "L"
+    },
+    {
+     "name": "KeyComma",
+     "rect": [600,287,26,26],
+     "leds": [12],
+     "label": ","
+    },
+    {
+     "name": "KeyWinR",
+     "rect": [696,315,26,26],
+     "leds": [13,14]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [765,336,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [396,166,26,26],
+     "leds": [16],
+     "label": "F1"
+    },
+    {
+     "name": "Key1",
+     "rect": [368,203,26,26],
+     "leds": [17],
+     "label": "1"
+    },
+    {
+     "name": "KeyQ",
+     "rect": [385,231,26,26],
+     "leds": [18],
+     "label": "Q"
+    },
+    {
+     "name": "KeyA",
+     "rect": [394,259,26,26],
+     "leds": [19,20],
+     "label": "k45"
+    },
+    {
+     "name": "KeyWinL",
+     "rect": [377,315,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,166,26,26],
+     "leds": [22,23],
+     "label": "PRT\rSC"
+    },
+    {
+     "name": "KeyF10",
+     "rect": [677,166,26,26],
+     "leds": [24],
+     "label": "F10"
+    },
+    {
+     "name": "Key0",
+     "rect": [621,203,26,26],
+     "leds": [25],
+     "label": "0"
+    },
+    {
+     "name": "KeyP",
+     "rect": [638,231,26,26],
+     "leds": [26],
+     "label": "P"
+    },
+    {
+     "name": "KeyColon",
+     "rect": [647,259,26,26],
+     "leds": [27],
+     "label": ";"
+    },
+    {
+     "name": "KeyDot",
+     "rect": [628,287,26,26],
+     "leds": [28,29],
+     "label": "."
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [703,259,57,26],
+     "leds": [30]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [793,336,26,26],
+     "leds": [31]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,166,26,26],
+     "leds": [32],
+     "label": "F2"
+    },
+    {
+     "name": "Key2",
+     "rect": [396,203,26,26],
+     "leds": [33],
+     "label": "2"
+    },
+    {
+     "name": "KeyW",
+     "rect": [413,231,26,26],
+     "leds": [34],
+     "label": "W"
+    },
+    {
+     "name": "KeyS",
+     "rect": [422,259,26,26],
+     "leds": [35],
+     "label": "S"
+    },
+    {
+     "name": "KeyZ",
+     "rect": [403,287,26,26],
+     "leds": [36],
+     "label": "Z"
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [405,315,36,26],
+     "leds": [37],
+     "label": "ALT"
+    },
+    {
+     "name": "KeyScLock",
+     "rect": [793,166,26,26],
+     "leds": [38],
+     "label": "SC\rLOCK"
+    },
+    {
+     "name": "KeyBack",
+     "rect": [705,203,54,26],
+     "leds": [39]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [705,166,26,26],
+     "leds": [40],
+     "label": "F11"
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [649,203,26,26],
+     "leds": [41],
+     "label": "-"
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [666,231,26,26],
+     "leds": [42],
+     "label": "["
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [675,259,26,26],
+     "leds": [43],
+     "label": "'"
+    },
+    {
+     "name": "KeySlash",
+     "rect": [656,287,26,26],
+     "leds": [44,45,46],
+     "label": "k56"
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [821,336,26,26],
+     "leds": [47]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [452,166,26,26],
+     "leds": [48],
+     "label": "F3"
+    },
+    {
+     "name": "Key3",
+     "rect": [424,203,26,26],
+     "leds": [49],
+     "label": "3"
+    },
+    {
+     "name": "KeyE",
+     "rect": [441,231,26,26],
+     "leds": [50],
+     "label": "E"
+    },
+    {
+     "name": "KeyD",
+     "rect": [450,259,26,26],
+     "leds": [51],
+     "label": "D"
+    },
+    {
+     "name": "KeyX",
+     "rect": [431,287,26,26],
+     "leds": [52,53],
+     "label": "X"
+    },
+    {
+     "name": "KeyPause",
+     "rect": [821,166,26,26],
+     "leds": [54],
+     "label": "PAUSE"
+    },
+    {
+     "name": "KeyDel",
+     "rect": [765,231,26,26],
+     "leds": [55,56],
+     "label": "DELETE"
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [854,231,26,26],
+     "leds": [57],
+     "label": "7"
+    },
+    {
+     "name": "KeyP1",
+     "rect": [304,203,26,26],
+     "leds": [58,59],
+     "label": "P1"
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [854,203,26,26],
+     "leds": [60],
+     "label": "NUM\rLOCK"
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [910,259,26,26],
+     "leds": [61,62,63],
+     "label": "6"
+    },
+    {
+     "name": "KeyF4",
+     "rect": [480,166,26,26],
+     "leds": [64],
+     "label": "F4"
+    },
+    {
+     "name": "Key4",
+     "rect": [452,203,26,26],
+     "leds": [65],
+     "label": "4"
+    },
+    {
+     "name": "KeyR",
+     "rect": [469,231,26,26],
+     "leds": [66],
+     "label": "R"
+    },
+    {
+     "name": "KeyF",
+     "rect": [478,259,26,26],
+     "leds": [67],
+     "label": "F"
+    },
+    {
+     "name": "KeyC",
+     "rect": [459,287,26,26],
+     "leds": [68],
+     "label": "C"
+    },
+    {
+     "name": "KeySpace",
+     "rect": [443,315,185,46],
+     "leds": [69]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [765,203,26,26],
+     "leds": [70],
+     "label": "INSERT"
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [793,231,26,26],
+     "leds": [71,72],
+     "label": "END"
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [882,231,26,26],
+     "leds": [73],
+     "label": "8"
+    },
+    {
+     "name": "KeyP2",
+     "rect": [304,231,26,26],
+     "leds": [74,75],
+     "label": "P2"
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [882,203,26,26],
+     "leds": [76],
+     "label": "/"
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [854,287,26,26],
+     "leds": [77,78,79],
+     "label": "1"
+    },
+    {
+     "name": "KeyF5",
+     "rect": [522,166,26,26],
+     "leds": [80],
+     "label": "F5"
+    },
+    {
+     "name": "Key5",
+     "rect": [480,203,26,26],
+     "leds": [81],
+     "label": "5"
+    },
+    {
+     "name": "KeyT",
+     "rect": [497,231,26,26],
+     "leds": [82],
+     "label": "T"
+    },
+    {
+     "name": "KeyG",
+     "rect": [506,259,26,26],
+     "leds": [83],
+     "label": "G"
+    },
+    {
+     "name": "KeyV",
+     "rect": [487,287,26,26],
+     "leds": [84,85],
+     "label": "V"
+    },
+    {
+     "name": "KeyHome",
+     "rect": [793,203,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [821,231,26,26],
+     "leds": [87],
+     "label": "PG\rDN"
+    },
+    {
+     "name": "KeyStop",
+     "rect": [882,166,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [910,231,26,26],
+     "leds": [89],
+     "label": "9"
+    },
+    {
+     "name": "KeyP3",
+     "rect": [304,259,26,26],
+     "leds": [90,91],
+     "label": "P3"
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [910,203,26,26],
+     "leds": [92],
+     "label": "*"
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [882,287,26,26],
+     "leds": [93,94,95],
+     "label": "2"
+    },
+    {
+     "name": "KeyF6",
+     "rect": [550,166,26,26],
+     "leds": [96],
+     "label": "F6"
+    },
+    {
+     "name": "Key6",
+     "rect": [508,203,26,26],
+     "leds": [97],
+     "label": "6"
+    },
+    {
+     "name": "KeyY",
+     "rect": [526,231,26,26],
+     "leds": [98],
+     "label": "Y"
+    },
+    {
+     "name": "KeyH",
+     "rect": [534,259,26,26],
+     "leds": [99],
+     "label": "H"
+    },
+    {
+     "name": "KeyB",
+     "rect": [515,287,26,26],
+     "leds": [100,101],
+     "label": "B"
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [821,203,26,26],
+     "leds": [102],
+     "label": "PG\rUP"
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [684,287,76,26],
+     "leds": [103]
+    },
+    {
+     "name": "KeyPreTrack",
+     "rect": [910,166,26,26],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [304,287,26,26],
+     "leds": [106,107],
+     "label": "P4"
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [938,203,26,26],
+     "leds": [108],
+     "label": "-"
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [910,287,26,26],
+     "leds": [109,110,111],
+     "label": "3"
+    },
+    {
+     "name": "KeyF7",
+     "rect": [578,166,26,26],
+     "leds": [112],
+     "label": "F7"
+    },
+    {
+     "name": "Key7",
+     "rect": [537,203,26,26],
+     "leds": [113],
+     "label": "7"
+    },
+    {
+     "name": "KeyU",
+     "rect": [554,231,26,26],
+     "leds": [114],
+     "label": "U"
+    },
+    {
+     "name": "KeyJ",
+     "rect": [562,259,26,26],
+     "leds": [115],
+     "label": "J"
+    },
+    {
+     "name": "KeyN",
+     "rect": [543,287,26,26],
+     "leds": [116],
+     "label": "N"
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [630,315,36,26],
+     "leds": [117],
+     "label": "ALT\r GR"
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [694,231,26,26],
+     "leds": [118],
+     "label": "]"
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [724,315,36,26],
+     "leds": [119],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyPlay",
+     "rect": [854,166,26,26],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [854,259,26,26],
+     "leds": [121],
+     "label": "4"
+    },
+    {
+     "name": "KeyP5",
+     "rect": [304,315,26,26],
+     "leds": [122,123],
+     "label": "P5"
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [938,231,26,54],
+     "leds": [124],
+     "label": "+"
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [854,315,54,26],
+     "leds": [125,126,127],
+     "label": "0"
+    },
+    {
+     "name": "KeyF8",
+     "rect": [607,166,26,26],
+     "leds": [128],
+     "label": "F8"
+    },
+    {
+     "name": "Key8",
+     "rect": [565,203,26,26],
+     "leds": [129],
+     "label": "8"
+    },
+    {
+     "name": "KeyI",
+     "rect": [582,231,26,26],
+     "leds": [130],
+     "label": "I"
+    },
+    {
+     "name": "KeyK",
+     "rect": [590,259,26,26],
+     "leds": [131],
+     "label": "K"
+    },
+    {
+     "name": "KeyM",
+     "rect": [572,287,26,26],
+     "leds": [132],
+     "label": "M"
+    },
+    {
+     "name": "KeyFn",
+     "rect": [668,315,26,26],
+     "leds": [133],
+     "label": "FN"
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [722,231,37,26],
+     "leds": [134],
+     "label": "\\"
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [793,307,26,26],
+     "leds": [135]
+    },
+    {
+     "name": "KeyNextTrack",
+     "rect": [938,166,26,26],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [882,259,26,26],
+     "leds": [137,138,139],
+     "label": "5"
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [938,287,26,54],
+     "leds": [140]
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [910,315,26,26],
+     "leds": [141],
+     "label": "."
+    }
+   ]
+  },
+  "Accessory/Spanish": {
+   "id": "Accessory/Spanish",
+   "leds": 142,
+   "bounds": [304,166,964,426],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [340,166,26,26],
+     "leds": [0],
+     "label": "ESC"
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [340,203,26,26],
+     "leds": [1]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [340,231,43,26],
+     "leds": [2]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [340,259,52,26],
+     "leds": [3],
+     "label": "BLOQ\rMAY\u00daS"
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [340,287,61,26],
+     "leds": [4]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [340,315,36,26],
+     "leds": [5],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyF12",
+     "rect": [733,166,26,26],
+     "leds": [6],
+     "label": "F12"
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [677,203,26,26],
+     "leds": [7],
+     "label": "\u00a1"
+    },
+    {
+     "name": "KeyF9",
+     "rect": [649,166,26,26],
+     "leds": [8],
+     "label": "F9"
+    },
+    {
+     "name": "Key9",
+     "rect": [593,203,26,26],
+     "leds": [9],
+     "label": "9"
+    },
+    {
+     "name": "KeyO",
+     "rect": [610,231,26,26],
+     "leds": [10],
+     "label": "O"
+    },
+    {
+     "name": "KeyL",
+     "rect": [618,259,26,26],
+     "leds": [11],
+     "label": "L"
+    },
+    {
+     "name": "KeyComma",
+     "rect": [600,287,26,26],
+     "leds": [12],
+     "label": ","
+    },
+    {
+     "name": "KeyWinR",
+     "rect": [696,315,26,26],
+     "leds": [13,14],
+     "label": "<"
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [765,336,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [396,166,26,26],
+     "leds": [16],
+     "label": "F1"
+    },
+    {
+     "name": "Key1",
+     "rect": [368,203,26,26],
+     "leds": [17],
+     "label": "1"
+    },
+    {
+     "name": "KeyQ",
+     "rect": [385,231,26,26],
+     "leds": [18],
+     "label": "Q"
+    },
+    {
+     "name": "KeyA",
+     "rect": [394,259,26,26],
+     "leds": [19,20],
+     "label": "k45"
+    },
+    {
+     "name": "KeyWinL",
+     "rect": [377,315,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,166,26,26],
+     "leds": [22,23],
+     "label": "IMPR\rPANT"
+    },
+    {
+     "name": "KeyF10",
+     "rect": [677,166,26,26],
+     "leds": [24],
+     "label": "F10"
+    },
+    {
+     "name": "Key0",
+     "rect": [621,203,26,26],
+     "leds": [25],
+     "label": "0"
+    },
+    {
+     "name": "KeyP",
+     "rect": [638,231,26,26],
+     "leds": [26],
+     "label": "P"
+    },
+    {
+     "name": "KeyColon",
+     "rect": [647,259,26,26],
+     "leds": [27],
+     "label": "\u00d1"
+    },
+    {
+     "name": "KeyDot",
+     "rect": [628,287,26,26],
+     "leds": [28,29],
+     "label": "."
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [703,259,57,26],
+     "leds": [30]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [793,336,26,26],
+     "leds": [31]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,166,26,26],
+     "leds": [32],
+     "label": "F2"
+    },
+    {
+     "name": "Key2",
+     "rect": [396,203,26,26],
+     "leds": [33],
+     "label": "2"
+    },
+    {
+     "name": "KeyW",
+     "rect": [413,231,26,26],
+     "leds": [34],
+     "label": "W"
+    },
+    {
+     "name": "KeyS",
+     "rect": [422,259,26,26],
+     "leds": [35],
+     "label": "S"
+    },
+    {
+     "name": "KeyZ",
+     "rect": [403,287,26,26],
+     "leds": [36],
+     "label": "Z"
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [405,315,36,26],
+     "leds": [37],
+     "label": "ALT"
+    },
+    {
+     "name": "KeyScLock",
+     "rect": [793,166,26,26],
+     "leds": [38],
+     "label": "BLOQ\rDESPL"
+    },
+    {
+     "name": "KeyBack",
+     "rect": [705,203,54,26],
+     "leds": [39]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [705,166,26,26],
+     "leds": [40],
+     "label": "F11"
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [649,203,26,26],
+     "leds": [41],
+     "label": "-"
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [666,231,26,26],
+     "leds": [42],
+     "label": "^"
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [675,259,26,26],
+     "leds": [43],
+     "label": "'"
+    },
+    {
+     "name": "KeySlash",
+     "rect": [656,287,26,26],
+     "leds": [44,45,46],
+     "label": "k56"
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [821,336,26,26],
+     "leds": [47]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [452,166,26,26],
+     "leds": [48],
+     "label": "F3"
+    },
+    {
+     "name": "Key3",
+     "rect": [424,203,26,26],
+     "leds": [49],
+     "label": "3"
+    },
+    {
+     "name": "KeyE",
+     "rect": [441,231,26,26],
+     "leds": [50],
+     "label": "E"
+    },
+    {
+     "name": "KeyD",
+     "rect": [450,259,26,26],
+     "leds": [51],
+     "label": "D"
+    },
+    {
+     "name": "KeyX",
+     "rect": [431,287,26,26],
+     "leds": [52,53],
+     "label": "X"
+    },
+    {
+     "name": "KeyPause",
+     "rect": [821,166,26,26],
+     "leds": [54],
+     "label": "PAUSA"
+    },
+    {
+     "name": "KeyDel",
+     "rect": [765,231,26,26],
+     "leds": [55,56],
+     "label": "SUPR"
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [854,231,26,26],
+     "leds": [57],
+     "label": "7"
+    },
+    {
+     "name": "KeyP1",
+     "rect": [304,203,26,26],
+     "leds": [58,59],
+     "label": "P1"
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [854,203,26,26],
+     "leds": [60],
+     "label": "BLOQ\rNUM"
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [910,259,26,26],
+     "leds": [61,62,63],
+     "label": "6"
+    },
+    {
+     "name": "KeyF4",
+     "rect": [480,166,26,26],
+     "leds": [64],
+     "label": "F4"
+    },
+    {
+     "name": "Key4",
+     "rect": [452,203,26,26],
+     "leds": [65],
+     "label": "4"
+    },
+    {
+     "name": "KeyR",
+     "rect": [469,231,26,26],
+     "leds": [66],
+     "label": "R"
+    },
+    {
+     "name": "KeyF",
+     "rect": [478,259,26,26],
+     "leds": [67],
+     "label": "F"
+    },
+    {
+     "name": "KeyC",
+     "rect": [459,287,26,26],
+     "leds": [68],
+     "label": "C"
+    },
+    {
+     "name": "KeySpace",
+     "rect": [443,315,185,46],
+     "leds": [69]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [765,203,26,26],
+     "leds": [70],
+     "label": "INSERT"
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [793,231,26,26],
+     "leds": [71,72],
+     "label": "FIN"
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [882,231,26,26],
+     "leds": [73],
+     "label": "8"
+    },
+    {
+     "name": "KeyP2",
+     "rect": [304,231,26,26],
+     "leds": [74,75],
+     "label": "P2"
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [882,203,26,26],
+     "leds": [76],
+     "label": "-"
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [854,287,26,26],
+     "leds": [77,78,79],
+     "label": "1"
+    },
+    {
+     "name": "KeyF5",
+     "rect": [522,166,26,26],
+     "leds": [80],
+     "label": "F5"
+    },
+    {
+     "name": "Key5",
+     "rect": [480,203,26,26],
+     "leds": [81],
+     "label": "5"
+    },
+    {
+     "name": "KeyT",
+     "rect": [497,231,26,26],
+     "leds": [82],
+     "label": "T"
+    },
+    {
+     "name": "KeyG",
+     "rect": [506,259,26,26],
+     "leds": [83],
+     "label": "G"
+    },
+    {
+     "name": "KeyV",
+     "rect": [487,287,26,26],
+     "leds": [84,85],
+     "label": "V"
+    },
+    {
+     "name": "KeyHome",
+     "rect": [793,203,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [821,231,26,26],
+     "leds": [87],
+     "label": "AV\rP\u00c1G"
+    },
+    {
+     "name": "KeyStop",
+     "rect": [882,166,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [910,231,26,26],
+     "leds": [89],
+     "label": "9"
+    },
+    {
+     "name": "KeyP3",
+     "rect": [304,259,26,26],
+     "leds": [90,91],
+     "label": "P3"
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [910,203,26,26],
+     "leds": [92],
+     "label": "*"
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [882,287,26,26],
+     "leds": [93,94,95],
+     "label": "2"
+    },
+    {
+     "name": "KeyF6",
+     "rect": [550,166,26,26],
+     "leds": [96],
+     "label": "F6"
+    },
+    {
+     "name": "Key6",
+     "rect": [508,203,26,26],
+     "leds": [97],
+     "label": "6"
+    },
+    {
+     "name": "KeyY",
+     "rect": [526,231,26,26],
+     "leds": [98],
+     "label": "Y"
+    },
+    {
+     "name": "KeyH",
+     "rect": [534,259,26,26],
+     "leds": [99],
+     "label": "H"
+    },
+    {
+     "name": "KeyB",
+     "rect": [515,287,26,26],
+     "leds": [100,101],
+     "label": "B"
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [821,203,26,26],
+     "leds": [102],
+     "label": "RE\rP\u00c1G"
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [684,287,76,26],
+     "leds": [103]
+    },
+    {
+     "name": "KeyPreTrack",
+     "rect": [910,166,26,26],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [304,287,26,26],
+     "leds": [106,107],
+     "label": "P4"
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [938,203,26,26],
+     "leds": [108],
+     "label": "-"
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [910,287,26,26],
+     "leds": [109,110,111],
+     "label": "3"
+    },
+    {
+     "name": "KeyF7",
+     "rect": [578,166,26,26],
+     "leds": [112],
+     "label": "F7"
+    },
+    {
+     "name": "Key7",
+     "rect": [537,203,26,26],
+     "leds": [113],
+     "label": "7"
+    },
+    {
+     "name": "KeyU",
+     "rect": [554,231,26,26],
+     "leds": [114],
+     "label": "U"
+    },
+    {
+     "name": "KeyJ",
+     "rect": [562,259,26,26],
+     "leds": [115],
+     "label": "J"
+    },
+    {
+     "name": "KeyN",
+     "rect": [543,287,26,26],
+     "leds": [116],
+     "label": "N"
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [630,315,36,26],
+     "leds": [117],
+     "label": "ALT\r GR"
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [694,231,26,26],
+     "leds": [118],
+     "label": "*"
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [724,315,36,26],
+     "leds": [119],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyPlay",
+     "rect": [854,166,26,26],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [854,259,26,26],
+     "leds": [121],
+     "label": "4"
+    },
+    {
+     "name": "KeyP5",
+     "rect": [304,315,26,26],
+     "leds": [122,123],
+     "label": "P5"
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [938,231,26,54],
+     "leds": [124],
+     "label": "+"
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [854,315,54,26],
+     "leds": [125,126,127],
+     "label": "0"
+    },
+    {
+     "name": "KeyF8",
+     "rect": [607,166,26,26],
+     "leds": [128],
+     "label": "F8"
+    },
+    {
+     "name": "Key8",
+     "rect": [565,203,26,26],
+     "leds": [129],
+     "label": "8"
+    },
+    {
+     "name": "KeyI",
+     "rect": [582,231,26,26],
+     "leds": [130],
+     "label": "I"
+    },
+    {
+     "name": "KeyK",
+     "rect": [590,259,26,26],
+     "leds": [131],
+     "label": "K"
+    },
+    {
+     "name": "KeyM",
+     "rect": [572,287,26,26],
+     "leds": [132],
+     "label": "M"
+    },
+    {
+     "name": "KeyFn",
+     "rect": [668,315,26,26],
+     "leds": [133],
+     "label": "FN"
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [722,231,37,26],
+     "leds": [134],
+     "label": "\u00c7"
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [793,307,26,26],
+     "leds": [135]
+    },
+    {
+     "name": "KeyNextTrack",
+     "rect": [938,166,26,26],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [882,259,26,26],
+     "leds": [137,138,139],
+     "label": "5"
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [938,287,26,54],
+     "leds": [140]
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [910,315,26,26],
+     "leds": [141],
+     "label": "."
+    }
+   ]
+  },
+  "Accessory/Swiss": {
+   "id": "Accessory/Swiss",
+   "leds": 142,
+   "bounds": [304,166,964,426],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [340,166,26,26],
+     "leds": [0],
+     "label": "ESC"
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [340,203,26,26],
+     "leds": [1],
+     "label": "\u00a7"
+    },
+    {
+     "name": "KeyTab",
+     "rect": [340,231,43,26],
+     "leds": [2]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [340,259,52,26],
+     "leds": [3],
+     "label": "CAPS"
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [340,287,61,26],
+     "leds": [4]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [340,315,36,26],
+     "leds": [5],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyF12",
+     "rect": [733,166,26,26],
+     "leds": [6],
+     "label": "F12"
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [677,203,26,26],
+     "leds": [7],
+     "label": "^"
+    },
+    {
+     "name": "KeyF9",
+     "rect": [649,166,26,26],
+     "leds": [8],
+     "label": "F9"
+    },
+    {
+     "name": "Key9",
+     "rect": [593,203,26,26],
+     "leds": [9],
+     "label": "9"
+    },
+    {
+     "name": "KeyO",
+     "rect": [610,231,26,26],
+     "leds": [10],
+     "label": "O"
+    },
+    {
+     "name": "KeyL",
+     "rect": [618,259,26,26],
+     "leds": [11],
+     "label": "L"
+    },
+    {
+     "name": "KeyComma",
+     "rect": [600,287,26,26],
+     "leds": [12],
+     "label": ","
+    },
+    {
+     "name": "KeyWinR",
+     "rect": [696,315,26,26],
+     "leds": [13,14],
+     "label": "<"
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [765,336,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [396,166,26,26],
+     "leds": [16],
+     "label": "F1"
+    },
+    {
+     "name": "Key1",
+     "rect": [368,203,26,26],
+     "leds": [17],
+     "label": "1"
+    },
+    {
+     "name": "KeyQ",
+     "rect": [385,231,26,26],
+     "leds": [18],
+     "label": "Q"
+    },
+    {
+     "name": "KeyA",
+     "rect": [394,259,26,26],
+     "leds": [19,20],
+     "label": "k45"
+    },
+    {
+     "name": "KeyWinL",
+     "rect": [377,315,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,166,26,26],
+     "leds": [22,23],
+     "label": "PRT\rSC"
+    },
+    {
+     "name": "KeyF10",
+     "rect": [677,166,26,26],
+     "leds": [24],
+     "label": "F10"
+    },
+    {
+     "name": "Key0",
+     "rect": [621,203,26,26],
+     "leds": [25],
+     "label": "0"
+    },
+    {
+     "name": "KeyP",
+     "rect": [638,231,26,26],
+     "leds": [26],
+     "label": "P"
+    },
+    {
+     "name": "KeyColon",
+     "rect": [647,259,26,26],
+     "leds": [27],
+     "label": "\u00d6"
+    },
+    {
+     "name": "KeyDot",
+     "rect": [628,287,26,26],
+     "leds": [28,29],
+     "label": "."
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [703,259,57,26],
+     "leds": [30]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [793,336,26,26],
+     "leds": [31]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,166,26,26],
+     "leds": [32],
+     "label": "F2"
+    },
+    {
+     "name": "Key2",
+     "rect": [396,203,26,26],
+     "leds": [33],
+     "label": "2"
+    },
+    {
+     "name": "KeyW",
+     "rect": [413,231,26,26],
+     "leds": [34],
+     "label": "W"
+    },
+    {
+     "name": "KeyS",
+     "rect": [422,259,26,26],
+     "leds": [35],
+     "label": "S"
+    },
+    {
+     "name": "KeyZ",
+     "rect": [403,287,26,26],
+     "leds": [36],
+     "label": "Z"
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [405,315,36,26],
+     "leds": [37],
+     "label": "ALT"
+    },
+    {
+     "name": "KeyScLock",
+     "rect": [793,166,26,26],
+     "leds": [38],
+     "label": "SC\rLOCK"
+    },
+    {
+     "name": "KeyBack",
+     "rect": [705,203,54,26],
+     "leds": [39]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [705,166,26,26],
+     "leds": [40],
+     "label": "F11"
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [649,203,26,26],
+     "leds": [41],
+     "label": "'"
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [666,231,26,26],
+     "leds": [42],
+     "label": "\u00dc"
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [675,259,26,26],
+     "leds": [43],
+     "label": "\u00c4"
+    },
+    {
+     "name": "KeySlash",
+     "rect": [656,287,26,26],
+     "leds": [44,45,46],
+     "label": "k56"
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [821,336,26,26],
+     "leds": [47]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [452,166,26,26],
+     "leds": [48],
+     "label": "F3"
+    },
+    {
+     "name": "Key3",
+     "rect": [424,203,26,26],
+     "leds": [49],
+     "label": "3"
+    },
+    {
+     "name": "KeyE",
+     "rect": [441,231,26,26],
+     "leds": [50],
+     "label": "E"
+    },
+    {
+     "name": "KeyD",
+     "rect": [450,259,26,26],
+     "leds": [51],
+     "label": "D"
+    },
+    {
+     "name": "KeyX",
+     "rect": [431,287,26,26],
+     "leds": [52,53],
+     "label": "X"
+    },
+    {
+     "name": "KeyPause",
+     "rect": [821,166,26,26],
+     "leds": [54],
+     "label": "PAUSE"
+    },
+    {
+     "name": "KeyDel",
+     "rect": [765,231,26,26],
+     "leds": [55,56],
+     "label": "DELETE"
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [854,231,26,26],
+     "leds": [57],
+     "label": "7"
+    },
+    {
+     "name": "KeyP1",
+     "rect": [304,203,26,26],
+     "leds": [58,59],
+     "label": "P1"
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [854,203,26,26],
+     "leds": [60],
+     "label": "NUM\rLOCK"
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [910,259,26,26],
+     "leds": [61,62,63],
+     "label": "6"
+    },
+    {
+     "name": "KeyF4",
+     "rect": [480,166,26,26],
+     "leds": [64],
+     "label": "F4"
+    },
+    {
+     "name": "Key4",
+     "rect": [452,203,26,26],
+     "leds": [65],
+     "label": "4"
+    },
+    {
+     "name": "KeyR",
+     "rect": [469,231,26,26],
+     "leds": [66],
+     "label": "R"
+    },
+    {
+     "name": "KeyF",
+     "rect": [478,259,26,26],
+     "leds": [67],
+     "label": "F"
+    },
+    {
+     "name": "KeyC",
+     "rect": [459,287,26,26],
+     "leds": [68],
+     "label": "C"
+    },
+    {
+     "name": "KeySpace",
+     "rect": [443,315,185,46],
+     "leds": [69]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [765,203,26,26],
+     "leds": [70],
+     "label": "INSERT"
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [793,231,26,26],
+     "leds": [71,72],
+     "label": "END"
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [882,231,26,26],
+     "leds": [73],
+     "label": "8"
+    },
+    {
+     "name": "KeyP2",
+     "rect": [304,231,26,26],
+     "leds": [74,75],
+     "label": "P2"
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [882,203,26,26],
+     "leds": [76],
+     "label": "/"
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [854,287,26,26],
+     "leds": [77,78,79],
+     "label": "1"
+    },
+    {
+     "name": "KeyF5",
+     "rect": [522,166,26,26],
+     "leds": [80],
+     "label": "F5"
+    },
+    {
+     "name": "Key5",
+     "rect": [480,203,26,26],
+     "leds": [81],
+     "label": "5"
+    },
+    {
+     "name": "KeyT",
+     "rect": [497,231,26,26],
+     "leds": [82],
+     "label": "T"
+    },
+    {
+     "name": "KeyG",
+     "rect": [506,259,26,26],
+     "leds": [83],
+     "label": "G"
+    },
+    {
+     "name": "KeyV",
+     "rect": [487,287,26,26],
+     "leds": [84,85],
+     "label": "V"
+    },
+    {
+     "name": "KeyHome",
+     "rect": [793,203,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [821,231,26,26],
+     "leds": [87],
+     "label": "PG\rDN"
+    },
+    {
+     "name": "KeyStop",
+     "rect": [882,166,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [910,231,26,26],
+     "leds": [89],
+     "label": "9"
+    },
+    {
+     "name": "KeyP3",
+     "rect": [304,259,26,26],
+     "leds": [90,91],
+     "label": "P3"
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [910,203,26,26],
+     "leds": [92],
+     "label": "*"
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [882,287,26,26],
+     "leds": [93,94,95],
+     "label": "2"
+    },
+    {
+     "name": "KeyF6",
+     "rect": [550,166,26,26],
+     "leds": [96],
+     "label": "F6"
+    },
+    {
+     "name": "Key6",
+     "rect": [508,203,26,26],
+     "leds": [97],
+     "label": "6"
+    },
+    {
+     "name": "KeyY",
+     "rect": [526,231,26,26],
+     "leds": [98],
+     "label": "Y"
+    },
+    {
+     "name": "KeyH",
+     "rect": [534,259,26,26],
+     "leds": [99],
+     "label": "H"
+    },
+    {
+     "name": "KeyB",
+     "rect": [515,287,26,26],
+     "leds": [100,101],
+     "label": "B"
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [821,203,26,26],
+     "leds": [102],
+     "label": "PG\rUP"
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [684,287,76,26],
+     "leds": [103]
+    },
+    {
+     "name": "KeyPreTrack",
+     "rect": [910,166,26,26],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [304,287,26,26],
+     "leds": [106,107],
+     "label": "P4"
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [938,203,26,26],
+     "leds": [108],
+     "label": "-"
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [910,287,26,26],
+     "leds": [109,110,111],
+     "label": "3"
+    },
+    {
+     "name": "KeyF7",
+     "rect": [578,166,26,26],
+     "leds": [112],
+     "label": "F7"
+    },
+    {
+     "name": "Key7",
+     "rect": [537,203,26,26],
+     "leds": [113],
+     "label": "7"
+    },
+    {
+     "name": "KeyU",
+     "rect": [554,231,26,26],
+     "leds": [114],
+     "label": "U"
+    },
+    {
+     "name": "KeyJ",
+     "rect": [562,259,26,26],
+     "leds": [115],
+     "label": "J"
+    },
+    {
+     "name": "KeyN",
+     "rect": [543,287,26,26],
+     "leds": [116],
+     "label": "N"
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [630,315,36,26],
+     "leds": [117],
+     "label": "ALT\r GR"
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [694,231,26,26],
+     "leds": [118],
+     "label": "\""
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [724,315,36,26],
+     "leds": [119],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyPlay",
+     "rect": [854,166,26,26],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [854,259,26,26],
+     "leds": [121],
+     "label": "4"
+    },
+    {
+     "name": "KeyP5",
+     "rect": [304,315,26,26],
+     "leds": [122,123],
+     "label": "P5"
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [938,231,26,54],
+     "leds": [124],
+     "label": "+"
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [854,315,54,26],
+     "leds": [125,126,127],
+     "label": "0"
+    },
+    {
+     "name": "KeyF8",
+     "rect": [607,166,26,26],
+     "leds": [128],
+     "label": "F8"
+    },
+    {
+     "name": "Key8",
+     "rect": [565,203,26,26],
+     "leds": [129],
+     "label": "8"
+    },
+    {
+     "name": "KeyI",
+     "rect": [582,231,26,26],
+     "leds": [130],
+     "label": "I"
+    },
+    {
+     "name": "KeyK",
+     "rect": [590,259,26,26],
+     "leds": [131],
+     "label": "K"
+    },
+    {
+     "name": "KeyM",
+     "rect": [572,287,26,26],
+     "leds": [132],
+     "label": "M"
+    },
+    {
+     "name": "KeyFn",
+     "rect": [668,315,26,26],
+     "leds": [133],
+     "label": "FN"
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [722,231,37,26],
+     "leds": [134],
+     "label": "$"
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [793,307,26,26],
+     "leds": [135]
+    },
+    {
+     "name": "KeyNextTrack",
+     "rect": [938,166,26,26],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [882,259,26,26],
+     "leds": [137,138,139],
+     "label": "5"
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [938,287,26,54],
+     "leds": [140]
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [910,315,26,26],
+     "leds": [141],
+     "label": "."
+    }
+   ]
+  },
+  "Accessory/UkEnglish": {
+   "id": "Accessory/UkEnglish",
+   "leds": 142,
+   "bounds": [304,166,964,426],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [340,166,26,26],
+     "leds": [0],
+     "label": "ESC"
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [340,203,26,26],
+     "leds": [1],
+     "label": "`"
+    },
+    {
+     "name": "KeyTab",
+     "rect": [340,231,43,26],
+     "leds": [2]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [340,259,52,26],
+     "leds": [3],
+     "label": "CAPS"
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [340,287,61,26],
+     "leds": [4]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [340,315,36,26],
+     "leds": [5],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyF12",
+     "rect": [733,166,26,26],
+     "leds": [6],
+     "label": "F12"
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [677,203,26,26],
+     "leds": [7],
+     "label": "="
+    },
+    {
+     "name": "KeyF9",
+     "rect": [649,166,26,26],
+     "leds": [8],
+     "label": "F9"
+    },
+    {
+     "name": "Key9",
+     "rect": [593,203,26,26],
+     "leds": [9],
+     "label": "9"
+    },
+    {
+     "name": "KeyO",
+     "rect": [610,231,26,26],
+     "leds": [10],
+     "label": "O"
+    },
+    {
+     "name": "KeyL",
+     "rect": [618,259,26,26],
+     "leds": [11],
+     "label": "L"
+    },
+    {
+     "name": "KeyComma",
+     "rect": [600,287,26,26],
+     "leds": [12],
+     "label": ","
+    },
+    {
+     "name": "KeyWinR",
+     "rect": [696,315,26,26],
+     "leds": [13,14],
+     "label": "\\"
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [765,336,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [396,166,26,26],
+     "leds": [16],
+     "label": "F1"
+    },
+    {
+     "name": "Key1",
+     "rect": [368,203,26,26],
+     "leds": [17],
+     "label": "1"
+    },
+    {
+     "name": "KeyQ",
+     "rect": [385,231,26,26],
+     "leds": [18],
+     "label": "Q"
+    },
+    {
+     "name": "KeyA",
+     "rect": [394,259,26,26],
+     "leds": [19,20],
+     "label": "k45"
+    },
+    {
+     "name": "KeyWinL",
+     "rect": [377,315,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,166,26,26],
+     "leds": [22,23],
+     "label": "PRT\rSC"
+    },
+    {
+     "name": "KeyF10",
+     "rect": [677,166,26,26],
+     "leds": [24],
+     "label": "F10"
+    },
+    {
+     "name": "Key0",
+     "rect": [621,203,26,26],
+     "leds": [25],
+     "label": "0"
+    },
+    {
+     "name": "KeyP",
+     "rect": [638,231,26,26],
+     "leds": [26],
+     "label": "P"
+    },
+    {
+     "name": "KeyColon",
+     "rect": [647,259,26,26],
+     "leds": [27],
+     "label": ";"
+    },
+    {
+     "name": "KeyDot",
+     "rect": [628,287,26,26],
+     "leds": [28,29],
+     "label": "."
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [703,259,57,26],
+     "leds": [30]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [793,336,26,26],
+     "leds": [31]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,166,26,26],
+     "leds": [32],
+     "label": "F2"
+    },
+    {
+     "name": "Key2",
+     "rect": [396,203,26,26],
+     "leds": [33],
+     "label": "2"
+    },
+    {
+     "name": "KeyW",
+     "rect": [413,231,26,26],
+     "leds": [34],
+     "label": "W"
+    },
+    {
+     "name": "KeyS",
+     "rect": [422,259,26,26],
+     "leds": [35],
+     "label": "S"
+    },
+    {
+     "name": "KeyZ",
+     "rect": [403,287,26,26],
+     "leds": [36],
+     "label": "Z"
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [405,315,36,26],
+     "leds": [37],
+     "label": "ALT"
+    },
+    {
+     "name": "KeyScLock",
+     "rect": [793,166,26,26],
+     "leds": [38],
+     "label": "SC\rLOCK"
+    },
+    {
+     "name": "KeyBack",
+     "rect": [705,203,54,26],
+     "leds": [39]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [705,166,26,26],
+     "leds": [40],
+     "label": "F11"
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [649,203,26,26],
+     "leds": [41],
+     "label": "-"
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [666,231,26,26],
+     "leds": [42],
+     "label": "["
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [675,259,26,26],
+     "leds": [43],
+     "label": "'"
+    },
+    {
+     "name": "KeySlash",
+     "rect": [656,287,26,26],
+     "leds": [44,45,46],
+     "label": "k56"
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [821,336,26,26],
+     "leds": [47]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [452,166,26,26],
+     "leds": [48],
+     "label": "F3"
+    },
+    {
+     "name": "Key3",
+     "rect": [424,203,26,26],
+     "leds": [49],
+     "label": "3"
+    },
+    {
+     "name": "KeyE",
+     "rect": [441,231,26,26],
+     "leds": [50],
+     "label": "E"
+    },
+    {
+     "name": "KeyD",
+     "rect": [450,259,26,26],
+     "leds": [51],
+     "label": "D"
+    },
+    {
+     "name": "KeyX",
+     "rect": [431,287,26,26],
+     "leds": [52,53],
+     "label": "X"
+    },
+    {
+     "name": "KeyPause",
+     "rect": [821,166,26,26],
+     "leds": [54],
+     "label": "PAUSE"
+    },
+    {
+     "name": "KeyDel",
+     "rect": [765,231,26,26],
+     "leds": [55,56],
+     "label": "DELETE"
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [854,231,26,26],
+     "leds": [57],
+     "label": "7"
+    },
+    {
+     "name": "KeyP1",
+     "rect": [304,203,26,26],
+     "leds": [58,59],
+     "label": "P1"
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [854,203,26,26],
+     "leds": [60],
+     "label": "NUM\rLOCK"
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [910,259,26,26],
+     "leds": [61,62,63],
+     "label": "6"
+    },
+    {
+     "name": "KeyF4",
+     "rect": [480,166,26,26],
+     "leds": [64],
+     "label": "F4"
+    },
+    {
+     "name": "Key4",
+     "rect": [452,203,26,26],
+     "leds": [65],
+     "label": "4"
+    },
+    {
+     "name": "KeyR",
+     "rect": [469,231,26,26],
+     "leds": [66],
+     "label": "R"
+    },
+    {
+     "name": "KeyF",
+     "rect": [478,259,26,26],
+     "leds": [67],
+     "label": "F"
+    },
+    {
+     "name": "KeyC",
+     "rect": [459,287,26,26],
+     "leds": [68],
+     "label": "C"
+    },
+    {
+     "name": "KeySpace",
+     "rect": [443,315,185,46],
+     "leds": [69]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [765,203,26,26],
+     "leds": [70],
+     "label": "INSERT"
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [793,231,26,26],
+     "leds": [71,72],
+     "label": "END"
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [882,231,26,26],
+     "leds": [73],
+     "label": "8"
+    },
+    {
+     "name": "KeyP2",
+     "rect": [304,231,26,26],
+     "leds": [74,75],
+     "label": "P2"
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [882,203,26,26],
+     "leds": [76],
+     "label": "/"
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [854,287,26,26],
+     "leds": [77,78,79],
+     "label": "1"
+    },
+    {
+     "name": "KeyF5",
+     "rect": [522,166,26,26],
+     "leds": [80],
+     "label": "F5"
+    },
+    {
+     "name": "Key5",
+     "rect": [480,203,26,26],
+     "leds": [81],
+     "label": "5"
+    },
+    {
+     "name": "KeyT",
+     "rect": [497,231,26,26],
+     "leds": [82],
+     "label": "T"
+    },
+    {
+     "name": "KeyG",
+     "rect": [506,259,26,26],
+     "leds": [83],
+     "label": "G"
+    },
+    {
+     "name": "KeyV",
+     "rect": [487,287,26,26],
+     "leds": [84,85],
+     "label": "V"
+    },
+    {
+     "name": "KeyHome",
+     "rect": [793,203,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [821,231,26,26],
+     "leds": [87],
+     "label": "PG\rDN"
+    },
+    {
+     "name": "KeyStop",
+     "rect": [882,166,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [910,231,26,26],
+     "leds": [89],
+     "label": "9"
+    },
+    {
+     "name": "KeyP3",
+     "rect": [304,259,26,26],
+     "leds": [90,91],
+     "label": "P3"
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [910,203,26,26],
+     "leds": [92],
+     "label": "*"
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [882,287,26,26],
+     "leds": [93,94,95],
+     "label": "2"
+    },
+    {
+     "name": "KeyF6",
+     "rect": [550,166,26,26],
+     "leds": [96],
+     "label": "F6"
+    },
+    {
+     "name": "Key6",
+     "rect": [508,203,26,26],
+     "leds": [97],
+     "label": "6"
+    },
+    {
+     "name": "KeyY",
+     "rect": [526,231,26,26],
+     "leds": [98],
+     "label": "Y"
+    },
+    {
+     "name": "KeyH",
+     "rect": [534,259,26,26],
+     "leds": [99],
+     "label": "H"
+    },
+    {
+     "name": "KeyB",
+     "rect": [515,287,26,26],
+     "leds": [100,101],
+     "label": "B"
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [821,203,26,26],
+     "leds": [102],
+     "label": "PG\rUP"
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [684,287,76,26],
+     "leds": [103]
+    },
+    {
+     "name": "KeyPreTrack",
+     "rect": [910,166,26,26],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [304,287,26,26],
+     "leds": [106,107],
+     "label": "P4"
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [938,203,26,26],
+     "leds": [108],
+     "label": "-"
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [910,287,26,26],
+     "leds": [109,110,111],
+     "label": "3"
+    },
+    {
+     "name": "KeyF7",
+     "rect": [578,166,26,26],
+     "leds": [112],
+     "label": "F7"
+    },
+    {
+     "name": "Key7",
+     "rect": [537,203,26,26],
+     "leds": [113],
+     "label": "7"
+    },
+    {
+     "name": "KeyU",
+     "rect": [554,231,26,26],
+     "leds": [114],
+     "label": "U"
+    },
+    {
+     "name": "KeyJ",
+     "rect": [562,259,26,26],
+     "leds": [115],
+     "label": "J"
+    },
+    {
+     "name": "KeyN",
+     "rect": [543,287,26,26],
+     "leds": [116],
+     "label": "N"
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [630,315,36,26],
+     "leds": [117],
+     "label": "ALT\r GR"
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [694,231,26,26],
+     "leds": [118],
+     "label": "]"
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [724,315,36,26],
+     "leds": [119],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyPlay",
+     "rect": [854,166,26,26],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [854,259,26,26],
+     "leds": [121],
+     "label": "4"
+    },
+    {
+     "name": "KeyP5",
+     "rect": [304,315,26,26],
+     "leds": [122,123],
+     "label": "P5"
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [938,231,26,54],
+     "leds": [124],
+     "label": "+"
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [854,315,54,26],
+     "leds": [125,126,127],
+     "label": "0"
+    },
+    {
+     "name": "KeyF8",
+     "rect": [607,166,26,26],
+     "leds": [128],
+     "label": "F8"
+    },
+    {
+     "name": "Key8",
+     "rect": [565,203,26,26],
+     "leds": [129],
+     "label": "8"
+    },
+    {
+     "name": "KeyI",
+     "rect": [582,231,26,26],
+     "leds": [130],
+     "label": "I"
+    },
+    {
+     "name": "KeyK",
+     "rect": [590,259,26,26],
+     "leds": [131],
+     "label": "K"
+    },
+    {
+     "name": "KeyM",
+     "rect": [572,287,26,26],
+     "leds": [132],
+     "label": "M"
+    },
+    {
+     "name": "KeyFn",
+     "rect": [668,315,26,26],
+     "leds": [133],
+     "label": "FN"
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [722,231,37,26],
+     "leds": [134],
+     "label": "~"
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [793,307,26,26],
+     "leds": [135]
+    },
+    {
+     "name": "KeyNextTrack",
+     "rect": [938,166,26,26],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [882,259,26,26],
+     "leds": [137,138,139],
+     "label": "5"
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [938,287,26,54],
+     "leds": [140]
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [910,315,26,26],
+     "leds": [141],
+     "label": "."
+    }
+   ]
+  },
+  "Accessory/UsInternational": {
+   "id": "Accessory/UsInternational",
+   "leds": 142,
+   "bounds": [304,166,964,426],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [340,166,26,26],
+     "leds": [0],
+     "label": "ESC"
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [340,203,26,26],
+     "leds": [1],
+     "label": "`"
+    },
+    {
+     "name": "KeyTab",
+     "rect": [340,231,43,26],
+     "leds": [2],
+     "label": "TAB"
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [340,259,52,26],
+     "leds": [3],
+     "label": "CAPS"
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [340,287,61,26],
+     "leds": [4],
+     "label": "SHIFT"
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [340,315,36,26],
+     "leds": [5],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyF12",
+     "rect": [733,166,26,26],
+     "leds": [6],
+     "label": "F12"
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [677,203,26,26],
+     "leds": [7],
+     "label": "="
+    },
+    {
+     "name": "KeyF9",
+     "rect": [649,166,26,26],
+     "leds": [8],
+     "label": "F9"
+    },
+    {
+     "name": "Key9",
+     "rect": [593,203,26,26],
+     "leds": [9],
+     "label": "9"
+    },
+    {
+     "name": "KeyO",
+     "rect": [610,231,26,26],
+     "leds": [10],
+     "label": "O"
+    },
+    {
+     "name": "KeyL",
+     "rect": [618,259,26,26],
+     "leds": [11],
+     "label": "L"
+    },
+    {
+     "name": "KeyComma",
+     "rect": [600,287,26,26],
+     "leds": [12],
+     "label": ","
+    },
+    {
+     "name": "KeyWinR",
+     "rect": [696,315,26,26],
+     "leds": [13,14]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [765,336,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [396,166,26,26],
+     "leds": [16],
+     "label": "F1"
+    },
+    {
+     "name": "Key1",
+     "rect": [368,203,26,26],
+     "leds": [17],
+     "label": "1"
+    },
+    {
+     "name": "KeyQ",
+     "rect": [385,231,26,26],
+     "leds": [18],
+     "label": "Q"
+    },
+    {
+     "name": "KeyA",
+     "rect": [394,259,26,26],
+     "leds": [19,20],
+     "label": "k45"
+    },
+    {
+     "name": "KeyWinL",
+     "rect": [377,315,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,166,26,26],
+     "leds": [22,23],
+     "label": "PRT\rSC"
+    },
+    {
+     "name": "KeyF10",
+     "rect": [677,166,26,26],
+     "leds": [24],
+     "label": "F10"
+    },
+    {
+     "name": "Key0",
+     "rect": [621,203,26,26],
+     "leds": [25],
+     "label": "0"
+    },
+    {
+     "name": "KeyP",
+     "rect": [638,231,26,26],
+     "leds": [26],
+     "label": "P"
+    },
+    {
+     "name": "KeyColon",
+     "rect": [647,259,26,26],
+     "leds": [27],
+     "label": ";"
+    },
+    {
+     "name": "KeyDot",
+     "rect": [628,287,26,26],
+     "leds": [28,29],
+     "label": "."
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [703,259,57,26],
+     "leds": [30],
+     "label": "ENTER"
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [793,336,26,26],
+     "leds": [31]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,166,26,26],
+     "leds": [32],
+     "label": "F2"
+    },
+    {
+     "name": "Key2",
+     "rect": [396,203,26,26],
+     "leds": [33],
+     "label": "2"
+    },
+    {
+     "name": "KeyW",
+     "rect": [413,231,26,26],
+     "leds": [34],
+     "label": "W"
+    },
+    {
+     "name": "KeyS",
+     "rect": [422,259,26,26],
+     "leds": [35],
+     "label": "S"
+    },
+    {
+     "name": "KeyZ",
+     "rect": [403,287,26,26],
+     "leds": [36],
+     "label": "Z"
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [405,315,36,26],
+     "leds": [37],
+     "label": "ALT"
+    },
+    {
+     "name": "KeyScLock",
+     "rect": [793,166,26,26],
+     "leds": [38],
+     "label": "SC\rLOCK"
+    },
+    {
+     "name": "KeyBack",
+     "rect": [705,203,54,26],
+     "leds": [39],
+     "label": "BACKSPACE"
+    },
+    {
+     "name": "KeyF11",
+     "rect": [705,166,26,26],
+     "leds": [40],
+     "label": "F11"
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [649,203,26,26],
+     "leds": [41],
+     "label": "-"
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [666,231,26,26],
+     "leds": [42],
+     "label": "["
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [675,259,26,26],
+     "leds": [43],
+     "label": "'"
+    },
+    {
+     "name": "KeySlash",
+     "rect": [656,287,26,26],
+     "leds": [44,45,46],
+     "label": "k56"
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [821,336,26,26],
+     "leds": [47]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [452,166,26,26],
+     "leds": [48],
+     "label": "F3"
+    },
+    {
+     "name": "Key3",
+     "rect": [424,203,26,26],
+     "leds": [49],
+     "label": "3"
+    },
+    {
+     "name": "KeyE",
+     "rect": [441,231,26,26],
+     "leds": [50],
+     "label": "E"
+    },
+    {
+     "name": "KeyD",
+     "rect": [450,259,26,26],
+     "leds": [51],
+     "label": "D"
+    },
+    {
+     "name": "KeyX",
+     "rect": [431,287,26,26],
+     "leds": [52,53],
+     "label": "X"
+    },
+    {
+     "name": "KeyPause",
+     "rect": [821,166,26,26],
+     "leds": [54],
+     "label": "PAUSE"
+    },
+    {
+     "name": "KeyDel",
+     "rect": [765,231,26,26],
+     "leds": [55,56],
+     "label": "DELETE"
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [854,231,26,26],
+     "leds": [57],
+     "label": "7"
+    },
+    {
+     "name": "KeyP1",
+     "rect": [304,203,26,26],
+     "leds": [58,59],
+     "label": "P1"
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [854,203,26,26],
+     "leds": [60],
+     "label": "NUM\rLOCK"
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [910,259,26,26],
+     "leds": [61,62,63],
+     "label": "6"
+    },
+    {
+     "name": "KeyF4",
+     "rect": [480,166,26,26],
+     "leds": [64],
+     "label": "F4"
+    },
+    {
+     "name": "Key4",
+     "rect": [452,203,26,26],
+     "leds": [65],
+     "label": "4"
+    },
+    {
+     "name": "KeyR",
+     "rect": [469,231,26,26],
+     "leds": [66],
+     "label": "R"
+    },
+    {
+     "name": "KeyF",
+     "rect": [478,259,26,26],
+     "leds": [67],
+     "label": "F"
+    },
+    {
+     "name": "KeyC",
+     "rect": [459,287,26,26],
+     "leds": [68],
+     "label": "C"
+    },
+    {
+     "name": "KeySpace",
+     "rect": [443,315,185,46],
+     "leds": [69]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [765,203,26,26],
+     "leds": [70],
+     "label": "INSERT"
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [793,231,26,26],
+     "leds": [71,72],
+     "label": "END"
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [882,231,26,26],
+     "leds": [73],
+     "label": "8"
+    },
+    {
+     "name": "KeyP2",
+     "rect": [304,231,26,26],
+     "leds": [74,75],
+     "label": "P2"
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [882,203,26,26],
+     "leds": [76],
+     "label": "/"
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [854,287,26,26],
+     "leds": [77,78,79],
+     "label": "1"
+    },
+    {
+     "name": "KeyF5",
+     "rect": [522,166,26,26],
+     "leds": [80],
+     "label": "F5"
+    },
+    {
+     "name": "Key5",
+     "rect": [480,203,26,26],
+     "leds": [81],
+     "label": "5"
+    },
+    {
+     "name": "KeyT",
+     "rect": [497,231,26,26],
+     "leds": [82],
+     "label": "T"
+    },
+    {
+     "name": "KeyG",
+     "rect": [506,259,26,26],
+     "leds": [83],
+     "label": "G"
+    },
+    {
+     "name": "KeyV",
+     "rect": [487,287,26,26],
+     "leds": [84,85],
+     "label": "V"
+    },
+    {
+     "name": "KeyHome",
+     "rect": [793,203,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [821,231,26,26],
+     "leds": [87],
+     "label": "PG\rDN"
+    },
+    {
+     "name": "KeyStop",
+     "rect": [882,166,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [910,231,26,26],
+     "leds": [89],
+     "label": "9"
+    },
+    {
+     "name": "KeyP3",
+     "rect": [304,259,26,26],
+     "leds": [90,91],
+     "label": "P3"
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [910,203,26,26],
+     "leds": [92],
+     "label": "*"
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [882,287,26,26],
+     "leds": [93,94,95],
+     "label": "2"
+    },
+    {
+     "name": "KeyF6",
+     "rect": [550,166,26,26],
+     "leds": [96],
+     "label": "F6"
+    },
+    {
+     "name": "Key6",
+     "rect": [508,203,26,26],
+     "leds": [97],
+     "label": "6"
+    },
+    {
+     "name": "KeyY",
+     "rect": [526,231,26,26],
+     "leds": [98],
+     "label": "Y"
+    },
+    {
+     "name": "KeyH",
+     "rect": [534,259,26,26],
+     "leds": [99],
+     "label": "H"
+    },
+    {
+     "name": "KeyB",
+     "rect": [515,287,26,26],
+     "leds": [100,101],
+     "label": "B"
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [821,203,26,26],
+     "leds": [102],
+     "label": "PG\rUP"
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [684,287,76,26],
+     "leds": [103],
+     "label": "SHIFT"
+    },
+    {
+     "name": "KeyPreTrack",
+     "rect": [910,166,26,26],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [304,287,26,26],
+     "leds": [106,107],
+     "label": "P4"
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [938,203,26,26],
+     "leds": [108],
+     "label": "-"
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [910,287,26,26],
+     "leds": [109,110,111],
+     "label": "3"
+    },
+    {
+     "name": "KeyF7",
+     "rect": [578,166,26,26],
+     "leds": [112],
+     "label": "F7"
+    },
+    {
+     "name": "Key7",
+     "rect": [537,203,26,26],
+     "leds": [113],
+     "label": "7"
+    },
+    {
+     "name": "KeyU",
+     "rect": [554,231,26,26],
+     "leds": [114],
+     "label": "U"
+    },
+    {
+     "name": "KeyJ",
+     "rect": [562,259,26,26],
+     "leds": [115],
+     "label": "J"
+    },
+    {
+     "name": "KeyN",
+     "rect": [543,287,26,26],
+     "leds": [116],
+     "label": "N"
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [630,315,36,26],
+     "leds": [117],
+     "label": "ALT\r GR"
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [694,231,26,26],
+     "leds": [118],
+     "label": "]"
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [724,315,36,26],
+     "leds": [119],
+     "label": "CTRL"
+    },
+    {
+     "name": "KeyPlay",
+     "rect": [854,166,26,26],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [854,259,26,26],
+     "leds": [121],
+     "label": "4"
+    },
+    {
+     "name": "KeyP5",
+     "rect": [304,315,26,26],
+     "leds": [122,123],
+     "label": "P5"
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [938,231,26,54],
+     "leds": [124],
+     "label": "+"
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [854,315,54,26],
+     "leds": [125,126,127],
+     "label": "0"
+    },
+    {
+     "name": "KeyF8",
+     "rect": [607,166,26,26],
+     "leds": [128],
+     "label": "F8"
+    },
+    {
+     "name": "Key8",
+     "rect": [565,203,26,26],
+     "leds": [129],
+     "label": "8"
+    },
+    {
+     "name": "KeyI",
+     "rect": [582,231,26,26],
+     "leds": [130],
+     "label": "I"
+    },
+    {
+     "name": "KeyK",
+     "rect": [590,259,26,26],
+     "leds": [131],
+     "label": "K"
+    },
+    {
+     "name": "KeyM",
+     "rect": [572,287,26,26],
+     "leds": [132],
+     "label": "M"
+    },
+    {
+     "name": "KeyFn",
+     "rect": [668,315,26,26],
+     "leds": [133],
+     "label": "FN"
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [722,231,37,26],
+     "leds": [134],
+     "label": "\\"
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [793,307,26,26],
+     "leds": [135]
+    },
+    {
+     "name": "KeyNextTrack",
+     "rect": [938,166,26,26],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [882,259,26,26],
+     "leds": [137,138,139],
+     "label": "5"
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [938,287,26,54],
+     "leds": [140],
+     "label": "ENTER"
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [910,315,26,26],
+     "leds": [141],
+     "label": "."
+    }
+   ]
+  },
+  "Brunobear/Global": {
+   "id": "Brunobear/Global",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Cybug/Global": {
+   "id": "Cybug/Global",
+   "leds": 168,
+   "bounds": [352.0,125.0,858.0,284.0],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyP1",
+     "rect": [352.0,125.0,24.0,19.0],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyEsc",
+     "rect": [386.0,125.0,24.0,19.0],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [412.0,125.0,24.0,19.0],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [438.0,125.0,24.0,19.0],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [464.0,125.0,24.0,19.0],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [490.0,125.0,24.0,19.0],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyP2",
+     "rect": [352.0,147.0,24.0,24.0],
+     "leds": [12]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [386.0,147.0,24.0,24.0],
+     "leds": [13]
+    },
+    {
+     "name": "Key1",
+     "rect": [412.0,147.0,25.0,24.0],
+     "leds": [14]
+    },
+    {
+     "name": "Key2",
+     "rect": [439.0,147.0,25.0,24.0],
+     "leds": [15]
+    },
+    {
+     "name": "Key3",
+     "rect": [466.0,147.0,25.0,24.0],
+     "leds": [16]
+    },
+    {
+     "name": "Key4",
+     "rect": [493.0,147.0,25.0,24.0],
+     "leds": [17]
+    },
+    {
+     "name": "KeyP3",
+     "rect": [352.0,174.0,24.0,24.0],
+     "leds": [18]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [386.0,174.0,37.0,24.0],
+     "leds": [19,25,31]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [425.0,174.0,25.0,24.0],
+     "leds": [20]
+    },
+    {
+     "name": "KeyW",
+     "rect": [452.0,174.0,25.0,24.0],
+     "leds": [21]
+    },
+    {
+     "name": "KeyE",
+     "rect": [479.0,174.0,25.0,24.0],
+     "leds": [22]
+    },
+    {
+     "name": "KeyR",
+     "rect": [506.0,174.0,25.0,24.0],
+     "leds": [23]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [352.0,201.0,24.0,24.0],
+     "leds": [24]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [386.0,201.0,44.0,24.0],
+     "leds": [26,27]
+    },
+    {
+     "name": "KeyA",
+     "rect": [432.0,201.0,25.0,24.0],
+     "leds": [28]
+    },
+    {
+     "name": "KeyS",
+     "rect": [459.0,201.0,25.0,24.0],
+     "leds": [29]
+    },
+    {
+     "name": "KeyP5",
+     "rect": [352.0,228.0,24.0,24.0],
+     "leds": [30]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [445.0,228.0,25.0,24.0],
+     "leds": [32]
+    },
+    {
+     "name": "KeyX",
+     "rect": [472.0,228.0,25.0,24.0],
+     "leds": [33]
+    },
+    {
+     "name": "KeyC",
+     "rect": [499.0,228.0,25.0,24.0],
+     "leds": [34]
+    },
+    {
+     "name": "KeyD",
+     "rect": [486.0,201.0,25.0,24.0],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [386.0,228.0,57.0,24.0],
+     "leds": [36,37,38,39,40,41]
+    },
+    {
+     "name": "KeyP6",
+     "rect": [352.0,255.0,24.0,24.0],
+     "leds": [42]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [386.0,255.0,24.0,24.0],
+     "leds": [43]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [412.0,255.0,25.0,24.0],
+     "leds": [44]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [439.0,255.0,25.0,24.0],
+     "leds": [45]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [466.0,255.0,25.0,24.0],
+     "leds": [46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [516.0,125.0,24.0,19.0],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [542.0,125.0,24.0,19.0],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [568.0,125.0,24.0,19.0],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [594.0,125.0,24.0,19.0],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [620.0,125.0,24.0,19.0],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [646.0,125.0,24.0,19.0],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key5",
+     "rect": [520.0,147.0,25.0,24.0],
+     "leds": [72]
+    },
+    {
+     "name": "Key6",
+     "rect": [547.0,147.0,25.0,24.0],
+     "leds": [73]
+    },
+    {
+     "name": "Key7",
+     "rect": [574.0,147.0,25.0,24.0],
+     "leds": [74]
+    },
+    {
+     "name": "Key8",
+     "rect": [601.0,147.0,25.0,24.0],
+     "leds": [75]
+    },
+    {
+     "name": "Key9",
+     "rect": [628.0,147.0,25.0,24.0],
+     "leds": [76]
+    },
+    {
+     "name": "Key0",
+     "rect": [655.0,147.0,25.0,24.0],
+     "leds": [77]
+    },
+    {
+     "name": "KeyT",
+     "rect": [533.0,174.0,25.0,24.0],
+     "leds": [78]
+    },
+    {
+     "name": "KeyY",
+     "rect": [560.0,174.0,25.0,24.0],
+     "leds": [79]
+    },
+    {
+     "name": "KeyU",
+     "rect": [587.0,174.0,25.0,24.0],
+     "leds": [80]
+    },
+    {
+     "name": "KeyI",
+     "rect": [614.0,174.0,25.0,24.0],
+     "leds": [81]
+    },
+    {
+     "name": "KeyO",
+     "rect": [641.0,174.0,25.0,24.0],
+     "leds": [82]
+    },
+    {
+     "name": "KeyP",
+     "rect": [668.0,174.0,25.0,24.0],
+     "leds": [83]
+    },
+    {
+     "name": "KeyF",
+     "rect": [513.0,201.0,25.0,24.0],
+     "leds": [84]
+    },
+    {
+     "name": "KeyG",
+     "rect": [540.0,201.0,25.0,24.0],
+     "leds": [85]
+    },
+    {
+     "name": "KeyH",
+     "rect": [567.0,201.0,25.0,24.0],
+     "leds": [86]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [594.0,201.0,25.0,24.0],
+     "leds": [87]
+    },
+    {
+     "name": "KeyK",
+     "rect": [621.0,201.0,25.0,24.0],
+     "leds": [88]
+    },
+    {
+     "name": "KeyL",
+     "rect": [648.0,201.0,25.0,24.0],
+     "leds": [89]
+    },
+    {
+     "name": "KeyV",
+     "rect": [526.0,228.0,25.0,24.0],
+     "leds": [90]
+    },
+    {
+     "name": "KeyB",
+     "rect": [553.0,228.0,25.0,24.0],
+     "leds": [91]
+    },
+    {
+     "name": "KeyN",
+     "rect": [580.0,228.0,25.0,24.0],
+     "leds": [92]
+    },
+    {
+     "name": "KeyM",
+     "rect": [607.0,228.0,25.0,24.0],
+     "leds": [93]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [634.0,228.0,25.0,24.0],
+     "leds": [94]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [661.0,228.0,25.0,24.0],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [493.0,255.0,172.0,29.0],
+     "leds": [96,97,98,99,100]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [667.0,255.0,25.0,24.0],
+     "leds": [101,102,103,104,105,106]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [694.0,255.0,25.0,24.0],
+     "leds": [107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [672.0,125.0,24.0,19.0],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [698.0,125.0,24.0,19.0],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [724.0,125.0,24.0,19.0],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [750.0,125.0,24.0,19.0],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [782.0,125.0,24.0,19.0],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [808.0,125.0,24.0,19.0],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [682.0,147.0,25.0,24.0],
+     "leds": [132]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [709.0,147.0,25.0,24.0],
+     "leds": [133]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [736.0,147.0,38.0,24.0],
+     "leds": [134,135,136]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [834.0,125.0,24.0,19.0],
+     "leds": [137,143]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [695.0,174.0,25.0,24.0],
+     "leds": [138]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [722.0,174.0,25.0,24.0],
+     "leds": [139]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [749.0,174.0,25.0,24.0],
+     "leds": [140,141,142]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [675.0,201.0,25.0,24.0],
+     "leds": [144]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [702.0,201.0,25.0,24.0],
+     "leds": [145]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [729.0,201.0,44.0,24.0],
+     "leds": [146,147,148,149]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [782.0,147.0,24.0,24.0],
+     "leds": [150]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [808.0,147.0,24.0,24.0],
+     "leds": [151]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [834.0,147.0,24.0,24.0],
+     "leds": [152]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [782.0,174.0,24.0,24.0],
+     "leds": [153]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [808.0,174.0,24.0,24.0],
+     "leds": [154]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [834.0,174.0,24.0,24.0],
+     "leds": [155]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [688.0,228.0,25.0,24.0],
+     "leds": [156]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [715.0,228.0,58.0,24.0],
+     "leds": [157,158,159]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [807.0,228.0,24.0,24.0],
+     "leds": [160,161,162]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [721.0,255.0,25.0,24.0],
+     "leds": [163]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [748.0,255.0,25.0,24.0],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [781.0,255.0,24.0,24.0],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [807.0,255.0,24.0,24.0],
+     "leds": [166]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833.0,255.0,24.0,24.0],
+     "leds": [167]
+    }
+   ]
+  },
+  "Dojo/Global": {
+   "id": "Dojo/Global",
+   "leds": 176,
+   "bounds": [322,144,829,308],
+   "verified": true,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [322,144,26,19],
+     "leds": [0,1]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [351,144,26,19],
+     "leds": [2,3]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [380,144,26,19],
+     "leds": [4,5]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [409,144,26,19],
+     "leds": [6,7]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [438,144,26,19],
+     "leds": [8,9]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [467,144,26,19],
+     "leds": [10,11]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [496,144,26,19],
+     "leds": [12,13]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [525,144,26,19],
+     "leds": [14,15]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [554,144,26,19],
+     "leds": [16,17]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [583,144,26,19],
+     "leds": [18,19]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [612,144,26,19],
+     "leds": [20,21]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [641,144,26,19],
+     "leds": [22,23]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [670,144,26,19],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [699,144,26,19],
+     "leds": [26,27]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [728,144,23,19],
+     "leds": [28]
+    },
+    {
+     "name": "KeyCalc",
+     "rect": [754,144,23,19],
+     "leds": [29]
+    },
+    {
+     "name": "KeySetting",
+     "rect": [780,144,23,19],
+     "leds": [30]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [806,144,23,19],
+     "leds": [31]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [322,166,21,25],
+     "leds": [32,33]
+    },
+    {
+     "name": "Key1",
+     "rect": [346,166,25,25],
+     "leds": [34,35]
+    },
+    {
+     "name": "Key2",
+     "rect": [374,166,25,25],
+     "leds": [36,37]
+    },
+    {
+     "name": "Key3",
+     "rect": [402,166,25,25],
+     "leds": [38,39]
+    },
+    {
+     "name": "Key4",
+     "rect": [430,166,25,25],
+     "leds": [40,41]
+    },
+    {
+     "name": "Key5",
+     "rect": [458,166,25,25],
+     "leds": [42,43]
+    },
+    {
+     "name": "Key6",
+     "rect": [486,166,25,25],
+     "leds": [44,45]
+    },
+    {
+     "name": "Key7",
+     "rect": [514,166,25,25],
+     "leds": [46,47]
+    },
+    {
+     "name": "Key8",
+     "rect": [542,166,25,25],
+     "leds": [48,49]
+    },
+    {
+     "name": "Key9",
+     "rect": [570,166,25,25],
+     "leds": [50,51]
+    },
+    {
+     "name": "Key0",
+     "rect": [598,166,25,25],
+     "leds": [52,53]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [626,166,25,25],
+     "leds": [54,55]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [654,166,25,25],
+     "leds": [56,57]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [682,166,43,25],
+     "leds": [58,59,60,61,62,63]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [728,166,23,25],
+     "leds": [64]
+    },
+    {
+     "name": "KeyNumSlash",
+     "rect": [754,166,23,25],
+     "leds": [65]
+    },
+    {
+     "name": "KeyNumStar",
+     "rect": [780,166,23,25],
+     "leds": [66]
+    },
+    {
+     "name": "KeyNumDash",
+     "rect": [806,166,23,25],
+     "leds": [67]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [322,195,31,25],
+     "leds": [68,69,70,71]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [356,195,25,25],
+     "leds": [72]
+    },
+    {
+     "name": "KeyW",
+     "rect": [384,195,25,25],
+     "leds": [73]
+    },
+    {
+     "name": "KeyE",
+     "rect": [412,195,25,25],
+     "leds": [74]
+    },
+    {
+     "name": "KeyR",
+     "rect": [440,195,25,25],
+     "leds": [75]
+    },
+    {
+     "name": "KeyT",
+     "rect": [468,195,25,25],
+     "leds": [76]
+    },
+    {
+     "name": "KeyY",
+     "rect": [496,195,25,25],
+     "leds": [77]
+    },
+    {
+     "name": "KeyU",
+     "rect": [524,195,25,25],
+     "leds": [78]
+    },
+    {
+     "name": "KeyI",
+     "rect": [552,195,25,25],
+     "leds": [79]
+    },
+    {
+     "name": "KeyO",
+     "rect": [580,195,25,25],
+     "leds": [80]
+    },
+    {
+     "name": "KeyP",
+     "rect": [608,195,25,25],
+     "leds": [81,175]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [636,195,25,25],
+     "leds": [82,83]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [664,195,25,25],
+     "leds": [84,85]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [692,195,33,25],
+     "leds": [86,87]
+    },
+    {
+     "name": "KeyNum7",
+     "rect": [728,195,23,25],
+     "leds": [88]
+    },
+    {
+     "name": "KeyNum8",
+     "rect": [754,195,23,25],
+     "leds": [89]
+    },
+    {
+     "name": "KeyNum9",
+     "rect": [780,195,23,25],
+     "leds": [90]
+    },
+    {
+     "name": "KeyNumPlus",
+     "rect": [806,195,23,54],
+     "leds": [91,92,93,94]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [322,224,38,25],
+     "leds": [95,96,97,98,99]
+    },
+    {
+     "name": "KeyA",
+     "rect": [363,224,25,25],
+     "leds": [100]
+    },
+    {
+     "name": "KeyS",
+     "rect": [391,224,25,25],
+     "leds": [101]
+    },
+    {
+     "name": "KeyD",
+     "rect": [419,224,25,25],
+     "leds": [102]
+    },
+    {
+     "name": "KeyF",
+     "rect": [447,224,25,25],
+     "leds": [103]
+    },
+    {
+     "name": "KeyG",
+     "rect": [475,224,25,25],
+     "leds": [104]
+    },
+    {
+     "name": "KeyH",
+     "rect": [503,224,25,25],
+     "leds": [105]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [531,224,25,25],
+     "leds": [106]
+    },
+    {
+     "name": "KeyK",
+     "rect": [559,224,25,25],
+     "leds": [107]
+    },
+    {
+     "name": "KeyL",
+     "rect": [587,224,25,25],
+     "leds": [108]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [615,224,25,25],
+     "leds": [109,110]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [643,224,25,25],
+     "leds": [111,112]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [671,224,54,25],
+     "leds": [113,114,115,116,117]
+    },
+    {
+     "name": "KeyNum4",
+     "rect": [728,224,23,25],
+     "leds": [118]
+    },
+    {
+     "name": "KeyNum5",
+     "rect": [754,224,23,25],
+     "leds": [119]
+    },
+    {
+     "name": "KeyNum6",
+     "rect": [780,224,23,25],
+     "leds": [120]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [322,253,52,25],
+     "leds": [121,122,123,124,125,126,127]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [377,253,25,25],
+     "leds": [128]
+    },
+    {
+     "name": "KeyX",
+     "rect": [405,253,25,25],
+     "leds": [129]
+    },
+    {
+     "name": "KeyC",
+     "rect": [433,253,25,25],
+     "leds": [130]
+    },
+    {
+     "name": "KeyV",
+     "rect": [461,253,25,25],
+     "leds": [131]
+    },
+    {
+     "name": "KeyB",
+     "rect": [489,253,25,25],
+     "leds": [132]
+    },
+    {
+     "name": "KeyN",
+     "rect": [517,253,25,25],
+     "leds": [133]
+    },
+    {
+     "name": "KeyM",
+     "rect": [545,253,25,25],
+     "leds": [134]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [573,253,25,25],
+     "leds": [135,136]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [601,253,25,25],
+     "leds": [137,138]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [629,253,25,25],
+     "leds": [139,140]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [657,253,68,25],
+     "leds": [141,142,143,144,145,146]
+    },
+    {
+     "name": "KeyNum1",
+     "rect": [728,253,23,25],
+     "leds": [147]
+    },
+    {
+     "name": "KeyNum2",
+     "rect": [754,253,23,25],
+     "leds": [148]
+    },
+    {
+     "name": "KeyNum3",
+     "rect": [780,253,23,25],
+     "leds": [149]
+    },
+    {
+     "name": "KeyNumEnter",
+     "rect": [806,253,23,55],
+     "leds": [150,151,152,153]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [322,282,25,25],
+     "leds": [154]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [350,282,25,25],
+     "leds": [155]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [378,282,25,25],
+     "leds": [156]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [406,282,25,25],
+     "leds": [157]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [434,282,137,25],
+     "leds": [158,159,160,161,162]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [574,282,25,25],
+     "leds": [163]
+    },
+    {
+     "name": "KeyCopliot",
+     "rect": [602,282,25,25],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [630,282,25,25],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [658,282,39,12],
+     "leds": [166,167]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [658,295,39,12],
+     "leds": [168,169]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [700,282,25,25],
+     "leds": [170]
+    },
+    {
+     "name": "KeyNum0",
+     "rect": [728,282,49,25],
+     "leds": [171,172,173]
+    },
+    {
+     "name": "KeyNumDel",
+     "rect": [780,282,23,25],
+     "leds": [174]
+    }
+   ]
+  },
+  "Dojo/JP": {
+   "id": "Dojo/JP",
+   "leds": 176,
+   "bounds": [322,144,829,308],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [322,144,26,19],
+     "leds": [0,1]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [351,144,26,19],
+     "leds": [2,3]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [380,144,26,19],
+     "leds": [4,5]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [409,144,26,19],
+     "leds": [6,7]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [438,144,26,19],
+     "leds": [8,9]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [467,144,26,19],
+     "leds": [10,11]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [496,144,26,19],
+     "leds": [12,13]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [525,144,26,19],
+     "leds": [14,15]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [554,144,26,19],
+     "leds": [16,17]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [583,144,26,19],
+     "leds": [18,19]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [612,144,26,19],
+     "leds": [20,21]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [641,144,26,19],
+     "leds": [22,23]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [670,144,26,19],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [699,144,26,19],
+     "leds": [26,27]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [728,144,23,19],
+     "leds": [28]
+    },
+    {
+     "name": "KeyCalc",
+     "rect": [754,144,23,19],
+     "leds": [29]
+    },
+    {
+     "name": "KeySetting",
+     "rect": [780,144,23,19],
+     "leds": [30]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [806,144,23,19],
+     "leds": [31]
+    },
+    {
+     "name": "KeyJPFull",
+     "rect": [322,166,21,25],
+     "leds": [32,33]
+    },
+    {
+     "name": "Key1",
+     "rect": [346,166,25,25],
+     "leds": [34,35]
+    },
+    {
+     "name": "Key2",
+     "rect": [374,166,25,25],
+     "leds": [36,37]
+    },
+    {
+     "name": "Key3",
+     "rect": [402,166,25,25],
+     "leds": [38,39]
+    },
+    {
+     "name": "Key4",
+     "rect": [430,166,25,25],
+     "leds": [40,41]
+    },
+    {
+     "name": "Key5",
+     "rect": [458,166,25,25],
+     "leds": [42,43]
+    },
+    {
+     "name": "Key6",
+     "rect": [486,166,25,25],
+     "leds": [44,45]
+    },
+    {
+     "name": "Key7",
+     "rect": [514,166,25,25],
+     "leds": [46,47]
+    },
+    {
+     "name": "Key8",
+     "rect": [542,166,25,25],
+     "leds": [48,49]
+    },
+    {
+     "name": "Key9",
+     "rect": [570,166,25,25],
+     "leds": [50,51]
+    },
+    {
+     "name": "Key0",
+     "rect": [598,166,25,25],
+     "leds": [52,53]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [626,166,21,25],
+     "leds": [54,55]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [650,166,21,25],
+     "leds": [56,57]
+    },
+    {
+     "name": "KeyYen",
+     "rect": [674,166,21,25],
+     "leds": [58,59]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [698,166,27,25],
+     "leds": [60,61,62,63]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [728,166,23,25],
+     "leds": [64]
+    },
+    {
+     "name": "KeyNumSlash",
+     "rect": [754,166,23,25],
+     "leds": [65]
+    },
+    {
+     "name": "KeyNumStar",
+     "rect": [780,166,23,25],
+     "leds": [66]
+    },
+    {
+     "name": "KeyNumDash",
+     "rect": [806,166,23,25],
+     "leds": [67]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [322,195,31,25],
+     "leds": [68,69,70,71]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [356,195,25,25],
+     "leds": [72]
+    },
+    {
+     "name": "KeyW",
+     "rect": [384,195,25,25],
+     "leds": [73]
+    },
+    {
+     "name": "KeyE",
+     "rect": [412,195,25,25],
+     "leds": [74]
+    },
+    {
+     "name": "KeyR",
+     "rect": [440,195,25,25],
+     "leds": [75]
+    },
+    {
+     "name": "KeyT",
+     "rect": [468,195,25,25],
+     "leds": [76]
+    },
+    {
+     "name": "KeyY",
+     "rect": [496,195,25,25],
+     "leds": [77]
+    },
+    {
+     "name": "KeyU",
+     "rect": [524,195,25,25],
+     "leds": [78]
+    },
+    {
+     "name": "KeyI",
+     "rect": [552,195,25,25],
+     "leds": [79]
+    },
+    {
+     "name": "KeyO",
+     "rect": [580,195,25,25],
+     "leds": [80]
+    },
+    {
+     "name": "KeyP",
+     "rect": [608,195,25,25],
+     "leds": [81,175]
+    },
+    {
+     "name": "KeyAt",
+     "rect": [636,195,22,25],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [661,195,22,25],
+     "leds": [83]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [686,195,54,25],
+     "leds": [84,85,86,87,113,114,115,116,117]
+    },
+    {
+     "name": "KeyNum7",
+     "rect": [728,195,23,25],
+     "leds": [88]
+    },
+    {
+     "name": "KeyNum8",
+     "rect": [754,195,23,25],
+     "leds": [89]
+    },
+    {
+     "name": "KeyNum9",
+     "rect": [780,195,23,25],
+     "leds": [90]
+    },
+    {
+     "name": "KeyNumPlus",
+     "rect": [806,195,23,54],
+     "leds": [91,92,93,94]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [322,224,38,25],
+     "leds": [95,96,97,98,99]
+    },
+    {
+     "name": "KeyA",
+     "rect": [363,224,25,25],
+     "leds": [100]
+    },
+    {
+     "name": "KeyS",
+     "rect": [391,224,25,25],
+     "leds": [101]
+    },
+    {
+     "name": "KeyD",
+     "rect": [419,224,25,25],
+     "leds": [102]
+    },
+    {
+     "name": "KeyF",
+     "rect": [447,224,25,25],
+     "leds": [103]
+    },
+    {
+     "name": "KeyG",
+     "rect": [475,224,25,25],
+     "leds": [104]
+    },
+    {
+     "name": "KeyH",
+     "rect": [503,224,25,25],
+     "leds": [105]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [531,224,25,25],
+     "leds": [106]
+    },
+    {
+     "name": "KeyK",
+     "rect": [559,224,25,25],
+     "leds": [107]
+    },
+    {
+     "name": "KeyL",
+     "rect": [587,224,25,25],
+     "leds": [108]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [615,224,25,25],
+     "leds": [109]
+    },
+    {
+     "name": "KeyStar",
+     "rect": [643,224,22,25],
+     "leds": [110]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [668,224,22,25],
+     "leds": [111]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [679,253,46,25],
+     "leds": [112,141,142,143,144,145,146]
+    },
+    {
+     "name": "KeyNum4",
+     "rect": [728,224,23,25],
+     "leds": [118]
+    },
+    {
+     "name": "KeyNum5",
+     "rect": [754,224,23,25],
+     "leds": [119]
+    },
+    {
+     "name": "KeyNum6",
+     "rect": [780,224,23,25],
+     "leds": [120]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [322,253,52,25],
+     "leds": [121,122,123,124,125,126,127]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [377,253,25,25],
+     "leds": [128]
+    },
+    {
+     "name": "KeyX",
+     "rect": [405,253,25,25],
+     "leds": [129]
+    },
+    {
+     "name": "KeyC",
+     "rect": [433,253,25,25],
+     "leds": [130]
+    },
+    {
+     "name": "KeyV",
+     "rect": [461,253,25,25],
+     "leds": [131]
+    },
+    {
+     "name": "KeyB",
+     "rect": [489,253,25,25],
+     "leds": [132]
+    },
+    {
+     "name": "KeyN",
+     "rect": [517,253,25,25],
+     "leds": [133]
+    },
+    {
+     "name": "KeyM",
+     "rect": [545,253,25,25],
+     "leds": [134]
+    },
+    {
+     "name": "KeyChange",
+     "rect": [552,282,20,25],
+     "leds": [135]
+    },
+    {
+     "name": "KeyJPSomeKey",
+     "rect": [575,282,20,25],
+     "leds": [136]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [573,253,25,25],
+     "leds": [137]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [601,253,25,25],
+     "leds": [138]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [629,253,22,25],
+     "leds": [139]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [654,253,22,25],
+     "leds": [140]
+    },
+    {
+     "name": "KeyNum1",
+     "rect": [728,253,23,25],
+     "leds": [147]
+    },
+    {
+     "name": "KeyNum2",
+     "rect": [754,253,23,25],
+     "leds": [148]
+    },
+    {
+     "name": "KeyNum3",
+     "rect": [780,253,23,25],
+     "leds": [149]
+    },
+    {
+     "name": "KeyNumEnter",
+     "rect": [806,253,23,55],
+     "leds": [150,151,152,153]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [322,282,20,25],
+     "leds": [154]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [345,282,20,25],
+     "leds": [155]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [368,282,20,25],
+     "leds": [156]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [391,282,20,25],
+     "leds": [157]
+    },
+    {
+     "name": "KeyNoChange",
+     "rect": [414,282,20,25],
+     "leds": [158]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [438,282,111,25],
+     "leds": [159,160,161,162]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [598,282,20,25],
+     "leds": [163]
+    },
+    {
+     "name": "KeyCopliot",
+     "rect": [621,282,20,25],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [644,282,25,25],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [672,282,25,12],
+     "leds": [166,167]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [672,295,25,12],
+     "leds": [168,169]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [700,282,25,25],
+     "leds": [170]
+    },
+    {
+     "name": "KeyNum0",
+     "rect": [728,282,49,25],
+     "leds": [171,172,173]
+    },
+    {
+     "name": "KeyNumDel",
+     "rect": [780,282,23,25],
+     "leds": [174]
+    }
+   ]
+  },
+  "Dojo26C1/Global": {
+   "id": "Dojo26C1/Global",
+   "leds": 176,
+   "bounds": [322,144,829,308],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [322,144,26,19],
+     "leds": [0,1]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [351,144,26,19],
+     "leds": [2,3]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [380,144,26,19],
+     "leds": [4,5]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [409,144,26,19],
+     "leds": [6,7]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [438,144,26,19],
+     "leds": [8,9]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [467,144,26,19],
+     "leds": [10,11]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [496,144,26,19],
+     "leds": [12,13]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [525,144,26,19],
+     "leds": [14,15]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [554,144,26,19],
+     "leds": [16,17]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [583,144,26,19],
+     "leds": [18,19]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [612,144,26,19],
+     "leds": [20,21]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [641,144,26,19],
+     "leds": [22,23]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [670,144,26,19],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [699,144,26,19],
+     "leds": [26,27]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [728,144,23,19],
+     "leds": [28]
+    },
+    {
+     "name": "KeyCalc",
+     "rect": [754,144,23,19],
+     "leds": [29]
+    },
+    {
+     "name": "KeySetting",
+     "rect": [780,144,23,19],
+     "leds": [30]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [806,144,23,19],
+     "leds": [31]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [322,166,21,25],
+     "leds": [32,33]
+    },
+    {
+     "name": "Key1",
+     "rect": [346,166,25,25],
+     "leds": [34,35]
+    },
+    {
+     "name": "Key2",
+     "rect": [374,166,25,25],
+     "leds": [36,37]
+    },
+    {
+     "name": "Key3",
+     "rect": [402,166,25,25],
+     "leds": [38,39]
+    },
+    {
+     "name": "Key4",
+     "rect": [430,166,25,25],
+     "leds": [40,41]
+    },
+    {
+     "name": "Key5",
+     "rect": [458,166,25,25],
+     "leds": [42,43]
+    },
+    {
+     "name": "Key6",
+     "rect": [486,166,25,25],
+     "leds": [44,45]
+    },
+    {
+     "name": "Key7",
+     "rect": [514,166,25,25],
+     "leds": [46,47]
+    },
+    {
+     "name": "Key8",
+     "rect": [542,166,25,25],
+     "leds": [48,49]
+    },
+    {
+     "name": "Key9",
+     "rect": [570,166,25,25],
+     "leds": [50,51]
+    },
+    {
+     "name": "Key0",
+     "rect": [598,166,25,25],
+     "leds": [52,53]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [626,166,25,25],
+     "leds": [54,55]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [654,166,25,25],
+     "leds": [56,57]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [682,166,43,25],
+     "leds": [58,59,60,61,62,63]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [728,166,23,25],
+     "leds": [64]
+    },
+    {
+     "name": "KeyNumSlash",
+     "rect": [754,166,23,25],
+     "leds": [65]
+    },
+    {
+     "name": "KeyNumStar",
+     "rect": [780,166,23,25],
+     "leds": [66]
+    },
+    {
+     "name": "KeyNumDash",
+     "rect": [806,166,23,25],
+     "leds": [67]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [322,195,35,25],
+     "leds": [68,69,70,71]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [360,195,25,25],
+     "leds": [72]
+    },
+    {
+     "name": "KeyW",
+     "rect": [388,195,25,25],
+     "leds": [73]
+    },
+    {
+     "name": "KeyE",
+     "rect": [416,195,25,25],
+     "leds": [74]
+    },
+    {
+     "name": "KeyR",
+     "rect": [444,195,25,25],
+     "leds": [75]
+    },
+    {
+     "name": "KeyT",
+     "rect": [472,195,25,25],
+     "leds": [76]
+    },
+    {
+     "name": "KeyY",
+     "rect": [500,195,25,25],
+     "leds": [77]
+    },
+    {
+     "name": "KeyU",
+     "rect": [528,195,25,25],
+     "leds": [78]
+    },
+    {
+     "name": "KeyI",
+     "rect": [556,195,25,25],
+     "leds": [79]
+    },
+    {
+     "name": "KeyO",
+     "rect": [584,195,25,25],
+     "leds": [80]
+    },
+    {
+     "name": "KeyP",
+     "rect": [612,195,25,25],
+     "leds": [81]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [640,195,25,25],
+     "leds": [82,83]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [668,195,25,25],
+     "leds": [84,85]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [696,195,29,25],
+     "leds": [86,87]
+    },
+    {
+     "name": "KeyNum7",
+     "rect": [728,195,23,25],
+     "leds": [88]
+    },
+    {
+     "name": "KeyNum8",
+     "rect": [754,195,23,25],
+     "leds": [89]
+    },
+    {
+     "name": "KeyNum9",
+     "rect": [780,195,23,25],
+     "leds": [90]
+    },
+    {
+     "name": "KeyNumPlus",
+     "rect": [806,195,23,54],
+     "leds": [91,92,93,94]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [322,224,38,25],
+     "leds": [95,96,97,98,175]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [630,282,39,25],
+     "leds": [99,165]
+    },
+    {
+     "name": "KeyA",
+     "rect": [363,224,25,25],
+     "leds": [100]
+    },
+    {
+     "name": "KeyS",
+     "rect": [391,224,25,25],
+     "leds": [101]
+    },
+    {
+     "name": "KeyD",
+     "rect": [419,224,25,25],
+     "leds": [102]
+    },
+    {
+     "name": "KeyF",
+     "rect": [447,224,25,25],
+     "leds": [103]
+    },
+    {
+     "name": "KeyG",
+     "rect": [475,224,25,25],
+     "leds": [104]
+    },
+    {
+     "name": "KeyH",
+     "rect": [503,224,25,25],
+     "leds": [105]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [531,224,25,25],
+     "leds": [106]
+    },
+    {
+     "name": "KeyK",
+     "rect": [559,224,25,25],
+     "leds": [107]
+    },
+    {
+     "name": "KeyL",
+     "rect": [587,224,25,25],
+     "leds": [108]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [615,224,25,25],
+     "leds": [109,110]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [643,224,25,25],
+     "leds": [111,112]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [671,224,54,25],
+     "leds": [113,114,115,116,117,139]
+    },
+    {
+     "name": "KeyNum4",
+     "rect": [728,224,23,25],
+     "leds": [118]
+    },
+    {
+     "name": "KeyNum5",
+     "rect": [754,224,23,25],
+     "leds": [119]
+    },
+    {
+     "name": "KeyNum6",
+     "rect": [780,224,23,25],
+     "leds": [120]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [322,253,52,25],
+     "leds": [121,122,123,124,125,126,127]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [377,253,25,25],
+     "leds": [128]
+    },
+    {
+     "name": "KeyX",
+     "rect": [405,253,25,25],
+     "leds": [129]
+    },
+    {
+     "name": "KeyC",
+     "rect": [433,253,25,25],
+     "leds": [130]
+    },
+    {
+     "name": "KeyV",
+     "rect": [461,253,25,25],
+     "leds": [131]
+    },
+    {
+     "name": "KeyB",
+     "rect": [489,253,25,25],
+     "leds": [132]
+    },
+    {
+     "name": "KeyN",
+     "rect": [517,253,25,25],
+     "leds": [133]
+    },
+    {
+     "name": "KeyM",
+     "rect": [545,253,25,25],
+     "leds": [134]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [573,253,25,25],
+     "leds": [135,136]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [629,253,25,25],
+     "leds": [140,166]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [657,253,40,25],
+     "leds": [141,142,143,144,145]
+    },
+    {
+     "name": "KeyNum1",
+     "rect": [728,253,23,25],
+     "leds": [147]
+    },
+    {
+     "name": "KeyNum2",
+     "rect": [754,253,23,25],
+     "leds": [148]
+    },
+    {
+     "name": "KeyNum3",
+     "rect": [780,253,23,25],
+     "leds": [149]
+    },
+    {
+     "name": "KeyNumEnter",
+     "rect": [806,253,23,55],
+     "leds": [150,151,152,153]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [322,282,25,25],
+     "leds": [154]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [350,282,25,25],
+     "leds": [155]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [378,282,25,25],
+     "leds": [156]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [406,282,25,25],
+     "leds": [157]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [434,282,137,25],
+     "leds": [158,159,160,161,162]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [574,282,25,25],
+     "leds": [163]
+    },
+    {
+     "name": "KeyCopliot",
+     "rect": [602,282,25,25],
+     "leds": [164]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [601,253,25,25],
+     "leds": [167,168]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [672,282,25,25],
+     "leds": [169]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [700,253,25,25],
+     "leds": [170]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [700,282,25,25],
+     "leds": [171]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [728,282,23,25],
+     "leds": [172]
+    },
+    {
+     "name": "KeyNum0",
+     "rect": [754,282,23,25],
+     "leds": [173]
+    },
+    {
+     "name": "KeyNumDel",
+     "rect": [780,282,23,25],
+     "leds": [174]
+    }
+   ]
+  },
+  "Dojo26C1/JP": {
+   "id": "Dojo26C1/JP",
+   "leds": 176,
+   "bounds": [322,144,829,308],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [322,144,26,19],
+     "leds": [0,1]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [351,144,26,19],
+     "leds": [2,3]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [380,144,26,19],
+     "leds": [4,5]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [409,144,26,19],
+     "leds": [6,7]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [438,144,26,19],
+     "leds": [8,9]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [467,144,26,19],
+     "leds": [10,11]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [496,144,26,19],
+     "leds": [12,13]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [525,144,26,19],
+     "leds": [14,15]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [554,144,26,19],
+     "leds": [16,17]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [583,144,26,19],
+     "leds": [18,19]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [612,144,26,19],
+     "leds": [20,21]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [641,144,26,19],
+     "leds": [22,23]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [670,144,26,19],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [699,144,26,19],
+     "leds": [26,27]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [728,144,23,19],
+     "leds": [28]
+    },
+    {
+     "name": "KeyCalc",
+     "rect": [754,144,23,19],
+     "leds": [29]
+    },
+    {
+     "name": "KeySetting",
+     "rect": [780,144,23,19],
+     "leds": [30]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [806,144,23,19],
+     "leds": [31]
+    },
+    {
+     "name": "KeyJPFull",
+     "rect": [322,166,21,25],
+     "leds": [32,33]
+    },
+    {
+     "name": "Key1",
+     "rect": [346,166,25,25],
+     "leds": [34,35]
+    },
+    {
+     "name": "Key2",
+     "rect": [374,166,25,25],
+     "leds": [36,37]
+    },
+    {
+     "name": "Key3",
+     "rect": [402,166,25,25],
+     "leds": [38,39]
+    },
+    {
+     "name": "Key4",
+     "rect": [430,166,25,25],
+     "leds": [40,41]
+    },
+    {
+     "name": "Key5",
+     "rect": [458,166,25,25],
+     "leds": [42,43]
+    },
+    {
+     "name": "Key6",
+     "rect": [486,166,25,25],
+     "leds": [44,45]
+    },
+    {
+     "name": "Key7",
+     "rect": [514,166,25,25],
+     "leds": [46,47]
+    },
+    {
+     "name": "Key8",
+     "rect": [542,166,25,25],
+     "leds": [48,49]
+    },
+    {
+     "name": "Key9",
+     "rect": [570,166,25,25],
+     "leds": [50,51]
+    },
+    {
+     "name": "Key0",
+     "rect": [598,166,25,25],
+     "leds": [52,53]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [626,166,21,25],
+     "leds": [54,55]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [650,166,21,25],
+     "leds": [56,57]
+    },
+    {
+     "name": "KeyYen",
+     "rect": [674,166,21,25],
+     "leds": [58,59]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [698,166,27,25],
+     "leds": [60,61,62]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [728,166,23,25],
+     "leds": [63]
+    },
+    {
+     "name": "KeyNumSlash",
+     "rect": [754,166,23,25],
+     "leds": [64]
+    },
+    {
+     "name": "KeyNumStar",
+     "rect": [780,166,23,25],
+     "leds": [65]
+    },
+    {
+     "name": "KeyNumDash",
+     "rect": [806,166,23,25],
+     "leds": [66]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [322,195,31,25],
+     "leds": [67,68,69]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [356,195,25,25],
+     "leds": [70]
+    },
+    {
+     "name": "KeyW",
+     "rect": [384,195,25,25],
+     "leds": [71]
+    },
+    {
+     "name": "KeyE",
+     "rect": [412,195,25,25],
+     "leds": [72]
+    },
+    {
+     "name": "KeyR",
+     "rect": [440,195,25,25],
+     "leds": [73]
+    },
+    {
+     "name": "KeyT",
+     "rect": [468,195,25,25],
+     "leds": [74]
+    },
+    {
+     "name": "KeyY",
+     "rect": [496,195,25,25],
+     "leds": [75]
+    },
+    {
+     "name": "KeyU",
+     "rect": [524,195,25,25],
+     "leds": [76]
+    },
+    {
+     "name": "KeyI",
+     "rect": [552,195,25,25],
+     "leds": [77]
+    },
+    {
+     "name": "KeyO",
+     "rect": [580,195,25,25],
+     "leds": [78]
+    },
+    {
+     "name": "KeyP",
+     "rect": [608,195,25,25],
+     "leds": [79]
+    },
+    {
+     "name": "KeyAt",
+     "rect": [636,195,22,25],
+     "leds": [80,81]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [661,195,22,25],
+     "leds": [82,83]
+    },
+    {
+     "name": "KeyNum7",
+     "rect": [728,195,23,25],
+     "leds": [84]
+    },
+    {
+     "name": "KeyNum8",
+     "rect": [754,195,23,25],
+     "leds": [85]
+    },
+    {
+     "name": "KeyNum9",
+     "rect": [780,195,23,25],
+     "leds": [86]
+    },
+    {
+     "name": "KeyNumPlus",
+     "rect": [806,195,23,54],
+     "leds": [87,88,89,90]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [322,224,38,25],
+     "leds": [91,92,93,94,95]
+    },
+    {
+     "name": "KeyA",
+     "rect": [363,224,25,25],
+     "leds": [96]
+    },
+    {
+     "name": "KeyS",
+     "rect": [391,224,25,25],
+     "leds": [97]
+    },
+    {
+     "name": "KeyD",
+     "rect": [419,224,25,25],
+     "leds": [98]
+    },
+    {
+     "name": "KeyF",
+     "rect": [447,224,25,25],
+     "leds": [99]
+    },
+    {
+     "name": "KeyG",
+     "rect": [475,224,25,25],
+     "leds": [100]
+    },
+    {
+     "name": "KeyH",
+     "rect": [503,224,25,25],
+     "leds": [101]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [531,224,25,25],
+     "leds": [102]
+    },
+    {
+     "name": "KeyK",
+     "rect": [559,224,25,25],
+     "leds": [103]
+    },
+    {
+     "name": "KeyL",
+     "rect": [587,224,25,25],
+     "leds": [104]
+    },
+    {
+     "name": "KeyStar",
+     "rect": [643,224,22,25],
+     "leds": [105,106]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [668,224,22,25],
+     "leds": [107,108]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [686,195,54,25],
+     "leds": [109,110,111,112,113,114,115]
+    },
+    {
+     "name": "KeyNum4",
+     "rect": [728,224,23,25],
+     "leds": [116]
+    },
+    {
+     "name": "KeyNum5",
+     "rect": [754,224,23,25],
+     "leds": [117]
+    },
+    {
+     "name": "KeyNum6",
+     "rect": [780,224,23,25],
+     "leds": [118]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [322,253,52,25],
+     "leds": [119,120,121,122,123,124,125]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [377,253,25,25],
+     "leds": [126]
+    },
+    {
+     "name": "KeyX",
+     "rect": [405,253,25,25],
+     "leds": [127]
+    },
+    {
+     "name": "KeyC",
+     "rect": [433,253,25,25],
+     "leds": [128]
+    },
+    {
+     "name": "KeyV",
+     "rect": [461,253,25,25],
+     "leds": [129]
+    },
+    {
+     "name": "KeyB",
+     "rect": [489,253,25,25],
+     "leds": [130]
+    },
+    {
+     "name": "KeyN",
+     "rect": [517,253,25,25],
+     "leds": [131]
+    },
+    {
+     "name": "KeyM",
+     "rect": [545,253,25,25],
+     "leds": [132]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [573,253,20,25],
+     "leds": [133,134]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [596,253,20,25],
+     "leds": [135,136]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [642,253,20,25],
+     "leds": [139]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [665,253,34,25],
+     "leds": [140,141,142,143,144]
+    },
+    {
+     "name": "KeyNum1",
+     "rect": [728,253,23,25],
+     "leds": [145]
+    },
+    {
+     "name": "KeyNum3",
+     "rect": [780,253,23,25],
+     "leds": [147]
+    },
+    {
+     "name": "KeyNumEnter",
+     "rect": [806,253,23,55],
+     "leds": [148,149,150,151]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [322,282,20,25],
+     "leds": [152]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [345,282,20,25],
+     "leds": [153]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [368,282,20,25],
+     "leds": [154]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [391,282,20,25],
+     "leds": [155]
+    },
+    {
+     "name": "KeyNoChange",
+     "rect": [414,282,20,25],
+     "leds": [156]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [437,282,115,25],
+     "leds": [157,158,159,160,161,162]
+    },
+    {
+     "name": "KeyChange",
+     "rect": [556,282,20,25],
+     "leds": [163]
+    },
+    {
+     "name": "KeyJPSomeKey",
+     "rect": [579,282,20,25],
+     "leds": [164]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [602,282,20,25],
+     "leds": [165]
+    },
+    {
+     "name": "KeyCopliot",
+     "rect": [625,282,20,25],
+     "leds": [166]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [648,282,25,25],
+     "leds": [167]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [676,282,23,25],
+     "leds": [168]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [702,253,23,25],
+     "leds": [169]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [702,282,23,25],
+     "leds": [170]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [728,282,23,25],
+     "leds": [171]
+    },
+    {
+     "name": "KeyNum0",
+     "rect": [754,282,23,25],
+     "leds": [172]
+    },
+    {
+     "name": "KeyNumDel",
+     "rect": [780,282,23,25],
+     "leds": [173,174,175]
+    }
+   ]
+  },
+  "Dragon/Global": {
+   "id": "Dragon/Global",
+   "leds": 140,
+   "bounds": [148,114,849,373],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [193,114,34,35],
+     "leds": [0]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [227,114,34,35],
+     "leds": [1]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [261,114,34,35],
+     "leds": [2]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [295,114,34,35],
+     "leds": [3]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [329,114,34,35],
+     "leds": [4]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [363,114,34,35],
+     "leds": [5]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [397,114,34,35],
+     "leds": [6]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [431,114,34,35],
+     "leds": [7]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [193,157,34,35],
+     "leds": [8]
+    },
+    {
+     "name": "Key1",
+     "rect": [227,157,34,35],
+     "leds": [9]
+    },
+    {
+     "name": "Key2",
+     "rect": [261,157,34,35],
+     "leds": [10]
+    },
+    {
+     "name": "Key3",
+     "rect": [295,157,34,35],
+     "leds": [11]
+    },
+    {
+     "name": "Key4",
+     "rect": [329,157,34,35],
+     "leds": [12]
+    },
+    {
+     "name": "Key5",
+     "rect": [363,157,34,35],
+     "leds": [13]
+    },
+    {
+     "name": "Key6",
+     "rect": [397,157,34,35],
+     "leds": [14]
+    },
+    {
+     "name": "Key7",
+     "rect": [431,157,34,35],
+     "leds": [15]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [193,192,52,34],
+     "leds": [16]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [245,192,34,34],
+     "leds": [17]
+    },
+    {
+     "name": "KeyW",
+     "rect": [279,192,34,34],
+     "leds": [18]
+    },
+    {
+     "name": "KeyE",
+     "rect": [313,192,34,34],
+     "leds": [19]
+    },
+    {
+     "name": "KeyR",
+     "rect": [347,192,34,34],
+     "leds": [20]
+    },
+    {
+     "name": "KeyT",
+     "rect": [381,192,34,34],
+     "leds": [21]
+    },
+    {
+     "name": "KeyY",
+     "rect": [415,192,34,34],
+     "leds": [22]
+    },
+    {
+     "name": "KeyU",
+     "rect": [449,192,34,34],
+     "leds": [23]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [193,226,60,34],
+     "leds": [24]
+    },
+    {
+     "name": "KeyA",
+     "rect": [253,226,34,34],
+     "leds": [25]
+    },
+    {
+     "name": "KeyS",
+     "rect": [287,226,34,34],
+     "leds": [26]
+    },
+    {
+     "name": "KeyD",
+     "rect": [321,226,34,34],
+     "leds": [27]
+    },
+    {
+     "name": "KeyF",
+     "rect": [355,226,34,34],
+     "leds": [28]
+    },
+    {
+     "name": "KeyG",
+     "rect": [389,226,34,34],
+     "leds": [29]
+    },
+    {
+     "name": "KeyH",
+     "rect": [423,226,34,34],
+     "leds": [30]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [457,226,34,34],
+     "leds": [31]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [193,260,75,34],
+     "leds": [32,33]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [268,260,34,34],
+     "leds": [34]
+    },
+    {
+     "name": "KeyX",
+     "rect": [302,260,34,34],
+     "leds": [35]
+    },
+    {
+     "name": "KeyC",
+     "rect": [336,260,34,34],
+     "leds": [36]
+    },
+    {
+     "name": "KeyV",
+     "rect": [370,260,34,34],
+     "leds": [37]
+    },
+    {
+     "name": "KeyB",
+     "rect": [404,260,34,34],
+     "leds": [38]
+    },
+    {
+     "name": "KeyN",
+     "rect": [438,260,34,34],
+     "leds": [39]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [193,294,41,34],
+     "leds": [40]
+    },
+    {
+     "name": "KeyFN",
+     "rect": [234,294,34,34],
+     "leds": [41]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [268,294,34,34],
+     "leds": [42]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [302,294,34,34],
+     "leds": [43,44]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [336,294,204,42],
+     "leds": [45,46,47]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [465,114,34,35],
+     "leds": [48]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [499,114,34,35],
+     "leds": [49]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [533,114,34,35],
+     "leds": [50]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [567,114,34,35],
+     "leds": [51]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [601,114,34,35],
+     "leds": [52]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [635,114,34,35],
+     "leds": [53]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [669,114,34,35],
+     "leds": [54]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [713,114,34,35],
+     "leds": [55]
+    },
+    {
+     "name": "Key8",
+     "rect": [465,157,34,35],
+     "leds": [56]
+    },
+    {
+     "name": "Key9",
+     "rect": [499,157,34,35],
+     "leds": [57]
+    },
+    {
+     "name": "Key0",
+     "rect": [533,157,34,35],
+     "leds": [58]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [567,157,34,35],
+     "leds": [59]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [601,157,34,35],
+     "leds": [60]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [635,157,68,35],
+     "leds": [61,62]
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [713,157,34,35],
+     "leds": [63]
+    },
+    {
+     "name": "KeyI",
+     "rect": [483,192,34,34],
+     "leds": [64]
+    },
+    {
+     "name": "KeyO",
+     "rect": [517,192,34,34],
+     "leds": [65]
+    },
+    {
+     "name": "KeyP",
+     "rect": [551,192,34,34],
+     "leds": [66]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [585,192,34,34],
+     "leds": [67]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [619,192,34,34],
+     "leds": [68]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [653,192,51,34],
+     "leds": [69,70]
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [713,192,34,35],
+     "leds": [71]
+    },
+    {
+     "name": "KeyK",
+     "rect": [491,226,34,34],
+     "leds": [72]
+    },
+    {
+     "name": "KeyL",
+     "rect": [525,226,34,34],
+     "leds": [73]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [559,226,34,34],
+     "leds": [74]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [593,226,34,34],
+     "leds": [75]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [627,226,77,34],
+     "leds": [76,77]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [608,260,96,34],
+     "leds": [78,84,85]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [713,226,34,34],
+     "leds": [79]
+    },
+    {
+     "name": "KeyM",
+     "rect": [472,260,34,34],
+     "leds": [80]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [506,260,34,34],
+     "leds": [81]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [540,260,34,34],
+     "leds": [82]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [574,260,34,34],
+     "leds": [83]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [692,305,34,34],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [713,260,34,34],
+     "leds": [87]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [540,294,34,34],
+     "leds": [88]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [574,294,96,34],
+     "leds": [89,90,91,92]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [658,339,34,34],
+     "leds": [93]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [692,339,34,34],
+     "leds": [94]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [726,339,34,34],
+     "leds": [95]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [747,114,34,35],
+     "leds": [96]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [781,114,34,35],
+     "leds": [97]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [815,114,34,35],
+     "leds": [98]
+    },
+    {
+     "name": "KeyP1",
+     "rect": [148,114,35,35],
+     "leds": [99,100,101,102,103]
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [747,157,34,35],
+     "leds": [104]
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [781,157,34,35],
+     "leds": [105]
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [815,157,34,35],
+     "leds": [106]
+    },
+    {
+     "name": "KeyP2",
+     "rect": [148,157,35,35],
+     "leds": [107,108,109,110,111]
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [747,192,34,35],
+     "leds": [112]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [781,192,34,35],
+     "leds": [113]
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [815,192.5,34,68],
+     "leds": [114,122]
+    },
+    {
+     "name": "KeyP3",
+     "rect": [148,192,35,35],
+     "leds": [115,116,117,118,119]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [747,226,34,35],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [781,226,34,35],
+     "leds": [121]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [148,226,35,35],
+     "leds": [123,124,125,126,127]
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [747,260,34,35],
+     "leds": [128]
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [781,260,34,35],
+     "leds": [129]
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [815,260.5,34,68],
+     "leds": [130,138]
+    },
+    {
+     "name": "KeyP5",
+     "rect": [148,260,35,35],
+     "leds": [131,132,133,134,135]
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [747,294,34,35],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [781,294,34,35],
+     "leds": [137]
+    },
+    {
+     "name": "KeyP6",
+     "rect": [148,294,35,35],
+     "leds": [139]
+    }
+   ]
+  },
+  "Dragon/JP": {
+   "id": "Dragon/JP",
+   "leds": 140,
+   "bounds": [148,114,849,373],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [193,114,34,35],
+     "leds": [0]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [227,114,34,35],
+     "leds": [1]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [261,114,34,35],
+     "leds": [2]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [295,114,34,35],
+     "leds": [3]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [329,114,34,35],
+     "leds": [4]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [363,114,34,35],
+     "leds": [5]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [397,114,34,35],
+     "leds": [6]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [431,114,34,35],
+     "leds": [7]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [193,157,34,35],
+     "leds": [8]
+    },
+    {
+     "name": "Key1",
+     "rect": [227,157,34,35],
+     "leds": [9]
+    },
+    {
+     "name": "Key2",
+     "rect": [261,157,34,35],
+     "leds": [10]
+    },
+    {
+     "name": "Key3",
+     "rect": [295,157,34,35],
+     "leds": [11]
+    },
+    {
+     "name": "Key4",
+     "rect": [329,157,34,35],
+     "leds": [12]
+    },
+    {
+     "name": "Key5",
+     "rect": [363,157,34,35],
+     "leds": [13]
+    },
+    {
+     "name": "Key6",
+     "rect": [397,157,34,35],
+     "leds": [14]
+    },
+    {
+     "name": "Key7",
+     "rect": [431,157,34,35],
+     "leds": [15]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [193,192,52,34],
+     "leds": [16]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [245,192,34,34],
+     "leds": [17]
+    },
+    {
+     "name": "KeyW",
+     "rect": [279,192,34,34],
+     "leds": [18]
+    },
+    {
+     "name": "KeyE",
+     "rect": [313,192,34,34],
+     "leds": [19]
+    },
+    {
+     "name": "KeyR",
+     "rect": [347,192,34,34],
+     "leds": [20]
+    },
+    {
+     "name": "KeyT",
+     "rect": [381,192,34,34],
+     "leds": [21]
+    },
+    {
+     "name": "KeyY",
+     "rect": [415,192,34,34],
+     "leds": [22]
+    },
+    {
+     "name": "KeyU",
+     "rect": [449,192,34,34],
+     "leds": [23]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [193,226,60,34],
+     "leds": [24]
+    },
+    {
+     "name": "KeyA",
+     "rect": [253,226,34,34],
+     "leds": [25]
+    },
+    {
+     "name": "KeyS",
+     "rect": [287,226,34,34],
+     "leds": [26]
+    },
+    {
+     "name": "KeyD",
+     "rect": [321,226,34,34],
+     "leds": [27]
+    },
+    {
+     "name": "KeyF",
+     "rect": [355,226,34,34],
+     "leds": [28]
+    },
+    {
+     "name": "KeyG",
+     "rect": [389,226,34,34],
+     "leds": [29]
+    },
+    {
+     "name": "KeyH",
+     "rect": [423,226,34,34],
+     "leds": [30]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [457,226,34,34],
+     "leds": [31]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [193,260,75,34],
+     "leds": [32,33]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [268,260,34,34],
+     "leds": [34]
+    },
+    {
+     "name": "KeyX",
+     "rect": [302,260,34,34],
+     "leds": [35]
+    },
+    {
+     "name": "KeyC",
+     "rect": [336,260,34,34],
+     "leds": [36]
+    },
+    {
+     "name": "KeyV",
+     "rect": [370,260,34,34],
+     "leds": [37]
+    },
+    {
+     "name": "KeyB",
+     "rect": [404,260,34,34],
+     "leds": [38]
+    },
+    {
+     "name": "KeyN",
+     "rect": [438,260,34,34],
+     "leds": [39]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [193,294,32,34],
+     "leds": [40]
+    },
+    {
+     "name": "KeyFN",
+     "rect": [226,294,32,34],
+     "leds": [41]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [259,294,32,34],
+     "leds": [42]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [292,294,32,34],
+     "leds": [43]
+    },
+    {
+     "name": "KeyK131",
+     "rect": [325,294,32,34],
+     "leds": [44]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [358,294,171,42],
+     "leds": [45,46,47]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [465,114,34,35],
+     "leds": [48]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [499,114,34,35],
+     "leds": [49]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [533,114,34,35],
+     "leds": [50]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [567,114,34,35],
+     "leds": [51]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [601,114,34,35],
+     "leds": [52]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [635,114,34,35],
+     "leds": [53]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [669,114,34,35],
+     "leds": [54]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [713,114,34,35],
+     "leds": [55]
+    },
+    {
+     "name": "Key8",
+     "rect": [465,157,34,35],
+     "leds": [56]
+    },
+    {
+     "name": "Key9",
+     "rect": [499,157,34,35],
+     "leds": [57]
+    },
+    {
+     "name": "Key0",
+     "rect": [533,157,34,35],
+     "leds": [58]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [567,157,34,35],
+     "leds": [59]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [601,157,34,35],
+     "leds": [60]
+    },
+    {
+     "name": "KeyK14",
+     "rect": [635,157,34,35],
+     "leds": [61]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [670,157,34,35],
+     "leds": [62]
+    },
+    {
+     "name": "KeyNumLock",
+     "rect": [713,157,34,35],
+     "leds": [63]
+    },
+    {
+     "name": "KeyI",
+     "rect": [483,192,34,34],
+     "leds": [64]
+    },
+    {
+     "name": "KeyO",
+     "rect": [517,192,34,34],
+     "leds": [65]
+    },
+    {
+     "name": "KeyP",
+     "rect": [551,192,34,34],
+     "leds": [66]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [585,192,34,34],
+     "leds": [67]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [619,192,34,34],
+     "leds": [68]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [653,192,51,68],
+     "leds": [69,70]
+    },
+    {
+     "name": "KeyPad7",
+     "rect": [713,192,34,35],
+     "leds": [71]
+    },
+    {
+     "name": "KeyK",
+     "rect": [491,226,34,34],
+     "leds": [72]
+    },
+    {
+     "name": "KeyL",
+     "rect": [525,226,34,34],
+     "leds": [73]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [559,226,34,34],
+     "leds": [74]
+    },
+    {
+     "name": "KeyK42",
+     "rect": [593,226,34,34],
+     "leds": [75]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [625,226,34,34],
+     "leds": [76,77]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [642,260,62,34],
+     "leds": [78,85]
+    },
+    {
+     "name": "KeyPad4",
+     "rect": [713,226,34,34],
+     "leds": [79]
+    },
+    {
+     "name": "KeyM",
+     "rect": [472,260,34,34],
+     "leds": [80]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [506,260,34,34],
+     "leds": [81]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [540,260,34,34],
+     "leds": [82]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [574,260,34,34],
+     "leds": [83]
+    },
+    {
+     "name": "KeyK56",
+     "rect": [606,260,34,34],
+     "leds": [84]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [692,305,34,34],
+     "leds": [86]
+    },
+    {
+     "name": "KeyPad1",
+     "rect": [713,260,34,34],
+     "leds": [87]
+    },
+    {
+     "name": "KeyK132",
+     "rect": [530,294,32,34],
+     "leds": [88]
+    },
+    {
+     "name": "KeyK133",
+     "rect": [563,294,32,34],
+     "leds": [89]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [596,294,32,34],
+     "leds": [90]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [629,294,50,34],
+     "leds": [91,92]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [658,339,34,34],
+     "leds": [93]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [692,339,34,34],
+     "leds": [94]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [726,339,34,34],
+     "leds": [95]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [747,114,34,35],
+     "leds": [96]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [781,114,34,35],
+     "leds": [97]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [815,114,34,35],
+     "leds": [98]
+    },
+    {
+     "name": "KeyP1",
+     "rect": [148,114,35,35],
+     "leds": [99,100,101,102,103]
+    },
+    {
+     "name": "KeyPadSlash",
+     "rect": [747,157,34,35],
+     "leds": [104]
+    },
+    {
+     "name": "KeyPadStar",
+     "rect": [781,157,34,35],
+     "leds": [105]
+    },
+    {
+     "name": "KeyPadHyphen",
+     "rect": [813,157,34,35],
+     "leds": [106]
+    },
+    {
+     "name": "KeyP2",
+     "rect": [148,157,35,35],
+     "leds": [107,108,109,110,111]
+    },
+    {
+     "name": "KeyPad8",
+     "rect": [747,192,34,35],
+     "leds": [112]
+    },
+    {
+     "name": "KeyPad9",
+     "rect": [781,192,34,35],
+     "leds": [113]
+    },
+    {
+     "name": "KeyPadPlus",
+     "rect": [815,192.5,34,68],
+     "leds": [114,122]
+    },
+    {
+     "name": "KeyP3",
+     "rect": [148,192,35,35],
+     "leds": [115,116,117,118,119]
+    },
+    {
+     "name": "KeyPad5",
+     "rect": [747,226,34,35],
+     "leds": [120]
+    },
+    {
+     "name": "KeyPad6",
+     "rect": [781,226,34,35],
+     "leds": [121]
+    },
+    {
+     "name": "KeyP4",
+     "rect": [148,226,35,35],
+     "leds": [123,124,125,126,127]
+    },
+    {
+     "name": "KeyPad2",
+     "rect": [747,260,34,35],
+     "leds": [128]
+    },
+    {
+     "name": "KeyPad3",
+     "rect": [781,260,34,35],
+     "leds": [129]
+    },
+    {
+     "name": "KeyPadEnter",
+     "rect": [815,260.5,34,68],
+     "leds": [130,138]
+    },
+    {
+     "name": "KeyP5",
+     "rect": [148,260,35,35],
+     "leds": [131,132,133,134,135]
+    },
+    {
+     "name": "KeyPad0",
+     "rect": [747,294,34,35],
+     "leds": [136]
+    },
+    {
+     "name": "KeyPadDot",
+     "rect": [781,294,34,35],
+     "leds": [137]
+    },
+    {
+     "name": "KeyP6",
+     "rect": [148,294,35,35],
+     "leds": [139]
+    }
+   ]
+  },
+  "Drax/Global": {
+   "id": "Drax/Global",
+   "leds": 152,
+   "bounds": [346,99,936,286],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [346,99,28,22],
+     "leds": [0,113]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [377,99,28,22],
+     "leds": [1,114]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,99,28,22],
+     "leds": [2,115]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [439,99,28,22],
+     "leds": [3,116]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [470,99,28,22],
+     "leds": [4,117]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [501,99,28,22],
+     "leds": [5,118]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [532,99,28,22],
+     "leds": [6,119]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [563,99,28,22],
+     "leds": [7,146,147]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [346,125,23,28],
+     "leds": [8,9]
+    },
+    {
+     "name": "Key1",
+     "rect": [372,125,30,28],
+     "leds": [10]
+    },
+    {
+     "name": "Key2",
+     "rect": [404,125,30,28],
+     "leds": [11]
+    },
+    {
+     "name": "Key3",
+     "rect": [436,125,30,28],
+     "leds": [12]
+    },
+    {
+     "name": "Key4",
+     "rect": [468,125,30,28],
+     "leds": [13]
+    },
+    {
+     "name": "Key5",
+     "rect": [500,125,30,28],
+     "leds": [14]
+    },
+    {
+     "name": "Key6",
+     "rect": [532,125,30,28],
+     "leds": [15]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [346,156,40,28],
+     "leds": [16,17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [388,156,30,28],
+     "leds": [18]
+    },
+    {
+     "name": "KeyW",
+     "rect": [420,156,30,28],
+     "leds": [19,126,127]
+    },
+    {
+     "name": "KeyE",
+     "rect": [452,156,30,28],
+     "leds": [20]
+    },
+    {
+     "name": "KeyR",
+     "rect": [484,156,30,28],
+     "leds": [21]
+    },
+    {
+     "name": "KeyT",
+     "rect": [516,156,30,28],
+     "leds": [22]
+    },
+    {
+     "name": "KeyY",
+     "rect": [548,156,30,28],
+     "leds": [23]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [346,188,47,28],
+     "leds": [24,25,26]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,188,30,28],
+     "leds": [27,149,150,151]
+    },
+    {
+     "name": "KeyS",
+     "rect": [428,188,30,28],
+     "leds": [28,142]
+    },
+    {
+     "name": "KeyD",
+     "rect": [460,188,30,28],
+     "leds": [29,143]
+    },
+    {
+     "name": "KeyF",
+     "rect": [492,188,30,28],
+     "leds": [30]
+    },
+    {
+     "name": "KeyG",
+     "rect": [524,188,30,28],
+     "leds": [31]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [346,219,64,28],
+     "leds": [32,33,34]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [412,219,30,28],
+     "leds": [35]
+    },
+    {
+     "name": "KeyX",
+     "rect": [444,219,30,28],
+     "leds": [36]
+    },
+    {
+     "name": "KeyC",
+     "rect": [476,219,30,28],
+     "leds": [37]
+    },
+    {
+     "name": "KeyV",
+     "rect": [508,219,30,28],
+     "leds": [38]
+    },
+    {
+     "name": "KeyB",
+     "rect": [540,219,30,28],
+     "leds": [39]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [346,251,32,29],
+     "leds": [40]
+    },
+    {
+     "name": "KeyFN",
+     "rect": [380,251,30,29],
+     "leds": [41]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [412,251,30,29],
+     "leds": [42]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [444,251,30,29],
+     "leds": [43,44]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [476,251,172,34],
+     "leds": [45,46,47,88,89,90,91]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [594,99,28,22],
+     "leds": [48,121]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [625,99,28,22],
+     "leds": [49,122]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [656,99,28,22],
+     "leds": [50,123]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [687,99,28,22],
+     "leds": [51,124]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [718,99,28,22],
+     "leds": [52,125]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [749,99,28,22],
+     "leds": [53,54]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [780,99,28,22],
+     "leds": [55,96]
+    },
+    {
+     "name": "Key7",
+     "rect": [564,125,30,28],
+     "leds": [56]
+    },
+    {
+     "name": "Key8",
+     "rect": [596,125,30,28],
+     "leds": [57]
+    },
+    {
+     "name": "Key9",
+     "rect": [628,125,30,28],
+     "leds": [58]
+    },
+    {
+     "name": "Key0",
+     "rect": [660,125,30,28],
+     "leds": [59]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [692,125,30,28],
+     "leds": [60]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [724,125,30,28],
+     "leds": [61]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [756,125,52,28],
+     "leds": [62,63,104]
+    },
+    {
+     "name": "KeyU",
+     "rect": [580,156,30,28],
+     "leds": [64]
+    },
+    {
+     "name": "KeyI",
+     "rect": [612,156,30,28],
+     "leds": [65]
+    },
+    {
+     "name": "KeyO",
+     "rect": [644,156,30,28],
+     "leds": [66]
+    },
+    {
+     "name": "KeyP",
+     "rect": [676,156,30,28],
+     "leds": [67]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [708,156,30,28],
+     "leds": [68]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [740,156,30,28],
+     "leds": [69]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [772,156,36,28],
+     "leds": [70,71]
+    },
+    {
+     "name": "KeyH",
+     "rect": [556,188,30,28],
+     "leds": [72]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [588,188,30,28],
+     "leds": [73]
+    },
+    {
+     "name": "KeyK",
+     "rect": [620,188,30,28],
+     "leds": [74]
+    },
+    {
+     "name": "KeyL",
+     "rect": [652,188,30,28],
+     "leds": [75]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [684,188,30,28],
+     "leds": [76]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [716,188,30,28],
+     "leds": [77]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [748,188,60,28],
+     "leds": [78,79,120]
+    },
+    {
+     "name": "KeyN",
+     "rect": [572,219,30,28],
+     "leds": [80]
+    },
+    {
+     "name": "KeyM",
+     "rect": [604,219,30,28],
+     "leds": [81]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [636,219,30,28],
+     "leds": [82]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [668,219,30,28],
+     "leds": [83]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [700,219,30,28],
+     "leds": [84]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [732,219,76,28],
+     "leds": [85,86,87,128,129,130,131,132,133,134,135]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [651,251,30,29],
+     "leds": [92]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [683,251,30,29],
+     "leds": [93]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [715,268,30,18],
+     "leds": [94,95]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [815,99,28,22],
+     "leds": [97,98]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [846,99,28,22],
+     "leds": [99,100]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [877,99,28,22],
+     "leds": [101,102]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [908,99,28,22],
+     "leds": [103,144,145]
+    },
+    {
+     "name": "Key200",
+     "rect": [815,125,28,18],
+     "leds": [105,106]
+    },
+    {
+     "name": "Key201",
+     "rect": [846,125,28,18],
+     "leds": [107,108]
+    },
+    {
+     "name": "Key202",
+     "rect": [877,125,28,18],
+     "leds": [109,110]
+    },
+    {
+     "name": "Key203",
+     "rect": [908,125,28,18],
+     "leds": [111,112,148]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [747,268,30,18],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [747,250,30,18],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [779,268,30,18],
+     "leds": [140,141]
+    }
+   ]
+  },
+  "Drax/JP": {
+   "id": "Drax/JP",
+   "leds": 152,
+   "bounds": [346,99,936,286],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [346,99,28,22],
+     "leds": [0,113]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [377,99,28,22],
+     "leds": [1,114]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,99,28,22],
+     "leds": [2,115]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [439,99,28,22],
+     "leds": [3,116]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [470,99,28,22],
+     "leds": [4,117]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [501,99,28,22],
+     "leds": [5,118]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [532,99,28,22],
+     "leds": [6,119]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [563,99,28,22],
+     "leds": [7,146]
+    },
+    {
+     "name": "KeyFull",
+     "rect": [346,125,23,28],
+     "leds": [8,9]
+    },
+    {
+     "name": "Key1",
+     "rect": [372,125,30,28],
+     "leds": [10]
+    },
+    {
+     "name": "Key2",
+     "rect": [404,125,30,28],
+     "leds": [11]
+    },
+    {
+     "name": "Key3",
+     "rect": [436,125,30,28],
+     "leds": [12]
+    },
+    {
+     "name": "Key4",
+     "rect": [468,125,30,28],
+     "leds": [13]
+    },
+    {
+     "name": "Key5",
+     "rect": [500,125,30,28],
+     "leds": [14]
+    },
+    {
+     "name": "Key6",
+     "rect": [532,125,30,28],
+     "leds": [15]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [346,156,40,28],
+     "leds": [16,17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [388,156,30,28],
+     "leds": [18]
+    },
+    {
+     "name": "KeyW",
+     "rect": [420,156,30,28],
+     "leds": [19,126]
+    },
+    {
+     "name": "KeyE",
+     "rect": [452,156,30,28],
+     "leds": [20]
+    },
+    {
+     "name": "KeyR",
+     "rect": [484,156,30,28],
+     "leds": [21]
+    },
+    {
+     "name": "KeyT",
+     "rect": [516,156,30,28],
+     "leds": [22]
+    },
+    {
+     "name": "KeyY",
+     "rect": [548,156,30,28],
+     "leds": [23]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [346,188,47,28],
+     "leds": [24,25,26]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,188,30,28],
+     "leds": [27]
+    },
+    {
+     "name": "KeyS",
+     "rect": [428,188,30,28],
+     "leds": [28,142]
+    },
+    {
+     "name": "KeyD",
+     "rect": [460,188,30,28],
+     "leds": [29,143]
+    },
+    {
+     "name": "KeyF",
+     "rect": [492,188,30,28],
+     "leds": [30]
+    },
+    {
+     "name": "KeyG",
+     "rect": [524,188,30,28],
+     "leds": [31]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [346,219,64,28],
+     "leds": [32,33,34]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [412,219,30,28],
+     "leds": [35]
+    },
+    {
+     "name": "KeyX",
+     "rect": [444,219,30,28],
+     "leds": [36]
+    },
+    {
+     "name": "KeyC",
+     "rect": [476,219,30,28],
+     "leds": [37]
+    },
+    {
+     "name": "KeyV",
+     "rect": [508,219,30,28],
+     "leds": [38]
+    },
+    {
+     "name": "KeyB",
+     "rect": [540,219,30,28],
+     "leds": [39]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [346,251,23,29],
+     "leds": [40]
+    },
+    {
+     "name": "KeyFN",
+     "rect": [372,251,23,29],
+     "leds": [41]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [398,251,23,29],
+     "leds": [42]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [424,251,23,29],
+     "leds": [43]
+    },
+    {
+     "name": "KeyNoChange",
+     "rect": [450,251,23,29],
+     "leds": [44]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [476,251,132,34],
+     "leds": [45,46,47,88,89]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [594,99,28,22],
+     "leds": [48,121]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [625,99,28,22],
+     "leds": [49,122]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [656,99,28,22],
+     "leds": [50,123]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [687,99,28,22],
+     "leds": [51,124]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [718,99,28,22],
+     "leds": [52,125]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [749,99,28,22],
+     "leds": [53,54]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [780,99,28,22],
+     "leds": [55,96]
+    },
+    {
+     "name": "Key7",
+     "rect": [564,125,30,28],
+     "leds": [56]
+    },
+    {
+     "name": "Key8",
+     "rect": [596,125,30,28],
+     "leds": [57]
+    },
+    {
+     "name": "Key9",
+     "rect": [628,125,30,28],
+     "leds": [58]
+    },
+    {
+     "name": "Key0",
+     "rect": [660,125,30,28],
+     "leds": [59]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [692,125,28,28],
+     "leds": [60,133]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [722,125,28,28],
+     "leds": [61,134]
+    },
+    {
+     "name": "KeyBaseline",
+     "rect": [752,125,28,28],
+     "leds": [62,135]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [782,125,28,28],
+     "leds": [63,104]
+    },
+    {
+     "name": "KeyU",
+     "rect": [580,156,30,28],
+     "leds": [64]
+    },
+    {
+     "name": "KeyI",
+     "rect": [612,156,30,28],
+     "leds": [65]
+    },
+    {
+     "name": "KeyO",
+     "rect": [644,156,30,28],
+     "leds": [66]
+    },
+    {
+     "name": "KeyP",
+     "rect": [676,156,30,28],
+     "leds": [67]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [708,156,30,28],
+     "leds": [68,69]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [740,156,30,28],
+     "leds": [70,127]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [772,156,36,60],
+     "leds": [71,112]
+    },
+    {
+     "name": "KeyH",
+     "rect": [556,188,30,28],
+     "leds": [72]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [588,188,30,28],
+     "leds": [73]
+    },
+    {
+     "name": "KeyK",
+     "rect": [620,188,30,28],
+     "leds": [74]
+    },
+    {
+     "name": "KeyL",
+     "rect": [652,188,30,28],
+     "leds": [75]
+    },
+    {
+     "name": "KeyAdd",
+     "rect": [684,188,30,28],
+     "leds": [76,147]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [716,188,30,28],
+     "leds": [77,78]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [748,188,30,28],
+     "leds": [79,120]
+    },
+    {
+     "name": "KeyN",
+     "rect": [572,219,30,28],
+     "leds": [80]
+    },
+    {
+     "name": "KeyM",
+     "rect": [604,219,30,28],
+     "leds": [81]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [636,219,30,28],
+     "leds": [82,129]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [668,219,30,28],
+     "leds": [83,130]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [700,219,30,28],
+     "leds": [84,131]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [732,219,30,28],
+     "leds": [85,132]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [764,219,44,28],
+     "leds": [86,87,128]
+    },
+    {
+     "name": "KeyChange",
+     "rect": [611,251,23,29],
+     "leds": [90]
+    },
+    {
+     "name": "KeyKatakana",
+     "rect": [637,251,23,29],
+     "leds": [91,149,150,151]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [663,251,23,29],
+     "leds": [92]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [689,251,23,29],
+     "leds": [93]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [715,268,30,18],
+     "leds": [94,95]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [815,99,28,22],
+     "leds": [97,98]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [846,99,28,22],
+     "leds": [99,100]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [877,99,28,22],
+     "leds": [101,102]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [908,99,28,22],
+     "leds": [103,144]
+    },
+    {
+     "name": "Key200",
+     "rect": [815,125,28,18],
+     "leds": [105,106]
+    },
+    {
+     "name": "Key201",
+     "rect": [846,125,28,18],
+     "leds": [107,108]
+    },
+    {
+     "name": "Key202",
+     "rect": [877,125,28,18],
+     "leds": [109,110]
+    },
+    {
+     "name": "Key203",
+     "rect": [908,125,28,18],
+     "leds": [111,145,148]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [747,268,30,18],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [747,250,30,18],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [779,268,30,18],
+     "leds": [140,141]
+    }
+   ]
+  },
+  "Hendricks/Global": {
+   "id": "Hendricks/Global",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Modena/Global": {
+   "id": "Modena/Global",
+   "leds": 112,
+   "bounds": [362,125,852,293],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [362,125,25,12],
+     "leds": [0,1]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [393,125,25,12],
+     "leds": [2]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,125,25,12],
+     "leds": [3]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [455,125,25,12],
+     "leds": [4]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [486,125,25,12],
+     "leds": [5]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [517,125,25,12],
+     "leds": [6]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [548,125,25,12],
+     "leds": [7]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [579,125,25,12],
+     "leds": [8]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [610,125,25,12],
+     "leds": [9]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [641,125,25,12],
+     "leds": [10]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [672,125,25,12],
+     "leds": [11]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [703,125,25,12],
+     "leds": [12]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [734,125,25,12],
+     "leds": [13]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,125,25,12],
+     "leds": [14,15]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [796,125,25,12],
+     "leds": [16]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [827,125,25,12],
+     "leds": [17,18]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [362,144,20,25],
+     "leds": [19,20]
+    },
+    {
+     "name": "Key1",
+     "rect": [388,144,26,25],
+     "leds": [21]
+    },
+    {
+     "name": "Key2",
+     "rect": [420,144,26,25],
+     "leds": [22]
+    },
+    {
+     "name": "Key3",
+     "rect": [452,144,26,25],
+     "leds": [23]
+    },
+    {
+     "name": "Key4",
+     "rect": [484,144,26,25],
+     "leds": [24]
+    },
+    {
+     "name": "Key5",
+     "rect": [516,144,26,25],
+     "leds": [25]
+    },
+    {
+     "name": "Key6",
+     "rect": [548,144,26,25],
+     "leds": [26]
+    },
+    {
+     "name": "Key7",
+     "rect": [579,144,26,25],
+     "leds": [27]
+    },
+    {
+     "name": "Key8",
+     "rect": [611,144,26,25],
+     "leds": [28]
+    },
+    {
+     "name": "Key9",
+     "rect": [643,144,26,25],
+     "leds": [29]
+    },
+    {
+     "name": "Key0",
+     "rect": [674,144,26,25],
+     "leds": [30]
+    },
+    {
+     "name": "KeyMinus",
+     "rect": [706,144,26,25],
+     "leds": [31]
+    },
+    {
+     "name": "KeyPlus",
+     "rect": [738,144,26,25],
+     "leds": [32]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [769,144,51,25],
+     "leds": [33,34,35]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [826,144,26,25],
+     "leds": [36,37]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [362,175,36,25],
+     "leds": [38,39,40,41]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [404,175,26,25],
+     "leds": [42]
+    },
+    {
+     "name": "KeyW",
+     "rect": [437,175,26,25],
+     "leds": [43]
+    },
+    {
+     "name": "KeyE",
+     "rect": [469,175,26,25],
+     "leds": [44]
+    },
+    {
+     "name": "KeyR",
+     "rect": [501,175,26,25],
+     "leds": [45]
+    },
+    {
+     "name": "KeyT",
+     "rect": [533,175,26,25],
+     "leds": [46]
+    },
+    {
+     "name": "KeyY",
+     "rect": [565,175,26,25],
+     "leds": [47]
+    },
+    {
+     "name": "KeyU",
+     "rect": [598,175,26,25],
+     "leds": [48]
+    },
+    {
+     "name": "KeyI",
+     "rect": [631,175,26,25],
+     "leds": [49]
+    },
+    {
+     "name": "KeyO",
+     "rect": [663,175,26,25],
+     "leds": [50]
+    },
+    {
+     "name": "KeyP",
+     "rect": [696,175,26,25],
+     "leds": [51]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [728,175,26,25],
+     "leds": [52]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [761,175,26,25],
+     "leds": [53]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [793,175,26,25],
+     "leds": [54,55]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [826,175,26,25],
+     "leds": [56,57]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [362,206,45,25],
+     "leds": [58,59,60]
+    },
+    {
+     "name": "KeyA",
+     "rect": [413,206,26,25],
+     "leds": [61]
+    },
+    {
+     "name": "KeyS",
+     "rect": [445,206,26,25],
+     "leds": [62]
+    },
+    {
+     "name": "KeyD",
+     "rect": [477,206,26,25],
+     "leds": [63]
+    },
+    {
+     "name": "KeyF",
+     "rect": [508,206,26,25],
+     "leds": [64]
+    },
+    {
+     "name": "KeyG",
+     "rect": [540,206,26,25],
+     "leds": [65]
+    },
+    {
+     "name": "KeyH",
+     "rect": [572,206,26,25],
+     "leds": [66]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [604,206,26,25],
+     "leds": [67]
+    },
+    {
+     "name": "KeyK",
+     "rect": [635,206,26,25],
+     "leds": [68]
+    },
+    {
+     "name": "KeyL",
+     "rect": [666,206,26,25],
+     "leds": [69]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [699,206,26,25],
+     "leds": [70]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [731,206,26,25],
+     "leds": [71]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [762,206,58,25],
+     "leds": [72,73,74,75,76]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [826,206,26,25],
+     "leds": [77,78]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [362,237,61,25],
+     "leds": [79,80,81,82]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [429,237,26,25],
+     "leds": [83]
+    },
+    {
+     "name": "KeyX",
+     "rect": [461,237,26,25],
+     "leds": [84]
+    },
+    {
+     "name": "KeyC",
+     "rect": [493,237,26,25],
+     "leds": [85]
+    },
+    {
+     "name": "KeyV",
+     "rect": [524,237,26,25],
+     "leds": [86]
+    },
+    {
+     "name": "KeyB",
+     "rect": [556,237,26,25],
+     "leds": [87]
+    },
+    {
+     "name": "KeyN",
+     "rect": [588,237,26,25],
+     "leds": [88]
+    },
+    {
+     "name": "KeyM",
+     "rect": [619,237,26,25],
+     "leds": [89]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [651,237,26,25],
+     "leds": [90]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [683,237,26,25],
+     "leds": [91]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [714,237,26,25],
+     "leds": [92]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [746,237,74,25],
+     "leds": [93,94,95]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [826,237,26,25],
+     "leds": [96,97]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [362,268,29,25],
+     "leds": [98]
+    },
+    {
+     "name": "KeyFn",
+     "rect": [397,268,26,25],
+     "leds": [99]
+    },
+    {
+     "name": "KeyWindow",
+     "rect": [428,268,26,25],
+     "leds": [100,101]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [459,268,26,25],
+     "leds": [102]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [650,268,26,25],
+     "leds": [103]
+    },
+    {
+     "name": "KeyMenu",
+     "rect": [681,268,26,25],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [713,268,26,25],
+     "leds": [106]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [745,268,26,25],
+     "leds": [107]
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [777,268,42,11],
+     "leds": [108]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [777,282,42,11],
+     "leds": [109]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [826,268,26,25],
+     "leds": [110]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [490,268,154,25],
+     "leds": [111]
+    }
+   ]
+  },
+  "Modena/UK": {
+   "id": "Modena/UK",
+   "leds": 112,
+   "bounds": [362,125,852,293],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [362,125,25,12],
+     "leds": [0,1]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [393,125,25,12],
+     "leds": [2]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [424,125,25,12],
+     "leds": [3]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [455,125,25,12],
+     "leds": [4]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [486,125,25,12],
+     "leds": [5]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [517,125,25,12],
+     "leds": [6]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [548,125,25,12],
+     "leds": [7]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [579,125,25,12],
+     "leds": [8]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [610,125,25,12],
+     "leds": [9]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [641,125,25,12],
+     "leds": [10]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [672,125,25,12],
+     "leds": [11]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [703,125,25,12],
+     "leds": [12]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [734,125,25,12],
+     "leds": [13]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [765,125,25,12],
+     "leds": [14,15]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [796,125,25,12],
+     "leds": [16]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [827,125,25,12],
+     "leds": [17,18]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [362,144,20,25],
+     "leds": [19,20]
+    },
+    {
+     "name": "Key1",
+     "rect": [388,144,26,25],
+     "leds": [21]
+    },
+    {
+     "name": "Key2",
+     "rect": [420,144,26,25],
+     "leds": [22]
+    },
+    {
+     "name": "Key3",
+     "rect": [452,144,26,25],
+     "leds": [23]
+    },
+    {
+     "name": "Key4",
+     "rect": [484,144,26,25],
+     "leds": [24]
+    },
+    {
+     "name": "Key5",
+     "rect": [516,144,26,25],
+     "leds": [25]
+    },
+    {
+     "name": "Key6",
+     "rect": [548,144,26,25],
+     "leds": [26]
+    },
+    {
+     "name": "Key7",
+     "rect": [579,144,26,25],
+     "leds": [27]
+    },
+    {
+     "name": "Key8",
+     "rect": [611,144,26,25],
+     "leds": [28]
+    },
+    {
+     "name": "Key9",
+     "rect": [643,144,26,25],
+     "leds": [29]
+    },
+    {
+     "name": "Key0",
+     "rect": [674,144,26,25],
+     "leds": [30]
+    },
+    {
+     "name": "KeyMinus",
+     "rect": [706,144,26,25],
+     "leds": [31]
+    },
+    {
+     "name": "KeyPlus",
+     "rect": [738,144,26,25],
+     "leds": [32]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [769,144,51,25],
+     "leds": [33,34,35]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [826,144,26,25],
+     "leds": [36,37]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [362,175,36,25],
+     "leds": [38,39,40,41]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [404,175,26,25],
+     "leds": [42]
+    },
+    {
+     "name": "KeyW",
+     "rect": [436,175,26,25],
+     "leds": [43]
+    },
+    {
+     "name": "KeyE",
+     "rect": [467,175,26,25],
+     "leds": [44]
+    },
+    {
+     "name": "KeyR",
+     "rect": [499,175,26,25],
+     "leds": [45]
+    },
+    {
+     "name": "KeyT",
+     "rect": [531,175,26,25],
+     "leds": [46]
+    },
+    {
+     "name": "KeyY",
+     "rect": [562,175,26,25],
+     "leds": [47]
+    },
+    {
+     "name": "KeyU",
+     "rect": [594,175,26,25],
+     "leds": [48]
+    },
+    {
+     "name": "KeyI",
+     "rect": [625,175,26,25],
+     "leds": [49]
+    },
+    {
+     "name": "KeyO",
+     "rect": [657,175,26,25],
+     "leds": [50]
+    },
+    {
+     "name": "KeyP",
+     "rect": [689,175,26,25],
+     "leds": [51]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [720,175,26,25],
+     "leds": [52]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [752,175,26,25],
+     "leds": [53]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [788,175,34,57],
+     "leds": [54,55,75,76]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [826,175,26,25],
+     "leds": [56,57]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [362,206,45,25],
+     "leds": [58,59,60]
+    },
+    {
+     "name": "KeyA",
+     "rect": [413,206,26,25],
+     "leds": [61]
+    },
+    {
+     "name": "KeyS",
+     "rect": [445,206,26,25],
+     "leds": [62]
+    },
+    {
+     "name": "KeyD",
+     "rect": [477,206,26,25],
+     "leds": [63]
+    },
+    {
+     "name": "KeyF",
+     "rect": [508,206,26,25],
+     "leds": [64]
+    },
+    {
+     "name": "KeyG",
+     "rect": [540,206,26,25],
+     "leds": [65]
+    },
+    {
+     "name": "KeyH",
+     "rect": [572,206,26,25],
+     "leds": [66]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [604,206,26,25],
+     "leds": [67]
+    },
+    {
+     "name": "KeyK",
+     "rect": [635,206,26,25],
+     "leds": [68]
+    },
+    {
+     "name": "KeyL",
+     "rect": [666,206,26,25],
+     "leds": [69]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [699,206,26,25],
+     "leds": [70]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [731,206,26,25],
+     "leds": [71]
+    },
+    {
+     "name": "KeyPound",
+     "rect": [762,206,26,25],
+     "leds": [72,73,74]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [826,206,26,25],
+     "leds": [77,78]
+    },
+    {
+     "name": "KeyFnLock",
+     "rect": [362,237,29,25],
+     "leds": [79,80]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [396,237,26,25],
+     "leds": [81,82]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [429,237,26,25],
+     "leds": [83]
+    },
+    {
+     "name": "KeyX",
+     "rect": [461,237,26,25],
+     "leds": [84]
+    },
+    {
+     "name": "KeyC",
+     "rect": [493,237,26,25],
+     "leds": [85]
+    },
+    {
+     "name": "KeyV",
+     "rect": [524,237,26,25],
+     "leds": [86]
+    },
+    {
+     "name": "KeyB",
+     "rect": [556,237,26,25],
+     "leds": [87]
+    },
+    {
+     "name": "KeyN",
+     "rect": [588,237,26,25],
+     "leds": [88]
+    },
+    {
+     "name": "KeyM",
+     "rect": [619,237,26,25],
+     "leds": [89]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [651,237,26,25],
+     "leds": [90]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [683,237,26,25],
+     "leds": [91]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [714,237,26,25],
+     "leds": [92]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [746,237,74,25],
+     "leds": [93,94,95]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [826,237,26,25],
+     "leds": [96,97]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [362,268,29,25],
+     "leds": [98]
+    },
+    {
+     "name": "KeyFn",
+     "rect": [397,268,26,25],
+     "leds": [99]
+    },
+    {
+     "name": "KeyWindow",
+     "rect": [428,268,26,25],
+     "leds": [100,101]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [459,268,26,25],
+     "leds": [102]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [650,268,26,25],
+     "leds": [103]
+    },
+    {
+     "name": "KeyMenu",
+     "rect": [681,268,26,25],
+     "leds": [104,105]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [713,268,26,25],
+     "leds": [106]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [745,268,26,25],
+     "leds": [107]
+    },
+    {
+     "name": "KeyArrUp",
+     "rect": [777,268,42,11],
+     "leds": [108]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [777,282,42,11],
+     "leds": [109]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [826,268,26,25],
+     "leds": [110]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [490,268,154,25],
+     "leds": [111]
+    }
+   ]
+  },
+  "Quaker/Global": {
+   "id": "Quaker/Global",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Ralph/Global": {
+   "id": "Ralph/Global",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/Arabic": {
+   "id": "Starmade/Arabic",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/BrazilianPortuguese": {
+   "id": "Starmade/BrazilianPortuguese",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/French": {
+   "id": "Starmade/French",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/German": {
+   "id": "Starmade/German",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/Global": {
+   "id": "Starmade/Global",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/Hebrew": {
+   "id": "Starmade/Hebrew",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/Italian": {
+   "id": "Starmade/Italian",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/JP": {
+   "id": "Starmade/JP",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/LatinAmerica": {
+   "id": "Starmade/LatinAmerica",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/Nordic": {
+   "id": "Starmade/Nordic",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/Portuguese": {
+   "id": "Starmade/Portuguese",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/Russian": {
+   "id": "Starmade/Russian",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/Spanish": {
+   "id": "Starmade/Spanish",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/Swiss": {
+   "id": "Starmade/Swiss",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/UK": {
+   "id": "Starmade/UK",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/UkEnglish": {
+   "id": "Starmade/UkEnglish",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Starmade/UsInternational": {
+   "id": "Starmade/UsInternational",
+   "leds": 167,
+   "bounds": [352,125,858,295],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,125,25,21],
+     "leds": [0,6]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,125,25,21],
+     "leds": [1,7]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,125,25,21],
+     "leds": [2,8]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,125,25,21],
+     "leds": [3,9]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,125,25,21],
+     "leds": [4,10]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,125,25,21],
+     "leds": [5,11]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,19,26],
+     "leds": [12,18]
+    },
+    {
+     "name": "Key1",
+     "rect": [374,149,26,26],
+     "leds": [13]
+    },
+    {
+     "name": "Key2",
+     "rect": [403,149,26,26],
+     "leds": [14]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,26,26],
+     "leds": [15]
+    },
+    {
+     "name": "Key4",
+     "rect": [461,149,26,26],
+     "leds": [16]
+    },
+    {
+     "name": "Key5",
+     "rect": [490,149,26,26],
+     "leds": [17]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [389,178,26,26],
+     "leds": [19]
+    },
+    {
+     "name": "KeyW",
+     "rect": [418,178,26,26],
+     "leds": [20]
+    },
+    {
+     "name": "KeyE",
+     "rect": [447,178,26,26],
+     "leds": [21]
+    },
+    {
+     "name": "KeyR",
+     "rect": [476,178,26,26],
+     "leds": [22]
+    },
+    {
+     "name": "KeyT",
+     "rect": [505,178,26,26],
+     "leds": [23]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,34,26],
+     "leds": [24,25]
+    },
+    {
+     "name": "KeyA",
+     "rect": [396,207,26,26],
+     "leds": [26]
+    },
+    {
+     "name": "KeyS",
+     "rect": [425,207,26,26],
+     "leds": [27]
+    },
+    {
+     "name": "KeyD",
+     "rect": [454,207,26,26],
+     "leds": [28]
+    },
+    {
+     "name": "KeyF",
+     "rect": [483,207,26,26],
+     "leds": [29]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,41,26],
+     "leds": [30,31,32]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [410,236,26,26],
+     "leds": [33]
+    },
+    {
+     "name": "KeyX",
+     "rect": [439,236,26,26],
+     "leds": [34]
+    },
+    {
+     "name": "KeyC",
+     "rect": [468,236,26,26],
+     "leds": [35]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,55,26],
+     "leds": [36,37,38,39,40]
+    },
+    {
+     "name": "KeyV",
+     "rect": [497,236,26,26],
+     "leds": [41]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,26,26],
+     "leds": [42]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [381,265,26,26],
+     "leds": [43]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [410,265,26,26],
+     "leds": [44]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [439,265,26,26],
+     "leds": [45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,125,25,21],
+     "leds": [60,66]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,125,25,21],
+     "leds": [61,67]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,125,25,21],
+     "leds": [62,68]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,125,25,21],
+     "leds": [63,69]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,125,25,21],
+     "leds": [64,70]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,125,25,21],
+     "leds": [65,71]
+    },
+    {
+     "name": "Key6",
+     "rect": [519,149,26,26],
+     "leds": [72]
+    },
+    {
+     "name": "Key7",
+     "rect": [548,149,26,26],
+     "leds": [73]
+    },
+    {
+     "name": "Key8",
+     "rect": [577,149,26,26],
+     "leds": [74]
+    },
+    {
+     "name": "Key9",
+     "rect": [606,149,26,26],
+     "leds": [75]
+    },
+    {
+     "name": "Key0",
+     "rect": [635,149,26,26],
+     "leds": [76]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [664,149,26,26],
+     "leds": [77]
+    },
+    {
+     "name": "KeyY",
+     "rect": [534,178,26,26],
+     "leds": [78]
+    },
+    {
+     "name": "KeyU",
+     "rect": [563,178,26,26],
+     "leds": [79]
+    },
+    {
+     "name": "KeyI",
+     "rect": [592,178,26,26],
+     "leds": [80]
+    },
+    {
+     "name": "KeyO",
+     "rect": [621,178,26,26],
+     "leds": [81]
+    },
+    {
+     "name": "KeyP",
+     "rect": [650,178,26,26],
+     "leds": [82]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [679,178,26,26],
+     "leds": [83]
+    },
+    {
+     "name": "KeyG",
+     "rect": [512,207,26,26],
+     "leds": [84]
+    },
+    {
+     "name": "KeyH",
+     "rect": [541,207,26,26],
+     "leds": [85]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [570,207,26,26],
+     "leds": [86]
+    },
+    {
+     "name": "KeyK",
+     "rect": [599,207,26,26],
+     "leds": [87]
+    },
+    {
+     "name": "KeyL",
+     "rect": [628,207,26,26],
+     "leds": [88]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [657,207,26,26],
+     "leds": [89]
+    },
+    {
+     "name": "KeyB",
+     "rect": [526,236,26,26],
+     "leds": [90]
+    },
+    {
+     "name": "KeyN",
+     "rect": [555,236,26,26],
+     "leds": [91]
+    },
+    {
+     "name": "KeyM",
+     "rect": [584,236,26,26],
+     "leds": [92]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [613,236,26,26],
+     "leds": [93]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [642,236,26,26],
+     "leds": [94]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [671,236,26,26],
+     "leds": [95]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [468,265,185,30],
+     "leds": [96,97,98,99,100,101]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [656,265,26,26],
+     "leds": [102]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [685,265,26,26],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,125,25,21],
+     "leds": [120,126]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,125,25,21],
+     "leds": [121,127]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,125,25,21],
+     "leds": [122,128]
+    },
+    {
+     "name": "KeyOmen",
+     "rect": [777,125,25,21],
+     "leds": [123,129]
+    },
+    {
+     "name": "KeyNumPad",
+     "rect": [805,125,25,21],
+     "leds": [124,130]
+    },
+    {
+     "name": "KeyPrtSC",
+     "rect": [833,125,25,21],
+     "leds": [125,131]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [693,149,26,26],
+     "leds": [132]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [722,149,47,26],
+     "leds": [133,134,135]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [737,178,32,26],
+     "leds": [136,137]
+    },
+    {
+     "name": "KeyIns",
+     "rect": [777,149,25,26],
+     "leds": [138,139]
+    },
+    {
+     "name": "KeyHome",
+     "rect": [805,149,25,26],
+     "leds": [140,141]
+    },
+    {
+     "name": "KeyPageUp",
+     "rect": [833,149,25,26],
+     "leds": [142,143]
+    },
+    {
+     "name": "KeyPause",
+     "rect": [777,178,25,26],
+     "leds": [144,145]
+    },
+    {
+     "name": "KeyEnd",
+     "rect": [805,178,25,26],
+     "leds": [146,147]
+    },
+    {
+     "name": "KeyPageDn",
+     "rect": [833,178,25,26],
+     "leds": [148,149]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [708,178,26,26],
+     "leds": [150]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [686,207,26,26],
+     "leds": [151]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [715,207,54,26],
+     "leds": [152,153,154,155]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [700,236,69,26],
+     "leds": [156,157,158,160,161]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [805,236,25,26],
+     "leds": [159]
+    },
+    {
+     "name": "KeyFNR",
+     "rect": [714,265,26,26],
+     "leds": [162]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [743,265,26,26],
+     "leds": [163]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [777,265,25,26],
+     "leds": [164]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [805,265,25,26],
+     "leds": [165]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [833,265,25,26],
+     "leds": [166]
+    }
+   ]
+  },
+  "Voco/Global": {
+   "id": "Voco/Global",
+   "leds": 130,
+   "bounds": [352,127,769,290],
+   "verified": false,
+   "keys": [
+    {
+     "name": "KeyEsc",
+     "rect": [352,127,25,19],
+     "leds": [0]
+    },
+    {
+     "name": "KeyF1",
+     "rect": [380,127,25,19],
+     "leds": [1]
+    },
+    {
+     "name": "KeyF2",
+     "rect": [408,127,25,19],
+     "leds": [2]
+    },
+    {
+     "name": "KeyF3",
+     "rect": [436,127,25,19],
+     "leds": [3]
+    },
+    {
+     "name": "KeyF4",
+     "rect": [464,127,25,19],
+     "leds": [4]
+    },
+    {
+     "name": "KeyF5",
+     "rect": [492,127,25,19],
+     "leds": [5]
+    },
+    {
+     "name": "KeyF6",
+     "rect": [520,127,25,19],
+     "leds": [6]
+    },
+    {
+     "name": "KeyF7",
+     "rect": [548,127,25,19],
+     "leds": [7]
+    },
+    {
+     "name": "KeyF8",
+     "rect": [576,127,25,19],
+     "leds": [8]
+    },
+    {
+     "name": "KeyF9",
+     "rect": [604,127,25,19],
+     "leds": [9]
+    },
+    {
+     "name": "KeyF10",
+     "rect": [632,127,25,19],
+     "leds": [10]
+    },
+    {
+     "name": "KeyF11",
+     "rect": [660,127,25,19],
+     "leds": [11]
+    },
+    {
+     "name": "KeyF12",
+     "rect": [688,127,25,19],
+     "leds": [12]
+    },
+    {
+     "name": "KeyPower",
+     "rect": [716,127,25,19],
+     "leds": [13]
+    },
+    {
+     "name": "KeyDel",
+     "rect": [744,127,25,19],
+     "leds": [14]
+    },
+    {
+     "name": "KeyTilde",
+     "rect": [352,149,21,25],
+     "leds": [15]
+    },
+    {
+     "name": "Key1",
+     "rect": [376,149,25,25],
+     "leds": [16]
+    },
+    {
+     "name": "Key2",
+     "rect": [404,149,25,25],
+     "leds": [17]
+    },
+    {
+     "name": "Key3",
+     "rect": [432,149,25,25],
+     "leds": [18]
+    },
+    {
+     "name": "Key4",
+     "rect": [460,149,25,25],
+     "leds": [19]
+    },
+    {
+     "name": "Key5",
+     "rect": [488,149,25,25],
+     "leds": [20]
+    },
+    {
+     "name": "Key6",
+     "rect": [516,149,25,25],
+     "leds": [21]
+    },
+    {
+     "name": "Key7",
+     "rect": [544,149,25,25],
+     "leds": [22]
+    },
+    {
+     "name": "Key8",
+     "rect": [572,149,25,25],
+     "leds": [23]
+    },
+    {
+     "name": "Key9",
+     "rect": [600,149,25,25],
+     "leds": [24]
+    },
+    {
+     "name": "Key0",
+     "rect": [628,149,25,25],
+     "leds": [25]
+    },
+    {
+     "name": "KeyHyphen",
+     "rect": [656,149,25,25],
+     "leds": [26]
+    },
+    {
+     "name": "KeyEqual",
+     "rect": [684,149,25,25],
+     "leds": [27]
+    },
+    {
+     "name": "KeyBack",
+     "rect": [712,149,57,25],
+     "leds": [28,29]
+    },
+    {
+     "name": "KeyTab",
+     "rect": [352,178,31,25],
+     "leds": [30]
+    },
+    {
+     "name": "KeyQ",
+     "rect": [386,178,25,25],
+     "leds": [31]
+    },
+    {
+     "name": "KeyW",
+     "rect": [414,178,25,25],
+     "leds": [32]
+    },
+    {
+     "name": "KeyE",
+     "rect": [442,178,25,25],
+     "leds": [33]
+    },
+    {
+     "name": "KeyR",
+     "rect": [470,178,25,25],
+     "leds": [34]
+    },
+    {
+     "name": "KeyT",
+     "rect": [498,178,25,25],
+     "leds": [35]
+    },
+    {
+     "name": "KeyY",
+     "rect": [526,178,25,25],
+     "leds": [36]
+    },
+    {
+     "name": "KeyU",
+     "rect": [554,178,25,25],
+     "leds": [37]
+    },
+    {
+     "name": "KeyI",
+     "rect": [582,178,25,25],
+     "leds": [38]
+    },
+    {
+     "name": "KeyO",
+     "rect": [610,178,25,25],
+     "leds": [39]
+    },
+    {
+     "name": "KeyP",
+     "rect": [638,178,25,25],
+     "leds": [40]
+    },
+    {
+     "name": "KeyBracketsL",
+     "rect": [666,178,25,25],
+     "leds": [41]
+    },
+    {
+     "name": "KeyBracketsR",
+     "rect": [694,178,25,25],
+     "leds": [42]
+    },
+    {
+     "name": "KeyBackslash",
+     "rect": [722,178,47,25],
+     "leds": [43,44]
+    },
+    {
+     "name": "KeyCaps",
+     "rect": [352,207,38,25],
+     "leds": [45]
+    },
+    {
+     "name": "KeyA",
+     "rect": [393,207,25,25],
+     "leds": [46]
+    },
+    {
+     "name": "KeyS",
+     "rect": [421,207,25,25],
+     "leds": [47]
+    },
+    {
+     "name": "KeyD",
+     "rect": [449,207,25,25],
+     "leds": [48]
+    },
+    {
+     "name": "KeyF",
+     "rect": [477,207,25,25],
+     "leds": [49]
+    },
+    {
+     "name": "KeyG",
+     "rect": [505,207,25,25],
+     "leds": [50]
+    },
+    {
+     "name": "KeyH",
+     "rect": [533,207,25,25],
+     "leds": [51]
+    },
+    {
+     "name": "KeyJ",
+     "rect": [561,207,25,25],
+     "leds": [52]
+    },
+    {
+     "name": "KeyK",
+     "rect": [589,207,25,25],
+     "leds": [53]
+    },
+    {
+     "name": "KeyL",
+     "rect": [617,207,25,25],
+     "leds": [54]
+    },
+    {
+     "name": "KeyColon",
+     "rect": [645,207,25,25],
+     "leds": [55]
+    },
+    {
+     "name": "KeyQuote",
+     "rect": [673,207,25,25],
+     "leds": [56,57]
+    },
+    {
+     "name": "KeyEnter",
+     "rect": [701,207,68,25],
+     "leds": [58,59]
+    },
+    {
+     "name": "KeyShiftL",
+     "rect": [352,236,52,25],
+     "leds": [60,61]
+    },
+    {
+     "name": "KeyZ",
+     "rect": [407,236,25,25],
+     "leds": [62]
+    },
+    {
+     "name": "KeyX",
+     "rect": [435,236,25,25],
+     "leds": [63]
+    },
+    {
+     "name": "KeyC",
+     "rect": [463,236,25,25],
+     "leds": [64]
+    },
+    {
+     "name": "KeyV",
+     "rect": [491,236,25,25],
+     "leds": [65]
+    },
+    {
+     "name": "KeyB",
+     "rect": [519,236,25,25],
+     "leds": [66]
+    },
+    {
+     "name": "KeyN",
+     "rect": [547,236,25,25],
+     "leds": [67]
+    },
+    {
+     "name": "KeyM",
+     "rect": [575,236,25,25],
+     "leds": [68]
+    },
+    {
+     "name": "KeyComma",
+     "rect": [603,236,25,25],
+     "leds": [69]
+    },
+    {
+     "name": "KeyDot",
+     "rect": [631,236,25,25],
+     "leds": [70]
+    },
+    {
+     "name": "KeySlash",
+     "rect": [659,236,25,25],
+     "leds": [71]
+    },
+    {
+     "name": "KeyShiftR",
+     "rect": [687,236,82,25],
+     "leds": [72,73,74]
+    },
+    {
+     "name": "KeyCtrlL",
+     "rect": [352,265,25,25],
+     "leds": [75]
+    },
+    {
+     "name": "KeyFNL",
+     "rect": [380,265,25,25],
+     "leds": [76]
+    },
+    {
+     "name": "KeyWin",
+     "rect": [408,265,25,25],
+     "leds": [77]
+    },
+    {
+     "name": "KeyAltL",
+     "rect": [436,265,25,25],
+     "leds": [78]
+    },
+    {
+     "name": "KeySpace",
+     "rect": [464,265,137,25],
+     "leds": [79,80,81,82,83]
+    },
+    {
+     "name": "KeyAltR",
+     "rect": [604,265,25,25],
+     "leds": [84]
+    },
+    {
+     "name": "KeyMouseR",
+     "rect": [632,265,25,25],
+     "leds": [85]
+    },
+    {
+     "name": "KeyCtrlR",
+     "rect": [660,265,25,25],
+     "leds": [86]
+    },
+    {
+     "name": "KeyArrLeft",
+     "rect": [688,265,25,25],
+     "leds": [87]
+    },
+    {
+     "name": "KeyArrUP",
+     "rect": [716,265,25,12],
+     "leds": [88]
+    },
+    {
+     "name": "KeyArrRight",
+     "rect": [744,265,25,25],
+     "leds": [89,90,91,92,93,94,95,96,97,98,99,100,101,102]
+    },
+    {
+     "name": "KeyArrDown",
+     "rect": [716,278,25,12],
+     "leds": [103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129]
+    }
+   ]
+  }
+ },
+ "boards": {
+  "8572": {
+   "device": "DRX",
+   "display": "OMEN X 2S LAPTOP",
+   "cycle": "",
+   "layout": "Drax"
+  },
+  "8573": {
+   "device": "DRX",
+   "display": "OMEN X 2S LAPTOP",
+   "cycle": "",
+   "layout": "Drax"
+  },
+  "878A": {
+   "device": "Starmade",
+   "display": "OMEN 15",
+   "cycle": "",
+   "layout": "Starmade"
+  },
+  "878B": {
+   "device": "Starmade",
+   "display": "OMEN 15",
+   "cycle": "",
+   "layout": "Starmade"
+  },
+  "878C": {
+   "device": "Starmade",
+   "display": "OMEN 15",
+   "cycle": "",
+   "layout": "Starmade"
+  },
+  "8873": {
+   "device": "Modena",
+   "display": "ZBook",
+   "cycle": "",
+   "layout": "Modena"
+  },
+  "88C8": {
+   "device": "Starmade",
+   "display": "OMEN 15",
+   "cycle": "",
+   "layout": "Starmade"
+  },
+  "88CB": {
+   "device": "Starmade",
+   "display": "OMEN 15",
+   "cycle": "",
+   "layout": "Starmade"
+  },
+  "88F4": {
+   "device": "Ralph",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Ralph"
+  },
+  "88F5": {
+   "device": "Ralph",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Ralph"
+  },
+  "88F6": {
+   "device": "Ralph",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Ralph"
+  },
+  "88F7": {
+   "device": "Cybug",
+   "display": "OMEN 17",
+   "cycle": "",
+   "layout": "Cybug"
+  },
+  "88FD": {
+   "device": "Ralph",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Ralph"
+  },
+  "88FE": {
+   "device": "Cybug",
+   "display": "OMEN 17",
+   "cycle": "",
+   "layout": "Cybug"
+  },
+  "8A13": {
+   "device": "Ralph",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Ralph"
+  },
+  "8A14": {
+   "device": "Ralph",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Ralph"
+  },
+  "8A15": {
+   "device": "Ralph",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Ralph"
+  },
+  "8A16": {
+   "device": "Ralph",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Ralph"
+  },
+  "8A17": {
+   "device": "Cybug",
+   "display": "OMEN 17",
+   "cycle": "",
+   "layout": "Cybug"
+  },
+  "8A18": {
+   "device": "Cybug",
+   "display": "OMEN 17",
+   "cycle": "",
+   "layout": "Cybug"
+  },
+  "8A19": {
+   "device": "Cybug",
+   "display": "OMEN 17",
+   "cycle": "",
+   "layout": "Cybug"
+  },
+  "8A1A": {
+   "device": "Cybug",
+   "display": "OMEN 17",
+   "cycle": "",
+   "layout": "Cybug"
+  },
+  "8A40": {
+   "device": "Nolet",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Drax"
+  },
+  "8A41": {
+   "device": "Nolet",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Drax"
+  },
+  "8A42": {
+   "device": "Nolet",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Drax"
+  },
+  "8A43": {
+   "device": "Nolet",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Drax"
+  },
+  "8A44": {
+   "device": "Nolet",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Drax"
+  },
+  "8A4C": {
+   "device": "Hendricks",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Hendricks"
+  },
+  "8A4D": {
+   "device": "Hendricks",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Hendricks"
+  },
+  "8A4E": {
+   "device": "Hendricks",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Hendricks"
+  },
+  "8BA8": {
+   "device": "Brunobear",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Brunobear"
+  },
+  "8BA9": {
+   "device": "Brunobear",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Brunobear"
+  },
+  "8BAA": {
+   "device": "Brunobear",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Brunobear"
+  },
+  "8BAB": {
+   "device": "Brunobear",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Brunobear"
+  },
+  "8BAC": {
+   "device": "Brunobear",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Brunobear"
+  },
+  "8BAD": {
+   "device": "Cybug",
+   "display": "OMEN 17",
+   "cycle": "",
+   "layout": "Cybug"
+  },
+  "8BB0": {
+   "device": "Cybug",
+   "display": "OMEN 17",
+   "cycle": "",
+   "layout": "Cybug"
+  },
+  "8BB3": {
+   "device": "Quaker",
+   "display": "OMEN TRANSCEND 16",
+   "cycle": "",
+   "layout": "Quaker"
+  },
+  "8BB4": {
+   "device": "Quaker",
+   "display": "OMEN TRANSCEND 16",
+   "cycle": "",
+   "layout": "Quaker"
+  },
+  "8C4D": {
+   "device": "Quaker",
+   "display": "OMEN TRANSCEND 16",
+   "cycle": "",
+   "layout": "Quaker"
+  },
+  "8C4E": {
+   "device": "Quaker",
+   "display": "OMEN TRANSCEND 16",
+   "cycle": "",
+   "layout": "Quaker"
+  },
+  "8C58": {
+   "device": "Voco",
+   "display": "HyperX OMEN TRANSCEND 14",
+   "cycle": "",
+   "layout": "Voco"
+  },
+  "8C76": {
+   "device": "Brunobear",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Brunobear"
+  },
+  "8C77": {
+   "device": "Brunobear",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Brunobear"
+  },
+  "8C78": {
+   "device": "Brunobear",
+   "display": "OMEN 16",
+   "cycle": "",
+   "layout": "Brunobear"
+  },
+  "8D23": {
+   "device": "Khalilah",
+   "display": "HyperX OMEN 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8D24": {
+   "device": "Khalilah",
+   "display": "HyperX OMEN 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8D25": {
+   "device": "Khalilah",
+   "display": "HyperX OMEN 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8D26": {
+   "device": "Khalilah",
+   "display": "HyperX OMEN 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8D2D": {
+   "device": "Hanna",
+   "display": "HyperX OMEN 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8D2E": {
+   "device": "Hanna",
+   "display": "HyperX OMEN 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8D2F": {
+   "device": "Hanna",
+   "display": "HyperX OMEN 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8D30": {
+   "device": "Hanna",
+   "display": "HyperX OMEN 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8D3F": {
+   "device": "Hanna",
+   "display": "HyperX OMEN 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8D40": {
+   "device": "Hanna",
+   "display": "HyperX OMEN 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8D41": {
+   "device": "Dojo",
+   "display": "HyperX OMEN MAX 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8D42": {
+   "device": "Dojo",
+   "display": "HyperX OMEN MAX 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8D87": {
+   "device": "Vibrance",
+   "display": "HyperX OMEN MAX 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8D88": {
+   "device": "Vibrance",
+   "display": "HyperX OMEN MAX 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8DD5": {
+   "device": "Vibrance",
+   "display": "HyperX OMEN MAX 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8DD6": {
+   "device": "Vibrance",
+   "display": "HyperX OMEN MAX 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8E35": {
+   "device": "Khalilah",
+   "display": "HyperX OMEN 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8E41": {
+   "device": "Voco",
+   "display": "HyperX OMEN TRANSCEND 14",
+   "cycle": "25C1",
+   "layout": "Voco"
+  },
+  "8E59": {
+   "device": "Hanna",
+   "display": "HyperX OMEN 16",
+   "cycle": "25C1",
+   "layout": "Dojo"
+  },
+  "8E71": {
+   "device": "Hanna",
+   "display": "HyperX OMEN 16",
+   "cycle": "25C2",
+   "layout": "Dojo"
+  },
+  "8E72": {
+   "device": "Hanna",
+   "display": "HyperX OMEN 16",
+   "cycle": "25C2",
+   "layout": "Dojo"
+  },
+  "8E9A": {
+   "device": "Dojo",
+   "display": "HyperX OMEN MAX 16",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8E9F": {
+   "device": "Vibrance",
+   "display": "HyperX OMEN MAX 16",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8EA0": {
+   "device": "Vibrance",
+   "display": "HyperX OMEN MAX 16",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8EDC": {
+   "device": "Pocari",
+   "display": "HyperX OMEN 15",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8EDD": {
+   "device": "Pocari",
+   "display": "HyperX OMEN 15",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8EDE": {
+   "device": "Pocari",
+   "display": "HyperX OMEN 15",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8EDF": {
+   "device": "Pocari",
+   "display": "HyperX OMEN 15",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8EEC": {
+   "device": "Propel",
+   "display": "HyperX OMEN 15",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8EED": {
+   "device": "Propel",
+   "display": "HyperX OMEN 15",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8EEE": {
+   "device": "Propel",
+   "display": "HyperX OMEN 15",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8EEF": {
+   "device": "Propel",
+   "display": "HyperX OMEN 15",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8F05": {
+   "device": "Khalilah",
+   "display": "HyperX OMEN 16",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8F06": {
+   "device": "Khalilah",
+   "display": "HyperX OMEN 16",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8F1C": {
+   "device": "Hanna",
+   "display": "HyperX OMEN 16",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8F1D": {
+   "device": "Hanna",
+   "display": "HyperX OMEN 16",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8F1E": {
+   "device": "Hanna",
+   "display": "HyperX OMEN 16",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8F1F": {
+   "device": "Hanna",
+   "display": "HyperX OMEN 16",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8F20": {
+   "device": "Hanna",
+   "display": "HyperX OMEN 16",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8F21": {
+   "device": "Khalilah",
+   "display": "HyperX OMEN 16",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8F5C": {
+   "device": "Pocari",
+   "display": "HyperX OMEN 15",
+   "cycle": "26C1",
+   "layout": "Dojo26C1"
+  },
+  "8FBE": {
+   "device": "Celsius",
+   "display": "HyperX OMEN 16",
+   "cycle": "27C1",
+   "layout": "Dojo26C1"
+  },
+  "8FBF": {
+   "device": "Celsius",
+   "display": "HyperX OMEN 16",
+   "cycle": "27C1",
+   "layout": "Dojo26C1"
+  },
+  "8FCF": {
+   "device": "Celsius",
+   "display": "HyperX OMEN 16",
+   "cycle": "27C1",
+   "layout": "Dojo26C1"
+  },
+  "8FE6": {
+   "device": "Celsius",
+   "display": "HyperX OMEN 16",
+   "cycle": "27C1",
+   "layout": "Dojo26C1"
+  },
+  "8FE7": {
+   "device": "Celsius",
+   "display": "HyperX OMEN 16",
+   "cycle": "27C1",
+   "layout": "Dojo26C1"
+  },
+  "8FE8": {
+   "device": "Celsius",
+   "display": "HyperX OMEN 16",
+   "cycle": "27C1",
+   "layout": "Dojo26C1"
+  }
+ }
+}

--- a/src/OmenCoreApp/Services/KeyboardLighting/KeyboardLightingServiceV2.cs
+++ b/src/OmenCoreApp/Services/KeyboardLighting/KeyboardLightingServiceV2.cs
@@ -284,6 +284,17 @@ namespace OmenCore.Services.KeyboardLighting
             ?? (IReadOnlyList<Hardware.HidLampArray.LampInfo>)Array.Empty<Hardware.HidLampArray.LampInfo>();
 
         /// <summary>
+        /// The keyboard's key/LED layout, or null when the board is not in the catalogue.
+        ///
+        /// FINER THAN <see cref="GetMeasuredKeyMap"/>, and the two do not line up. LampArray reports
+        /// 120 lamps on 8D87 where the colour map has 176 LEDs: an F key is one lamp and two LEDs,
+        /// Num0 is two lamps and three LEDs, and the Omen and Copilot keys are LEDs with no lamp at
+        /// all. So a caller that wants every addressable light has to come through here, not through
+        /// the lamp map, and pair it with <see cref="SetLedColorsAsync"/>.
+        /// </summary>
+        public KeyboardLayout? GetKeyboardLayout() => (_activeBackend as DojoPerKeyBackend)?.Layout;
+
+        /// <summary>
         /// Colour individually addressed keys, leaving every unnamed key alone.
         /// Keys are lamp ids from <see cref="GetMeasuredKeyMap"/>.
         /// </summary>
@@ -295,6 +306,26 @@ namespace OmenCore.Services.KeyboardLighting
             try
             {
                 return dojo.SetKeyColors(keyColors);
+            }
+            finally
+            {
+                _backendOperationLock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Colour individual LEDs of the MCU's colour map, addressed by the positions in
+        /// <see cref="KeyboardKey.Leds"/>. Every position not named takes <paramref name="background"/>,
+        /// because the map is written whole - there is no partial update on this path.
+        /// </summary>
+        public async Task<bool> SetLedColorsAsync(IReadOnlyDictionary<int, Color> ledColors, Color background)
+        {
+            if (_activeBackend is not DojoPerKeyBackend dojo) return false;
+
+            await _backendOperationLock.WaitAsync();
+            try
+            {
+                return dojo.SetLedColors(ledColors, background);
             }
             finally
             {

--- a/src/OmenCoreApp/Services/KeyboardLighting/KeyboardLightingServiceV2.cs
+++ b/src/OmenCoreApp/Services/KeyboardLighting/KeyboardLightingServiceV2.cs
@@ -158,10 +158,19 @@ namespace OmenCore.Services.KeyboardLighting
             else
             {
                 _logging.Info("[KeyboardLightingV2] No model-specific config found, trying all backends...");
-                
-                // Try backends in order: WMI BIOS → EC Direct
+
+                // HidPerKey FIRST, and its absence from this list was a real bug: a per-key keyboard
+                // on any board the model database does not recognise was invisible, because the
+                // fallback only ever tried the two four-zone paths. Those "succeed" on a per-key
+                // chassis by landing on the light bar, so detection stopped at a backend that
+                // cannot touch the keyboard.
+                //
+                // Putting it first is safe because the per-key backends identify their own device
+                // and decline when it is absent - unlike the WMI paths, which answer for whatever
+                // surface the firmware wires them to.
                 var methodsToTry = new[]
                 {
+                    KeyboardMethod.HidPerKey,
                     KeyboardMethod.ColorTable2020,
                     KeyboardMethod.EcDirect
                 };
@@ -262,6 +271,86 @@ namespace OmenCore.Services.KeyboardLighting
             }
         }
         
+        /// <summary>
+        /// The active backend's measured lamp map - every addressable key with its real position
+        /// and the HID usage it lights - or empty when the backend cannot supply one.
+        ///
+        /// EMPTY IS THE NORMAL ANSWER on most hardware, and callers must treat it as "no real
+        /// layout is known here" rather than as a failure. Only a backend that has interrogated
+        /// the device returns anything; nothing here infers a layout from a model name.
+        /// </summary>
+        public IReadOnlyList<Hardware.HidLampArray.LampInfo> GetMeasuredKeyMap() =>
+            (_activeBackend as DojoPerKeyBackend)?.GetKeyMap()
+            ?? (IReadOnlyList<Hardware.HidLampArray.LampInfo>)Array.Empty<Hardware.HidLampArray.LampInfo>();
+
+        /// <summary>
+        /// Colour individually addressed keys, leaving every unnamed key alone.
+        /// Keys are lamp ids from <see cref="GetMeasuredKeyMap"/>.
+        /// </summary>
+        public async Task<bool> SetKeyColorsAsync(IReadOnlyDictionary<ushort, Color> keyColors)
+        {
+            if (_activeBackend is not DojoPerKeyBackend dojo) return false;
+
+            await _backendOperationLock.WaitAsync();
+            try
+            {
+                return dojo.SetKeyColors(keyColors);
+            }
+            finally
+            {
+                _backendOperationLock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Set the LampArray intensity used by subsequent per-key colour writes, without repainting.
+        /// </summary>
+        public bool SetPerKeyBrightness(int brightness)
+        {
+            if (_activeBackend is not DojoPerKeyBackend dojo) return false;
+            dojo.SetLampIntensity(brightness);
+            return true;
+        }
+
+        /// <summary>Whether this exact keyboard was confirmed on hardware, rather than matched from
+        /// HP's device table. False is not a failure — it means "expected to work, unproven here".</summary>
+        public bool IsVerifiedPerKeyDevice =>
+            (_activeBackend as DojoPerKeyBackend)?.IsVerifiedDevice ?? false;
+
+        /// <summary>USB identity of the per-key keyboard, for display and field reports.</summary>
+        public string PerKeyDeviceIdentity =>
+            (_activeBackend as DojoPerKeyBackend)?.DeviceIdentity ?? string.Empty;
+
+        /// <summary>Whether the active backend can run the device's own animation engine.</summary>
+        public bool SupportsDeviceEffects =>
+            (_activeBackend as DojoPerKeyBackend)?.SupportsDeviceEffects ?? false;
+
+        /// <summary>
+        /// Install one of the device's built-in effects, with the fields that effect consumes.
+        ///
+        /// Distinct from <see cref="IKeyboardBackend.SetEffectAsync"/>, whose four-effect vocabulary
+        /// is all the shared interface can express. The device has twelve.
+        /// </summary>
+        public async Task<RgbApplyResult> SetDeviceEffectAsync(Hardware.DojoKeyboardMcu.EffectRecord record)
+        {
+            if (_activeBackend is not DojoPerKeyBackend dojo)
+                return new RgbApplyResult { FailureReason = "No device-effect capable backend is active" };
+
+            await _backendOperationLock.WaitAsync();
+            try
+            {
+                return dojo.SetDeviceEffect(record);
+            }
+            finally
+            {
+                _backendOperationLock.Release();
+            }
+        }
+
+        /// <summary>The effect the device is currently holding, or null if it will not answer.</summary>
+        public Hardware.DojoKeyboardMcu.EffectRecord? ReadDeviceEffect() =>
+            (_activeBackend as DojoPerKeyBackend)?.ReadDeviceEffect();
+
         private async Task<IKeyboardBackend?> TryInitializeBackend(KeyboardMethod method)
         {
             IKeyboardBackend? backend = null;
@@ -304,9 +393,19 @@ namespace OmenCore.Services.KeyboardLighting
                         break;
                         
                     case KeyboardMethod.HidPerKey:
-                        // Use the USB HID per-key backend (HidSharp, VID 0x03F0).
-                        // Scans for known OMEN per-key keyboard PIDs and falls back
-                        // cleanly if no matching device is found.
+                        // Two per-key backends, for two different keyboards - not a primary and a
+                        // fallback. DojoPerKeyBackend serves Darfon 0D62:54BF (OMEN MAX 16, board
+                        // 8D87), whose protocol was measured on hardware; HidPerKeyBackend serves
+                        // the 0x03F0 OMEN family and speaks a command set this keyboard does not.
+                        // Neither can stand in for the other, so each declines cleanly when its
+                        // device is absent and the loop moves on.
+                        var dojo = new DojoPerKeyBackend(_logging);
+                        if (await dojo.InitializeAsync() && dojo.IsAvailable)
+                        {
+                            return dojo;
+                        }
+
+                        dojo.Dispose();
                         backend = new HidPerKeyBackend(_logging);
                         break;
                         

--- a/src/OmenCoreApp/Services/KeyboardLighting/KeyboardModelDatabase.cs
+++ b/src/OmenCoreApp/Services/KeyboardLighting/KeyboardModelDatabase.cs
@@ -484,12 +484,18 @@ namespace OmenCore.Services.KeyboardLighting
                 PreferredMethod = KeyboardMethod.HidPerKey,
                 FallbackMethods = new[] { KeyboardMethod.NewWmi2023, KeyboardMethod.ColorTable2020 },
                 ModelYear = 2025,
-                UserVerified = false,
-                Notes = "GitHub #117 — OMEN MAX Gaming Laptop 16-ak0xxx (Product ID 8D87). " +
-                    "HidPerKeyBackend (VID 0x03F0) is now active for this model; USB PID 0x054F is probable but requires " +
-                    "field confirmation. If per-key probe fails (unrecognized PID), WMI ColorTable fallback provides " +
-                    "light-bar zone control. Field report noted light bar responds but keyboard body does not — " +
-                    "this is expected until the correct USB PID is confirmed and per-key segment writes are verified."
+                UserVerified = true,
+                Notes = "GitHub #117 — OMEN MAX Gaming Laptop 16-ak0xxx (Product ID 8D87), BIOS F.07 / EC 40.38. " +
+                    "Owner-verified on hardware. The keyboard is Darfon 0D62:54BF, NOT a 0x03F0 device — the earlier " +
+                    "guess of USB PID 0x054F does not exist on this machine, and HidPerKeyBackend's command set is a " +
+                    "different keyboard's. DojoPerKeyBackend serves it over two interfaces: mi_04 (HID LampArray) for " +
+                    "static per-key colour, 120 addressable lamps; mi_03 (vendor HID) for the device's own effect " +
+                    "engine, all twelve animations confirmed by eye. Neither needs administrator. " +
+                    "The old 'light bar responds but keyboard body does not' report is explained: the four-zone WMI " +
+                    "commands reach this chassis's light bar, which is a separate device, so they always looked like " +
+                    "successful keyboard writes. Keyboard brightness is LampArray intensity only — the MCU refuses its " +
+                    "own brightness command (0x0C) at every value, and no effect consumes the brightness field, so a " +
+                    "running device effect cannot be dimmed."
             });
 
             // ═══════════════════════════════════════════════════════════════════════════════════

--- a/src/OmenCoreApp/Services/KeyboardLightingService.cs
+++ b/src/OmenCoreApp/Services/KeyboardLightingService.cs
@@ -869,8 +869,23 @@ namespace OmenCore.Services
                 // Log telemetry summary before disposing
                 LogTelemetrySummary();
                 _v2Service?.Dispose();
+                ReleaseLightBarLampArray();
                 _disposed = true;
             }
+        }
+
+        private void ReleaseLightBarLampArray()
+        {
+            try
+            {
+                using var bar = Hardware.HidLampArray.OpenLightBar();
+                if (bar != null)
+                {
+                    bar.SetAutonomousMode(true);
+                    _logging.Info("[KeyboardLighting] Released light bar LampArray back to device control");
+                }
+            }
+            catch { }
         }
         
         /// <summary>

--- a/src/OmenCoreApp/Services/KeyboardLightingService.cs
+++ b/src/OmenCoreApp/Services/KeyboardLightingService.cs
@@ -1163,6 +1163,20 @@ namespace OmenCore.Services
             return await _v2Service.SetKeyColorsAsync(keyColors);
         }
 
+        /// <summary>The keyboard's key/LED layout, or null when this board is not in the catalogue.</summary>
+        public KeyboardLighting.KeyboardLayout? GetKeyboardLayout() => _v2Service?.GetKeyboardLayout();
+
+        /// <summary>
+        /// Colour individual LEDs by colour-map position. Finer than <see cref="SetKeyColorsAsync"/>,
+        /// which can only reach whole keys; positions come from the layout's <c>Leds</c>.
+        /// </summary>
+        public async Task<bool> SetLedColorsAsync(IReadOnlyDictionary<int, System.Drawing.Color> ledColors,
+                                                  System.Drawing.Color background)
+        {
+            if (_v2Service == null) return false;
+            return await _v2Service.SetLedColorsAsync(ledColors, background);
+        }
+
         /// <summary>
         /// Per-key brightness: the LampArray intensity applied to subsequent colour writes.
         ///

--- a/src/OmenCoreApp/Services/KeyboardLightingService.cs
+++ b/src/OmenCoreApp/Services/KeyboardLightingService.cs
@@ -995,9 +995,164 @@ namespace OmenCore.Services
                 _logging.Info("[KeyboardLighting] ApplyPerKeyGridAsync: no per-key backend active");
                 return false;
             }
-            _logging.Info("[KeyboardLighting] ApplyPerKeyGridAsync: routing to V2 per-key backend");
-            return await Task.FromResult(false); // Placeholder until HidPerKeyBackend is implemented
+            // The grid is a 6 x 14 abstraction with no physical positions, and the device has real
+            // lamps at real coordinates - 120 of them on 8D87 against 84 cells. Mapping cell order
+            // onto lamp order would be a guess about wiring; mapping by POSITION is not. Each cell
+            // owns a rectangle of the keyboard, and every lamp inside that rectangle takes its
+            // colour, so the picture the user drew is the picture that lights up even though the
+            // counts do not match.
+            var map = _v2Service.GetMeasuredKeyMap();
+            if (map.Count == 0)
+            {
+                _logging.Info("[KeyboardLighting] ApplyPerKeyGridAsync: backend has no measured key map, " +
+                              "so grid cells cannot be placed on the keyboard");
+                return false;
+            }
+
+            const int gridRows = 6, gridCols = 14;
+            uint minX = map.Min(l => l.XMicrometres), maxX = map.Max(l => l.XMicrometres);
+            uint minY = map.Min(l => l.YMicrometres), maxY = map.Max(l => l.YMicrometres);
+            double spanX = Math.Max(1, (double)maxX - minX), spanY = Math.Max(1, (double)maxY - minY);
+
+            var keyColors = new Dictionary<ushort, System.Drawing.Color>(map.Count);
+            foreach (var lamp in map)
+            {
+                int col = Math.Clamp((int)((lamp.XMicrometres - minX) / spanX * gridCols), 0, gridCols - 1);
+                int row = Math.Clamp((int)((lamp.YMicrometres - minY) / spanY * gridRows), 0, gridRows - 1);
+
+                int index = (row * gridCols) + col;
+                if (index < flatColors.Length) keyColors[lamp.LampId] = flatColors[index];
+            }
+
+            _logging.Info($"[KeyboardLighting] ApplyPerKeyGridAsync: {flatColors.Length} cells placed onto " +
+                          $"{keyColors.Count} lamps by position");
+            return await _v2Service.SetKeyColorsAsync(keyColors);
         }
+
+        // ── The device's own effect engine ─────────────────────────────────────────────
+
+        /// <summary>Whether the keyboard can run its built-in animations.</summary>
+        public bool SupportsDeviceEffects => _v2Service?.SupportsDeviceEffects ?? false;
+
+        /// <summary>Install one of the keyboard's built-in effects.</summary>
+        public async Task<bool> SetDeviceEffectAsync(Hardware.DojoKeyboardMcu.EffectRecord record)
+        {
+            if (_v2Service == null) return false;
+
+            var result = await _v2Service.SetDeviceEffectAsync(record);
+            if (!result.BackendReportedSuccess)
+                _logging.Warn($"[KeyboardLighting] Device effect {record.Effect} refused: {result.FailureReason}");
+
+            return result.BackendReportedSuccess;
+        }
+
+        /// <summary>The effect the keyboard is currently holding, or null if it will not answer.</summary>
+        public Hardware.DojoKeyboardMcu.EffectRecord? ReadDeviceEffect() => _v2Service?.ReadDeviceEffect();
+
+        // ── Light bar ──────────────────────────────────────────────────────────────────
+        //
+        // A SEPARATE DEVICE from the keyboard, on a separate transport, and the split runs deeper
+        // than it looks: colour is reachable over HID without administrator, while brightness and
+        // the built-in animations exist only behind HP's WMI commands and cannot be reached without
+        // it. So this surface is deliberately not uniform - some of it degrades when unelevated and
+        // some of it disappears, and pretending otherwise would just move the confusion downstream.
+
+        /// <summary>Whether anything at all can drive the light bar on this machine.</summary>
+        public bool IsLightBarAvailable =>
+            (_wmiBios?.IsAvailable ?? false) || Hardware.OmenBoard.SupportsHidLightBar();
+
+        /// <summary>Whether brightness and the built-in animations are reachable (WMI, so elevated).</summary>
+        public bool SupportsLightBarEffects => _wmiBios?.IsAvailable ?? false;
+
+        /// <summary>Current zone colours, or an empty array when they cannot be read.</summary>
+        public (byte R, byte G, byte B)?[] GetLightBarColors() =>
+            _wmiBios?.IsAvailable == true
+                ? _wmiBios.GetLightBarColors()
+                : Array.Empty<(byte R, byte G, byte B)?>();
+
+        /// <summary>
+        /// Paint the bar. Prefers WMI, which also carries brightness; falls back to the bar's own
+        /// LampArray when WMI is unavailable, which is colour only.
+        /// </summary>
+        public bool SetLightBarColors(IReadOnlyList<(byte R, byte G, byte B)> zoneColors, byte brightness = 100)
+        {
+            if (_wmiBios?.IsAvailable == true)
+                return _wmiBios.SetLightBarColors(zoneColors, brightness);
+
+            using var bar = Hardware.HidLampArray.OpenLightBar();
+            if (bar == null)
+            {
+                _logging.Info("[KeyboardLighting] Light bar unreachable: no WMI and no HID LampArray for this board");
+                return false;
+            }
+
+            var lamps = new List<Hardware.HidLampArray.LampColor>();
+            for (ushort zone = 0; zone < bar.LampCount; zone++)
+            {
+                var c = zoneColors[Math.Min(zone, zoneColors.Count - 1)];
+                lamps.Add(new Hardware.HidLampArray.LampColor(zone, c.R, c.G, c.B));
+            }
+
+            bar.SetAutonomousMode(false);
+            bool ok = bar.SetLamps(lamps);
+            _logging.Info($"[KeyboardLighting] Light bar over HID (unelevated path): accepted={ok}. " +
+                          "Brightness and animations are not available this way.");
+            return ok;
+        }
+
+        /// <summary>Run a built-in light bar animation. WMI only - returns false unelevated.</summary>
+        public bool SetLightBarAnimation(
+            HpWmiBios.LightBarEffect effect,
+            HpWmiBios.LightBarTheme theme = HpWmiBios.LightBarTheme.Galaxy,
+            HpWmiBios.LightBarSpeed speed = HpWmiBios.LightBarSpeed.Medium,
+            byte brightness = 100,
+            IReadOnlyList<(byte R, byte G, byte B)>? customColors = null)
+        {
+            if (_wmiBios?.IsAvailable != true)
+            {
+                _logging.Info("[KeyboardLighting] Light bar animations need the WMI BIOS, which needs administrator");
+                return false;
+            }
+
+            return _wmiBios.SetLightBarAnimation(effect, theme, speed,
+                                                 HpWmiBios.LightBarDirection.Left, brightness, customColors);
+        }
+
+        /// <summary>Turn the light bar off.</summary>
+        public bool SetLightBarOff()
+        {
+            if (_wmiBios?.IsAvailable == true) return _wmiBios.SetLightBarOff();
+
+            using var bar = Hardware.HidLampArray.OpenLightBar();
+            return bar != null && bar.SetAll(0, 0, 0);
+        }
+
+        /// <summary>Whether this exact keyboard's per-key support was confirmed on hardware.</summary>
+        public bool IsVerifiedPerKeyDevice => _v2Service?.IsVerifiedPerKeyDevice ?? false;
+
+        /// <summary>USB identity of the per-key keyboard, for display and field reports.</summary>
+        public string PerKeyDeviceIdentity => _v2Service?.PerKeyDeviceIdentity ?? string.Empty;
+
+        /// <summary>The active backend's measured lamp map, or empty when none is known.</summary>
+        public IReadOnlyList<Hardware.HidLampArray.LampInfo> GetMeasuredKeyMap() =>
+            _v2Service?.GetMeasuredKeyMap()
+            ?? (IReadOnlyList<Hardware.HidLampArray.LampInfo>)Array.Empty<Hardware.HidLampArray.LampInfo>();
+
+        /// <summary>Colour individually addressed keys, leaving every unnamed key alone.</summary>
+        public async Task<bool> SetKeyColorsAsync(IReadOnlyDictionary<ushort, System.Drawing.Color> keyColors)
+        {
+            if (_v2Service == null) return false;
+            return await _v2Service.SetKeyColorsAsync(keyColors);
+        }
+
+        /// <summary>
+        /// Per-key brightness: the LampArray intensity applied to subsequent colour writes.
+        ///
+        /// Deliberately does NOT repaint. The caller is about to write colours anyway, and
+        /// repainting here would send the whole map twice for one slider move.
+        /// </summary>
+        public Task<bool> SetPerKeyBrightnessAsync(int brightness) =>
+            Task.FromResult(_v2Service?.SetPerKeyBrightness(brightness) ?? false);
     }
     
     /// <summary>

--- a/src/OmenCoreApp/Services/KeyboardLightingService.cs
+++ b/src/OmenCoreApp/Services/KeyboardLightingService.cs
@@ -885,7 +885,10 @@ namespace OmenCore.Services
                     _logging.Info("[KeyboardLighting] Released light bar LampArray back to device control");
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                _logging.Warn($"[KeyboardLighting] Failed to release light bar LampArray: {ex.Message}");
+            }
         }
         
         /// <summary>

--- a/src/OmenCoreApp/Services/PerformanceModeService.cs
+++ b/src/OmenCoreApp/Services/PerformanceModeService.cs
@@ -251,7 +251,38 @@ namespace OmenCore.Services
                     }
                 }
 
-                _logging.Info($"✓ Performance mode '{effectiveMode.Name}' applied successfully");
+                // Say what actually happened. Every path above can decline to do anything - EC writes
+                // blocked for the model, the WMI policy fallback not permitted, fan policy decoupled
+                // by default - and on a board where all three decline, the only real effect of an
+                // "applied successfully" is the Windows power plan. Reporting success there trains a
+                // user to believe a mode switch did something it did not, and hides the one line that
+                // would tell them why: the skip reason. The flags are already tracked for the trace
+                // entry below; this just stops discarding them on the way to the log.
+                var appliedEffects = new List<string>();
+                if (!string.IsNullOrEmpty(effectiveMode.LinkedPowerPlanGuid)) appliedEffects.Add("Windows power plan");
+                if (ecPowerLimitApplied) appliedEffects.Add("EC power limits");
+                if (wmiPolicyFallbackApplied) appliedEffects.Add("WMI thermal policy");
+                if (LinkFanToPerformanceMode && fanPolicyAction.StartsWith("Linked", StringComparison.Ordinal))
+                    appliedEffects.Add(fanPolicyAction == "Linked fan policy" ? "fan policy" : "fan curve");
+
+                var hardwareEffectApplied = ecPowerLimitApplied || wmiPolicyFallbackApplied ||
+                    (LinkFanToPerformanceMode && fanPolicyAction.StartsWith("Linked", StringComparison.Ordinal));
+
+                if (appliedEffects.Count == 0)
+                {
+                    _logging.Warn($"⚠️ Performance mode '{effectiveMode.Name}': nothing was applied" +
+                        (string.IsNullOrEmpty(ecPowerLimitSkipReason) ? "" : $" ({ecPowerLimitSkipReason})"));
+                }
+                else if (!hardwareEffectApplied)
+                {
+                    _logging.Info($"✓ Performance mode '{effectiveMode.Name}' applied: {string.Join(", ", appliedEffects)}" +
+                        " — no hardware power or fan change" +
+                        (string.IsNullOrEmpty(ecPowerLimitSkipReason) ? "" : $" ({ecPowerLimitSkipReason})"));
+                }
+                else
+                {
+                    _logging.Info($"✓ Performance mode '{effectiveMode.Name}' applied: {string.Join(", ", appliedEffects)}");
+                }
 
                 RecordApplyTrace(new PerformanceModeApplyTraceEntry
                 {

--- a/src/OmenCoreApp/ViewModels/DeviceLightingViewModel.cs
+++ b/src/OmenCoreApp/ViewModels/DeviceLightingViewModel.cs
@@ -1,0 +1,353 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using OmenCore.Hardware;
+using OmenCore.Services;
+using OmenCore.Utils;
+
+namespace OmenCore.ViewModels
+{
+    /// <summary>
+    /// The two surfaces that are rendered BY THE HARDWARE rather than painted by us: the keyboard's
+    /// built-in effect engine, and the light bar.
+    ///
+    /// Kept apart from the per-key editor because they are a different kind of thing. An effect is
+    /// one frame the device then animates on its own - it survives this process exiting, needs no
+    /// repaint loop, and cannot be combined with a host-painted picture, because installing one
+    /// hands the keys back to the firmware.
+    ///
+    /// WHAT IS DELIBERATELY NOT OFFERED HERE:
+    ///
+    /// * Keyboard brightness. The MCU refuses the brightness command on 8D87, and no effect
+    ///   consumes the brightness field, so a slider would move nothing. The per-key editor's
+    ///   intensity is the only working lever and it only scales a host-painted picture.
+    /// * Light bar brightness and animations when unelevated. Those exist solely behind HP's WMI
+    ///   commands. <see cref="SupportsLightBarEffects"/> reports it so the view can hide them
+    ///   rather than offer controls that silently do nothing.
+    /// </summary>
+    public class DeviceLightingViewModel : ViewModelBase
+    {
+        private readonly KeyboardLightingService? _keyboard;
+        private readonly LoggingService _logging;
+
+        private EffectOption? _selectedEffect;
+        private ThemeOption? _selectedTheme;
+        private string _speed = "Medium";
+        private string _direction = "Left to right";
+        private string _primaryColorHex = "#FF0000";
+        private string _secondaryColorHex = "#0000FF";
+        private bool _useCustomColors;
+        private string _status = string.Empty;
+
+        private LightBarEffectOption? _selectedBarEffect;
+        private string _barColorHex = "#0000FF";
+        private int _barBrightness = 100;
+        private string _barStatus = string.Empty;
+
+        public DeviceLightingViewModel(KeyboardLightingService? keyboard, LoggingService logging)
+        {
+            _keyboard = keyboard;
+            _logging = logging;
+
+            _selectedEffect = Effects.FirstOrDefault();
+            _selectedTheme = Themes.FirstOrDefault();
+            _selectedBarEffect = LightBarEffects.FirstOrDefault();
+
+            ApplyEffectCommand = new AsyncRelayCommand(async _ => await ApplyEffectAsync(), _ => SupportsDeviceEffects);
+            ReadEffectCommand = new RelayCommand(_ => ReadEffect(), _ => SupportsDeviceEffects);
+            ApplyLightBarColorCommand = new RelayCommand(_ => ApplyLightBarColor(), _ => IsLightBarAvailable);
+            ApplyLightBarEffectCommand = new RelayCommand(_ => ApplyLightBarEffect(), _ => SupportsLightBarEffects);
+            LightBarOffCommand = new RelayCommand(_ => LightBarOff(), _ => IsLightBarAvailable);
+
+            if (SupportsDeviceEffects) ReadEffect();
+            RefreshLightBar();
+        }
+
+        // ── Keyboard effects ───────────────────────────────────────────────────────
+
+        public bool SupportsDeviceEffects => _keyboard?.SupportsDeviceEffects ?? false;
+
+        /// <summary>
+        /// The device's twelve, in the order OMEN Gaming Hub lists them so a user moving across
+        /// recognises the set. The wire values are NOT this order and are not exposed.
+        /// </summary>
+        public ObservableCollection<EffectOption> Effects { get; } = new(new[]
+        {
+            new EffectOption("Colour cycle", DojoKeyboardMcu.Effect.ColorCycle),
+            new EffectOption("Starlight",    DojoKeyboardMcu.Effect.Starlight),
+            new EffectOption("Breathing",    DojoKeyboardMcu.Effect.Breathing),
+            new EffectOption("Ghosting",     DojoKeyboardMcu.Effect.Ghosting),
+            new EffectOption("Ripple",       DojoKeyboardMcu.Effect.Ripple),
+            new EffectOption("Wave",         DojoKeyboardMcu.Effect.Wave),
+            new EffectOption("OMEN X",       DojoKeyboardMcu.Effect.OmenX),
+            new EffectOption("Raindrop",     DojoKeyboardMcu.Effect.Raindrop),
+            new EffectOption("Audio pulse",  DojoKeyboardMcu.Effect.AudioPulse),
+            new EffectOption("Confetti",     DojoKeyboardMcu.Effect.Confetti),
+            new EffectOption("Sun",          DojoKeyboardMcu.Effect.Sun),
+            new EffectOption("Swipe",        DojoKeyboardMcu.Effect.Swipe),
+        });
+
+        public ObservableCollection<ThemeOption> Themes { get; } = new(new[]
+        {
+            new ThemeOption("Volcano", DojoKeyboardMcu.ShowMode.Volcano),
+            new ThemeOption("Jungle",  DojoKeyboardMcu.ShowMode.Jungle),
+            new ThemeOption("Ocean",   DojoKeyboardMcu.ShowMode.Ocean),
+            new ThemeOption("Rainbow", DojoKeyboardMcu.ShowMode.Rainbow),
+        });
+
+        public ObservableCollection<string> Speeds { get; } = new(new[] { "Slow", "Medium", "Fast" });
+
+        public ObservableCollection<string> Directions { get; } = new(new[]
+        {
+            "Left to right", "Right to left", "Up", "Down", "Inward", "Outward", "Clockwise", "Anticlockwise"
+        });
+
+        public EffectOption? SelectedEffect
+        {
+            get => _selectedEffect;
+            set
+            {
+                _selectedEffect = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(EffectAdvice));
+            }
+        }
+
+        public ThemeOption? SelectedTheme
+        {
+            get => _selectedTheme;
+            set { _selectedTheme = value; OnPropertyChanged(); OnPropertyChanged(nameof(EffectAdvice)); }
+        }
+
+        public string Speed { get => _speed; set { _speed = value; OnPropertyChanged(); } }
+        public string Direction { get => _direction; set { _direction = value; OnPropertyChanged(); } }
+
+        public bool UseCustomColors
+        {
+            get => _useCustomColors;
+            set { _useCustomColors = value; OnPropertyChanged(); OnPropertyChanged(nameof(EffectAdvice)); }
+        }
+
+        public string PrimaryColorHex { get => _primaryColorHex; set { _primaryColorHex = value; OnPropertyChanged(); } }
+        public string SecondaryColorHex { get => _secondaryColorHex; set { _secondaryColorHex = value; OnPropertyChanged(); } }
+
+        public string Status { get => _status; private set { _status = value; OnPropertyChanged(); } }
+
+        /// <summary>
+        /// Warn about the two combinations that produce a black keyboard by design. Both look
+        /// exactly like a broken feature from the user's chair, and both are the firmware doing what
+        /// the field map says - so they are worth saying BEFORE the button is pressed rather than
+        /// explaining afterwards.
+        /// </summary>
+        public string EffectAdvice
+        {
+            get
+            {
+                if (SelectedEffect?.Wire == DojoKeyboardMcu.Effect.Swipe && !UseCustomColors)
+                    return "Swipe has no preset palette — with a theme selected it renders black. Tick custom colours.";
+
+                if (SelectedEffect?.Wire == DojoKeyboardMcu.Effect.AudioPulse)
+                    return "Audio pulse is driven by live audio levels the host feeds it. Applied on its own it shows a steady colour rather than pulsing.";
+
+                if (SelectedEffect?.Wire is DojoKeyboardMcu.Effect.Confetti or DojoKeyboardMcu.Effect.Sun && UseCustomColors)
+                    return "Confetti and Sun take no custom colours — the theme is used regardless.";
+
+                return string.Empty;
+            }
+        }
+
+        public ICommand ApplyEffectCommand { get; }
+        public ICommand ReadEffectCommand { get; }
+
+        private async Task ApplyEffectAsync()
+        {
+            if (_keyboard == null || SelectedEffect == null) return;
+
+            var speed = Speed switch
+            {
+                "Slow" => DojoKeyboardMcu.EffectSpeed.Slow,
+                "Fast" => DojoKeyboardMcu.EffectSpeed.Fast,
+                _ => DojoKeyboardMcu.EffectSpeed.Medium
+            };
+
+            var colors = UseCustomColors
+                ? new[] { ToRgb(PrimaryColorHex), ToRgb(SecondaryColorHex) }
+                : Array.Empty<(byte, byte, byte)>();
+
+            var record = new DojoKeyboardMcu.EffectRecord
+            {
+                Effect = SelectedEffect.Wire,
+                ShowMode = UseCustomColors
+                    ? DojoKeyboardMcu.ShowMode.MultipleCustomColors
+                    : SelectedTheme?.Wire ?? DojoKeyboardMcu.ShowMode.Volcano,
+
+                // Zero-based count when custom, and the preset sentinel otherwise. Sending a count
+                // where a sentinel belongs is what makes Swipe render black.
+                ColorNumber = UseCustomColors ? (byte)(colors.Length - 1) : DojoKeyboardMcu.ColorNumberPreset,
+
+                Speed = speed,
+                Brightness = 0,
+                Direction = ToDirection(Direction),
+                RippleSize = 1,
+                RaindropFrequency = (byte)speed,
+                Colors = colors
+            };
+
+            bool ok = await _keyboard.SetDeviceEffectAsync(record);
+            Status = ok
+                ? $"{SelectedEffect.Name} installed. It keeps running with OmenCore closed."
+                : $"The keyboard refused {SelectedEffect.Name}.";
+        }
+
+        private void ReadEffect()
+        {
+            var current = _keyboard?.ReadDeviceEffect();
+            if (current == null)
+            {
+                Status = "The keyboard did not answer a state read.";
+                return;
+            }
+
+            var r = current.Value;
+            string palette = r.ColorNumber == DojoKeyboardMcu.ColorNumberPreset
+                ? r.ShowMode.ToString()
+                : $"{r.ColorNumber + 1} custom colour(s)";
+
+            Status = $"On the keyboard now: {r.Effect}, {palette}, {r.Speed.ToString().ToLowerInvariant()}.";
+        }
+
+        // ── Light bar ──────────────────────────────────────────────────────────────
+
+        public bool IsLightBarAvailable => _keyboard?.IsLightBarAvailable ?? false;
+        public bool SupportsLightBarEffects => _keyboard?.SupportsLightBarEffects ?? false;
+
+        public ObservableCollection<LightBarEffectOption> LightBarEffects { get; } = new(new[]
+        {
+            new LightBarEffectOption("Colour cycle", HpWmiBios.LightBarEffect.ColorCycle),
+            new LightBarEffectOption("Starlight",    HpWmiBios.LightBarEffect.Starlight),
+            new LightBarEffectOption("Breathing",    HpWmiBios.LightBarEffect.Breathing),
+            new LightBarEffectOption("Wave",         HpWmiBios.LightBarEffect.Wave),
+            new LightBarEffectOption("Raindrop",     HpWmiBios.LightBarEffect.Raindrop),
+            new LightBarEffectOption("Audio pulse",  HpWmiBios.LightBarEffect.AudioPulse),
+            new LightBarEffectOption("Confetti",     HpWmiBios.LightBarEffect.Confetti),
+            new LightBarEffectOption("Sun",          HpWmiBios.LightBarEffect.Sun),
+            new LightBarEffectOption("Swipe",        HpWmiBios.LightBarEffect.Swipe),
+        });
+
+        public LightBarEffectOption? SelectedBarEffect
+        {
+            get => _selectedBarEffect;
+            set { _selectedBarEffect = value; OnPropertyChanged(); }
+        }
+
+        public string BarColorHex { get => _barColorHex; set { _barColorHex = value; OnPropertyChanged(); } }
+
+        public int BarBrightness
+        {
+            get => _barBrightness;
+            set { _barBrightness = Math.Clamp(value, 0, 100); OnPropertyChanged(); }
+        }
+
+        public string BarStatus { get => _barStatus; private set { _barStatus = value; OnPropertyChanged(); } }
+
+        /// <summary>Shown when unelevated, so the missing controls are explained rather than absent.</summary>
+        public string LightBarLimitation => SupportsLightBarEffects
+            ? string.Empty
+            : "Run OmenCore as administrator for light bar brightness and animations — those go through " +
+              "HP's BIOS interface, which Windows restricts. Colour works either way.";
+
+        public ICommand ApplyLightBarColorCommand { get; }
+        public ICommand ApplyLightBarEffectCommand { get; }
+        public ICommand LightBarOffCommand { get; }
+
+        private void ApplyLightBarColor()
+        {
+            if (_keyboard == null) return;
+
+            bool ok = _keyboard.SetLightBarColors(new[] { ToRgb(BarColorHex) }, (byte)BarBrightness);
+            BarStatus = ok ? "Light bar updated." : "The light bar refused the update.";
+            RefreshLightBar();
+        }
+
+        private void ApplyLightBarEffect()
+        {
+            if (_keyboard == null || SelectedBarEffect == null) return;
+
+            // Swipe is custom-colour only on this device too, so it is given the picked colour
+            // rather than a theme - otherwise selecting it from a menu produces a dark bar.
+            bool custom = SelectedBarEffect.Wire == HpWmiBios.LightBarEffect.Swipe;
+
+            bool ok = _keyboard.SetLightBarAnimation(
+                SelectedBarEffect.Wire,
+                custom ? HpWmiBios.LightBarTheme.Custom : HpWmiBios.LightBarTheme.Galaxy,
+                HpWmiBios.LightBarSpeed.Medium,
+                (byte)BarBrightness,
+                custom ? new[] { ToRgb(BarColorHex) } : null);
+
+            BarStatus = ok
+                ? $"{SelectedBarEffect.Name} sent. There is no readback for animations — look at the bar."
+                : $"The light bar refused {SelectedBarEffect.Name}.";
+        }
+
+        private void LightBarOff()
+        {
+            if (_keyboard == null) return;
+            BarStatus = _keyboard.SetLightBarOff() ? "Light bar off." : "The light bar refused the command.";
+        }
+
+        private void RefreshLightBar()
+        {
+            var zones = _keyboard?.GetLightBarColors() ?? Array.Empty<(byte R, byte G, byte B)?>();
+            if (zones.Length == 0) return;
+
+            BarStatus = "Now showing: " + string.Join("  ",
+                zones.Select(z => z == null ? "??" : $"#{z.Value.R:X2}{z.Value.G:X2}{z.Value.B:X2}"));
+        }
+
+        // ── Helpers ────────────────────────────────────────────────────────────────
+
+        private static (byte R, byte G, byte B) ToRgb(string hex)
+        {
+            try
+            {
+                var c = (System.Windows.Media.Color)System.Windows.Media.ColorConverter.ConvertFromString(
+                    hex.StartsWith('#') ? hex : "#" + hex);
+                return (c.R, c.G, c.B);
+            }
+            catch
+            {
+                return (0, 0, 0);
+            }
+        }
+
+        private static DojoKeyboardMcu.EffectDirection ToDirection(string name) => name switch
+        {
+            "Right to left" => DojoKeyboardMcu.EffectDirection.RightToLeft,
+            "Up" => DojoKeyboardMcu.EffectDirection.Up,
+            "Down" => DojoKeyboardMcu.EffectDirection.Down,
+            "Inward" => DojoKeyboardMcu.EffectDirection.Inward,
+            "Outward" => DojoKeyboardMcu.EffectDirection.Outward,
+            "Clockwise" => DojoKeyboardMcu.EffectDirection.Clockwise,
+            "Anticlockwise" => DojoKeyboardMcu.EffectDirection.CounterClockwise,
+            _ => DojoKeyboardMcu.EffectDirection.LeftToRight
+        };
+
+        public record EffectOption(string Name, DojoKeyboardMcu.Effect Wire)
+        {
+            public override string ToString() => Name;
+        }
+
+        public record ThemeOption(string Name, DojoKeyboardMcu.ShowMode Wire)
+        {
+            public override string ToString() => Name;
+        }
+
+        public record LightBarEffectOption(string Name, HpWmiBios.LightBarEffect Wire)
+        {
+            public override string ToString() => Name;
+        }
+    }
+}

--- a/src/OmenCoreApp/ViewModels/FanDiagnosticsViewModel.cs
+++ b/src/OmenCoreApp/ViewModels/FanDiagnosticsViewModel.cs
@@ -284,6 +284,7 @@ namespace OmenCore.ViewModels
             var testLevels = new[] { 30, 60, 100 };
             var fanNames = new[] { "CPU", "GPU" };
             var results = new System.Collections.Generic.List<(string fan, int target, bool passed, string rpm, double deviation, int score, string rating, string evidence)>();
+            var sourcesSeen = new System.Collections.Generic.List<RpmSource>();
             
             // v2.7.1: Save current preset before diagnostic
             _preTestPreset = _fanService.ActivePreset;
@@ -312,6 +313,7 @@ namespace OmenCore.ViewModels
                             var passed = result.VerificationPassed;
                             var evidence = string.IsNullOrWhiteSpace(result.VerificationEvidence) ? "None" : result.VerificationEvidence;
                             results.Add((fanName, targetPercent, passed, result.RpmDisplay, result.DeviationPercent, result.VerificationScore, result.ScoreRating, evidence));
+                            sourcesSeen.Add(result.RpmSource);
                             
                             // Add to history
                             History.Insert(0, result);
@@ -347,7 +349,14 @@ namespace OmenCore.ViewModels
                 
                 var summary = new System.Text.StringBuilder();
                 summary.AppendLine($"=== DIAGNOSTIC COMPLETE: {(overallPassed ? "✅ PASS" : "❌ FAIL")} ===");
-                summary.AppendLine($"Backend: {_fanService.Backend} | RPM source: {RpmSourceDisplay}");
+                // Report the sources this run actually read from, not RpmSourceDisplay - that is
+                // the "current state" panel's property, refreshed on its own schedule, and it read
+                // "?" on a run whose every result was EcDirect. A header that disagrees with the
+                // lines beneath it is worse than no header.
+                var sourceLabel = sourcesSeen.Count == 0
+                    ? "none"
+                    : string.Join(" + ", sourcesSeen.Distinct().OrderBy(s => s.ToString()));
+                summary.AppendLine($"Backend: {_fanService.Backend} | RPM source: {sourceLabel}");
                 summary.AppendLine($"Tests: {passCount}/{totalTests} passed | Overall Score: {avgScore}/100 ({overallRating})");
                 summary.AppendLine();
                 

--- a/src/OmenCoreApp/ViewModels/FanDiagnosticsViewModel.cs
+++ b/src/OmenCoreApp/ViewModels/FanDiagnosticsViewModel.cs
@@ -60,7 +60,7 @@ namespace OmenCore.ViewModels
         public bool IsDiagnosticActive
         {
             get => _isDiagnosticActive;
-            private set { _isDiagnosticActive = value; OnPropertyChanged(); }
+            private set { _isDiagnosticActive = value; OnPropertyChanged(); RaiseTestCommandStates(); }
         }
 
         public bool IsVerificationAvailable => _verifier?.IsAvailable ?? false;
@@ -76,6 +76,18 @@ namespace OmenCore.ViewModels
 
             RefreshStateCommand = new RelayCommand(_ => _ = UpdateCurrentStateAsync());
             ApplyAndVerifyCommand = new AsyncRelayCommand(_ => ApplyAndVerifyAsync(), _ => IsVerificationAvailable && !IsDiagnosticActive);
+
+            // Constructed once and kept. These were previously expression-bodied properties that
+            // returned a new command on every get: the button bound to whatever instance existed
+            // when the binding first evaluated - at load, with no results yet - and since nothing
+            // held that instance, its CanExecute could never be re-run. Copy Results was disabled
+            // for the life of the window.
+            RunGuidedDiagnosticCommand = new AsyncRelayCommand(
+                _ => RunGuidedDiagnosticAsync(),
+                _ => IsVerificationAvailable && !IsDiagnosticActive && !IsGuidedTestRunning);
+            CopyGuidedResultCommand = new RelayCommand(
+                _ => CopyGuidedResult(),
+                _ => !string.IsNullOrEmpty(GuidedTestResult) && !IsGuidedTestRunning);
 
             // Default to CPU fan
             SelectedFanIndex = 0;
@@ -191,7 +203,7 @@ namespace OmenCore.ViewModels
         public bool IsGuidedTestRunning
         {
             get => _isGuidedTestRunning;
-            private set { _isGuidedTestRunning = value; OnPropertyChanged(); }
+            private set { _isGuidedTestRunning = value; OnPropertyChanged(); RaiseTestCommandStates(); }
         }
         
         /// <summary>
@@ -209,7 +221,7 @@ namespace OmenCore.ViewModels
         public string GuidedTestResult
         {
             get => _guidedTestResult;
-            private set { _guidedTestResult = value; OnPropertyChanged(); }
+            private set { _guidedTestResult = value; OnPropertyChanged(); RaiseTestCommandStates(); }
         }
         
         /// <summary>
@@ -221,13 +233,27 @@ namespace OmenCore.ViewModels
             private set { _guidedTestProgress = value; OnPropertyChanged(); }
         }
         
-        public ICommand RunGuidedDiagnosticCommand => new AsyncRelayCommand(_ => RunGuidedDiagnosticAsync(), _ => IsVerificationAvailable && !IsDiagnosticActive && !IsGuidedTestRunning);
-
+        public ICommand RunGuidedDiagnosticCommand { get; }
 
         /// <summary>
         /// Copy the guided diagnostic result summary to the clipboard.
         /// </summary>
-        public ICommand CopyGuidedResultCommand => new RelayCommand(_ => CopyGuidedResult(), _ => !string.IsNullOrEmpty(GuidedTestResult) && !IsGuidedTestRunning);
+        public ICommand CopyGuidedResultCommand { get; }
+
+        /// <summary>
+        /// Re-evaluate every command whose CanExecute depends on test state.
+        ///
+        /// This has to be explicit. RelayCommand raises CanExecuteChanged only when asked - it
+        /// does not chain off CommandManager.RequerySuggested - so a command that is not held in
+        /// a field and poked here can never change its enabled state after the binding first
+        /// evaluates it.
+        /// </summary>
+        private void RaiseTestCommandStates()
+        {
+            (RunGuidedDiagnosticCommand as AsyncRelayCommand)?.RaiseCanExecuteChanged();
+            (CopyGuidedResultCommand as RelayCommand)?.RaiseCanExecuteChanged();
+            (ApplyAndVerifyCommand as AsyncRelayCommand)?.RaiseCanExecuteChanged();
+        }
 
         private void CopyGuidedResult()
         {

--- a/src/OmenCoreApp/ViewModels/KeyboardMapViewModel.cs
+++ b/src/OmenCoreApp/ViewModels/KeyboardMapViewModel.cs
@@ -1,0 +1,695 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Drawing;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using OmenCore.Hardware;
+using OmenCore.Services;
+using OmenCore.Utils;
+
+namespace OmenCore.ViewModels
+{
+    /// <summary>
+    /// Per-key editor backed by the keyboard's MEASURED lamp map - every key at the position the
+    /// device reported, rather than a grid of assumed shape.
+    ///
+    /// This exists alongside the 6 x 14 grid editor rather than replacing it: that one is a fixed
+    /// abstraction that works on any per-key model, while this needs a backend that has actually
+    /// interrogated the hardware. Where no map is available <see cref="IsAvailable"/> is false and
+    /// the view hides itself, leaving the existing editor as it was.
+    ///
+    /// The selection maths lives here rather than in the code-behind so it can be tested without a
+    /// window - a bounds check that is off by one selects a neighbouring key, which looks plausible
+    /// until the wrong key lights up.
+    ///
+    /// WITH THANKS TO arfelious/omen-rgb-linux (https://github.com/arfelious/omen-rgb-linux), whose
+    /// hand-built key table for this chassis family was used to check this layout. That project
+    /// addresses a 182-entry LED space over the vendor protocol rather than this 120-lamp HID
+    /// LampArray, so none of its offsets are reused here - but its per-key WIDTHS independently
+    /// establish that one key spans several LEDs (backspace 8, left shift 7, caps lock 5), which is
+    /// the model this layout is built on and the bug that produced a crushed modifier column.
+    /// </summary>
+    public class KeyboardMapViewModel : ViewModelBase
+    {
+        private readonly KeyboardLightingService? _keyboard;
+        private readonly LoggingService _logging;
+
+        // Layout scale. The view scales the canvas to fit, so PixelsPerMm only sets the resolution
+        // the layout is computed at. The device reports lamp CENTRES and no extents, so a key has to
+        // be given a size: 15 mm sits under the ~18 mm pitch, leaving a gap between neighbours
+        // instead of a solid sheet. MinKeyWidth keeps the ~9 mm filler lamps clickable.
+        private const double PixelsPerMm = 2.6;
+        private const double KeySizeMm = 15.0;
+        private const double MinKeyWidth = 14.0;
+
+        private string _brushColorHex = "#FF0000";
+        private string _status = string.Empty;
+        private int _brightness = 100;
+
+        public KeyboardMapViewModel(KeyboardLightingService? keyboard, LoggingService logging)
+        {
+            _keyboard = keyboard;
+            _logging = logging;
+
+            PickColorCommand = new RelayCommand(_ => PickColor());
+            SelectAllCommand = new RelayCommand(_ => SetSelection(Keys, true));
+            ClearSelectionCommand = new RelayCommand(_ => SetSelection(Keys, false));
+            PaintSelectionCommand = new RelayCommand(_ => PaintSelection());
+            ClearAllColorsCommand = new RelayCommand(_ => ClearAllColors());
+            ApplyCommand = new AsyncRelayCommand(async _ => await ApplyAsync(), _ => IsAvailable);
+
+            Load();
+        }
+
+        public ObservableCollection<KeyLampViewModel> Keys { get; } = new();
+
+        /// <summary>Whether a measured map was found. False hides the whole editor.</summary>
+        public bool IsAvailable => Keys.Count > 0;
+
+        private const int LightBarZoneCount = 4;
+
+        /// <summary>Whether the light bar is reachable, and so worth drawing under the keyboard.</summary>
+        public bool HasLightBar => _keyboard?.IsLightBarAvailable ?? false;
+
+        /// <summary>
+        /// Warning text for a keyboard that matched HP's device table but has never been driven here,
+        /// or empty when this exact device was confirmed on hardware. The editor is offered either
+        /// way - the map comes from the device itself - but the user is told which footing they are
+        /// on. Treating HP's table as measurement is what put a non-existent PID in the database.
+        /// </summary>
+        public string VerificationWarning =>
+            !IsAvailable || (_keyboard?.IsVerifiedPerKeyDevice ?? false)
+                ? string.Empty
+                : $"This keyboard ({_keyboard?.PerKeyDeviceIdentity}) matches HP's device list for this " +
+                  "protocol but has not been confirmed on hardware here. Per-key colour is expected to " +
+                  "work and the layout is read from the keyboard itself, so it should be correct — but " +
+                  "if anything misbehaves, that is worth reporting with this device id.";
+
+        public bool HasVerificationWarning => VerificationWarning.Length > 0;
+
+        /// <summary>Logical canvas size, in device-independent pixels.</summary>
+        public double CanvasWidth { get; private set; }
+        public double CanvasHeight { get; private set; }
+
+        public string BrushColorHex
+        {
+            get => _brushColorHex;
+            set
+            {
+                if (_brushColorHex == value) return;
+                _brushColorHex = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(BrushColorBrush));
+            }
+        }
+
+        public System.Windows.Media.SolidColorBrush BrushColorBrush => new(ParseColor(BrushColorHex));
+
+        /// <summary>
+        /// 0-100, applied as the LampArray per-lamp intensity channel on the next apply.
+        ///
+        /// The ONLY brightness lever this keyboard has: the MCU's own command is refused by this
+        /// firmware at every value, and no device effect consumes the effect record's brightness
+        /// field. So this scales a host-painted picture and nothing else - a running effect cannot be
+        /// dimmed, which the UI says rather than implying otherwise.
+        /// </summary>
+        public int Brightness
+        {
+            get => _brightness;
+            set
+            {
+                int clamped = Math.Clamp(value, 0, 100);
+                if (_brightness == clamped) return;
+                _brightness = clamped;
+                OnPropertyChanged();
+            }
+        }
+
+        public int SelectedCount => Keys.Count(k => k.IsSelected);
+
+        public string Status
+        {
+            get => _status;
+            private set { _status = value; OnPropertyChanged(); }
+        }
+
+        public ICommand PickColorCommand { get; }
+        public ICommand SelectAllCommand { get; }
+        public ICommand ClearSelectionCommand { get; }
+        public ICommand PaintSelectionCommand { get; }
+        public ICommand ClearAllColorsCommand { get; }
+        public ICommand ApplyCommand { get; }
+
+        // ── Selection ──────────────────────────────────────────────────────────────
+
+        /// <summary>Toggle one key: clicking a selected key deselects it.</summary>
+        public void ToggleKey(KeyLampViewModel key)
+        {
+            key.IsSelected = !key.IsSelected;
+            OnPropertyChanged(nameof(SelectedCount));
+        }
+
+        /// <summary>
+        /// Select every key whose drawn rectangle INTERSECTS the band, not every key whose centre
+        /// falls inside it - catching only enclosed centres is what users read as "it missed some".
+        /// </summary>
+        /// <param name="additive">True to add to the current selection, false to replace it.</param>
+        public void SelectWithin(double x1, double y1, double x2, double y2, bool additive)
+        {
+            double left = Math.Min(x1, x2), right = Math.Max(x1, x2);
+            double top = Math.Min(y1, y2), bottom = Math.Max(y1, y2);
+
+            foreach (var key in Keys)
+            {
+                bool hit = key.X < right && key.X + key.Width > left &&
+                           key.Y < bottom && key.Y + key.Height > top;
+
+                if (hit) key.IsSelected = true;
+                else if (!additive) key.IsSelected = false;
+            }
+
+            OnPropertyChanged(nameof(SelectedCount));
+        }
+
+        private void SetSelection(IEnumerable<KeyLampViewModel> keys, bool selected)
+        {
+            foreach (var key in keys) key.IsSelected = selected;
+            OnPropertyChanged(nameof(SelectedCount));
+        }
+
+        // ── Colour ─────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Open the app's existing colour picker rather than a new one - a second picker would be a
+        /// second set of swatches and hex parsing to keep consistent with this page.
+        /// </summary>
+        private void PickColor()
+        {
+            var dialog = new Views.ColorPickerDialog
+            {
+                Owner = System.Windows.Application.Current?.MainWindow
+            };
+
+            dialog.SetInitialColor(BrushColorHex);
+
+            if (dialog.ShowDialog() == true && dialog.DialogResultOk)
+            {
+                BrushColorHex = dialog.SelectedHexColor;
+
+                // Painting immediately is the point of picking a colour while keys are selected -
+                // otherwise the picker sets a brush and appears to have done nothing.
+                if (SelectedCount > 0) PaintSelection();
+            }
+        }
+
+        /// <summary>
+        /// Colour the selected keys, then CLEAR the selection. The white selection ring sits on top
+        /// of the key's own colour, so leaving it up hides the colour just applied - which reads as
+        /// "the paint button did nothing".
+        /// </summary>
+        private void PaintSelection()
+        {
+            var targets = Keys.Where(k => k.IsSelected).ToList();
+
+            if (targets.Count == 0)
+            {
+                Status = "Nothing selected. Click keys, or drag a box across them.";
+                return;
+            }
+
+            foreach (var key in targets)
+            {
+                key.ColorHex = BrushColorHex;
+                key.IsSelected = false;
+            }
+
+            OnPropertyChanged(nameof(SelectedCount));
+            Status = $"Painted {targets.Count} key(s) {BrushColorHex}. " +
+                     "Keep going, then Apply to send the whole map to the keyboard.";
+        }
+
+        private void ClearAllColors()
+        {
+            foreach (var key in Keys) key.ColorHex = "#000000";
+            Status = "All keys set to black. Apply to send it.";
+        }
+
+        private async Task ApplyAsync()
+        {
+            if (_keyboard == null || Keys.Count == 0) return;
+
+            // One picture, two devices. The keys and the bar are edited together and sent apart,
+            // because they are different hardware on different transports - HID lamps for the
+            // keyboard, HP's WMI command or the bar's own LampArray for the bar.
+            var colors = new Dictionary<ushort, System.Drawing.Color>();
+            var barZones = new (byte R, byte G, byte B)[LightBarZoneCount];
+            bool anyBar = false;
+
+            foreach (var key in Keys)
+            {
+                var parsed = ParseColor(key.ColorHex);
+
+                if (key.IsLightBar)
+                {
+                    barZones[key.ZoneIndex] = (parsed.R, parsed.G, parsed.B);
+                    anyBar = true;
+                    continue;
+                }
+
+                // Flattened back to lamps, because that is what the keyboard addresses. A wide key
+                // contributes each of its lamps with the same colour.
+                var color = ToDrawingColor(parsed);
+                foreach (ushort lampId in key.LampIds) colors[lampId] = color;
+            }
+
+            // Brightness first: it is the intensity byte attached to each lamp in the write below,
+            // so setting it after would need a second full repaint to take effect.
+            await _keyboard.SetPerKeyBrightnessAsync(Brightness);
+
+            bool keysOk = colors.Count == 0 || await _keyboard.SetKeyColorsAsync(colors);
+            bool barOk = !anyBar || _keyboard.SetLightBarColors(barZones, (byte)Brightness);
+
+            // "Accepted" is the honest word for the keyboard: there is no colour readback anywhere
+            // in the LampArray spec, so the software cannot confirm a key changed - only that the
+            // device took the report. The bar's colours ARE readable, but not through this call.
+            var parts = new List<string>();
+            if (colors.Count > 0) parts.Add($"{colors.Count} keys {(keysOk ? "accepted" : "REFUSED")}");
+            if (anyBar) parts.Add($"4 bar zones {(barOk ? "accepted" : "REFUSED")}");
+
+            Status = string.Join(", ", parts) + ". Only looking confirms it.";
+            _logging.Info($"[KeyboardMap] Apply: {colors.Count} keys keysOk={keysOk}, " +
+                          $"bar={anyBar} barOk={barOk}");
+        }
+
+        // ── Loading ────────────────────────────────────────────────────────────────
+
+        private void Load()
+        {
+            var map = _keyboard?.GetMeasuredKeyMap() ?? Array.Empty<HidLampArray.LampInfo>();
+            if (map.Count == 0)
+            {
+                Status = "No measured key map on this machine.";
+                return;
+            }
+
+            // Lay out from the lamps' own coordinates, normalised so the leftmost/topmost key sits
+            // at the canvas edge. Absolute device coordinates would leave whatever margin the
+            // firmware happens to report, which differs per model.
+            uint minX = map.Min(l => l.XMicrometres), maxX = map.Max(l => l.XMicrometres);
+            uint minY = map.Min(l => l.YMicrometres), maxY = map.Max(l => l.YMicrometres);
+
+            double keySize = KeySizeMm * PixelsPerMm;
+            CanvasWidth = ((maxX - minX) / 1000.0 * PixelsPerMm) + keySize;
+            CanvasHeight = ((maxY - minY) / 1000.0 * PixelsPerMm) + keySize;
+
+            // Snap every key in a row to one Y. Lamp centres within a row differ by a fraction of a
+            // millimetre - real manufacturing placement - and drawn faithfully that reads as a
+            // wobbly keyboard rather than as precision.
+            var rowTops = SnapRows(map);
+
+            var keyGroups = GroupLampsIntoKeys(map);
+
+            for (int i = 0; i < keyGroups.Count; i++)
+            {
+                var group = keyGroups[i];
+                double first = (group[0].XMicrometres - minX) / 1000.0 * PixelsPerMm;
+                double last = (group[^1].XMicrometres - minX) / 1000.0 * PixelsPerMm;
+
+                // Width runs to the NEXT key in the same row, not a fixed key size. This is what
+                // fixes the crushed left-hand columns: the keyboard reports filler lamps between
+                // real keys - usage 0x03 at 9 mm spacing - which at a full 15 mm cap overlapped
+                // their neighbours three deep. Measuring to the next key gives each lamp the room it
+                // actually occupies, so a filler renders as a sliver and Space still spans five.
+                double available = keySize;
+                if (i + 1 < keyGroups.Count)
+                {
+                    var next = keyGroups[i + 1];
+                    bool sameRow = rowTops[next[0].YMicrometres] == rowTops[group[0].YMicrometres];
+
+                    // Two keys at the SAME x are the half-height arrow stack: Up and Down share one
+                    // reported position. They are split vertically below, so neither constrains the
+                    // other's width.
+                    bool stacked = sameRow && next[0].XMicrometres == group[^1].XMicrometres;
+
+                    if (sameRow && !stacked)
+                    {
+                        double nextX = (next[0].XMicrometres - minX) / 1000.0 * PixelsPerMm;
+                        available = Math.Max(MinKeyWidth, Math.Min(keySize, nextX - last));
+                    }
+                }
+
+                // Half-height keys, for the inverted-T arrow cluster: Up and Down occupy one cell,
+                // stacked. Drawing them side by side at full height is what produced an overlap.
+                bool sharesCellWithPrevious = i > 0 &&
+                    keyGroups[i - 1][^1].XMicrometres == group[0].XMicrometres &&
+                    rowTops[keyGroups[i - 1][0].YMicrometres] == rowTops[group[0].YMicrometres];
+                bool sharesCellWithNext = i + 1 < keyGroups.Count &&
+                    keyGroups[i + 1][0].XMicrometres == group[^1].XMicrometres &&
+                    rowTops[keyGroups[i + 1][0].YMicrometres] == rowTops[group[0].YMicrometres];
+
+                bool halfHeight = sharesCellWithPrevious || sharesCellWithNext;
+                double height = halfHeight ? keySize / 2 : keySize;
+                double yNudge = sharesCellWithPrevious ? keySize / 2 : 0;
+
+                Keys.Add(new KeyLampViewModel
+                {
+                    LampIds = group.Select(l => l.LampId).ToArray(),
+                    KeyUsage = group[0].KeyUsage,
+                    Label = KeyName(group[0].KeyUsage),
+
+                    // A wide key spans from the first lamp's box to the last one's, so Shift draws
+                    // as one long cap rather than three overlapping squares.
+                    X = first,
+                    Y = ((rowTops[group[0].YMicrometres] - minY) / 1000.0 * PixelsPerMm) + yNudge,
+                    Width = last - first + available,
+                    Height = height,
+
+                    // Keys start at the BRUSH colour, not black. Apply sends every key, so a black
+                    // default means painting WASD red and applying blanks the rest of the keyboard -
+                    // which reads as "it does not work". There is no colour readback here, so the
+                    // true state cannot be loaded; the brush is the honest default because it is the
+                    // one colour the user has already chosen.
+                    ColorHex = BrushColorHex
+                });
+            }
+
+            int keyCount = Keys.Count;
+            AddLightBarZones(keySize);
+
+            Status = HasLightBar
+                ? $"{keyCount} keys and 4 light bar zones. Click to select, or drag a box. Hold Ctrl to add."
+                : $"{keyCount} keys. Click to select, or drag a box. Hold Ctrl to add.";
+
+            _logging.Info($"[KeyboardMap] Loaded {keyCount} keys from the measured lamp map" +
+                          (HasLightBar ? ", plus 4 light bar zones" : string.Empty));
+        }
+
+        /// <summary>
+        /// Collect the lamps into physical KEYS - the difference between a keyboard and a scatter
+        /// plot. The device reports lamps, not keys, and a wide key carries several: Space has five
+        /// on 8D87, both Shifts three, Caps and Tab two. Their centres are 7 to 11 mm apart, closer
+        /// than one key is wide, so a cap per lamp drew three overlapping squares where the keyboard
+        /// has one long one.
+        ///
+        /// Lamps join a key when they agree on all three of usage, row, and adjacency. All three are
+        /// needed - usage alone merges the two Enter keys either side of the numpad, adjacency alone
+        /// merges neighbouring letters. Usage 0 lamps are NEVER merged: "no key reported" is not
+        /// evidence two lamps belong together, and on this board each is independently addressable.
+        /// </summary>
+        internal static List<List<HidLampArray.LampInfo>> GroupLampsIntoKeys(
+            IReadOnlyList<HidLampArray.LampInfo> map)
+        {
+            // A row is a band of Y, not an exact value: lamps under one key row can differ by a
+            // fraction of a millimetre. A key is ~15 mm tall, so half that separates rows safely.
+            const uint RowToleranceUm = 7_000;
+
+            // Two lamps under one key cap are at most a key-width apart. Beyond that they are
+            // separate keys that happen to share a usage - the two Enters, the two Shifts.
+            const uint AdjacencyLimitUm = 20_000;
+
+            var ordered = map.OrderBy(l => l.YMicrometres).ThenBy(l => l.XMicrometres).ToList();
+            var keys = new List<List<HidLampArray.LampInfo>>();
+
+            foreach (var lamp in ordered)
+            {
+                var current = keys.Count > 0 ? keys[^1] : null;
+                var previous = current?[^1];
+
+                bool joins = current != null && previous.HasValue
+                    && lamp.KeyUsage != 0
+                    && lamp.KeyUsage == previous.Value.KeyUsage
+                    && AbsDiff(lamp.YMicrometres, previous.Value.YMicrometres) <= RowToleranceUm
+                    && AbsDiff(lamp.XMicrometres, previous.Value.XMicrometres) <= AdjacencyLimitUm;
+
+                if (joins) current!.Add(lamp);
+                else keys.Add(new List<HidLampArray.LampInfo> { lamp });
+            }
+
+            return keys;
+        }
+
+        private static uint AbsDiff(uint a, uint b) => a > b ? a - b : b - a;
+
+        /// <summary>
+        /// Map each lamp's reported Y to a single Y shared by its whole row.
+        ///
+        /// Rows are found by gap rather than by a fixed count: the row COUNT differs by model, and
+        /// hard-coding six would silently mis-group anything else. Clustering on the gap between
+        /// sorted Y values works wherever rows are further apart than the wobble within one.
+        /// </summary>
+        private static Dictionary<uint, uint> SnapRows(IReadOnlyList<HidLampArray.LampInfo> map)
+        {
+            const uint RowGapUm = 7_000;
+
+            var distinct = map.Select(l => l.YMicrometres).Distinct().OrderBy(y => y).ToList();
+            var snapped = new Dictionary<uint, uint>();
+
+            uint rowTop = distinct[0];
+            uint previous = distinct[0];
+
+            foreach (uint y in distinct)
+            {
+                if (y - previous > RowGapUm) rowTop = y;
+                snapped[y] = rowTop;
+                previous = y;
+            }
+
+            return snapped;
+        }
+
+        /// <summary>
+        /// Lay the light bar's four zones across the full canvas width, below the keyboard.
+        ///
+        /// Drawn to scale with the keys rather than as a separate widget, because that is what the
+        /// hardware looks like - a 323 mm strip under a 342 mm keyboard - and because it puts the
+        /// zones inside the same selection model, so one drag and one picker cover both devices.
+        /// </summary>
+        private void AddLightBarZones(double keySize)
+        {
+            if (!HasLightBar) return;
+
+            double gap = keySize * 0.35;
+            double top = CanvasHeight + gap;
+            double zoneWidth = (CanvasWidth - (gap * (LightBarZoneCount - 1))) / LightBarZoneCount;
+            double zoneHeight = keySize * 0.75;
+
+            var current = _keyboard?.GetLightBarColors() ?? Array.Empty<(byte R, byte G, byte B)?>();
+
+            for (int zone = 0; zone < LightBarZoneCount; zone++)
+            {
+                // The bar's colours ARE readable, unlike the keyboard's, so the zones start at what
+                // the hardware is showing rather than at the brush colour. That makes the editor
+                // open as a picture of the current state for the half of it that can be read.
+                string colour = zone < current.Length && current[zone] != null
+                    ? $"#{current[zone]!.Value.R:X2}{current[zone]!.Value.G:X2}{current[zone]!.Value.B:X2}"
+                    : BrushColorHex;
+
+                Keys.Add(new KeyLampViewModel
+                {
+                    IsLightBar = true,
+                    ZoneIndex = zone,
+                    Label = $"Bar {zone + 1}",
+                    X = zone * (zoneWidth + gap),
+                    Y = top,
+                    Width = zoneWidth,
+                    Height = zoneHeight,
+                    ColorHex = colour
+                });
+            }
+
+            CanvasHeight = top + zoneHeight;
+        }
+
+        // ── Helpers ────────────────────────────────────────────────────────────────
+
+        private static System.Drawing.Color ToDrawingColor(System.Windows.Media.Color c) =>
+            System.Drawing.Color.FromArgb(c.R, c.G, c.B);
+
+        private static System.Windows.Media.Color ParseColor(string hex)
+        {
+            try
+            {
+                var c = (System.Windows.Media.Color)System.Windows.Media.ColorConverter.ConvertFromString(
+                    hex.StartsWith('#') ? hex : "#" + hex);
+                return c;
+            }
+            catch
+            {
+                return System.Windows.Media.Colors.Black;
+            }
+        }
+
+        /// <summary>
+        /// A readable name for a HID keyboard usage, abbreviated to fit a key cap. Three characters
+        /// or so on purpose: the cap is drawn at the key's real size, so an overflowing label gets
+        /// trimmed anyway and choosing the abbreviation beats letting the renderer pick it. An
+        /// unnamed usage renders blank rather than as truncated hex; the full value is in the
+        /// tooltip, which is enough to match a key against the probe's --map output.
+        /// </summary>
+        internal static string KeyName(byte usage) => usage switch
+        {
+            0x00 => "",
+            >= 0x04 and <= 0x1D => ((char)('A' + (usage - 0x04))).ToString(),
+            >= 0x1E and <= 0x26 => ((char)('1' + (usage - 0x1E))).ToString(),
+            0x27 => "0",
+            0x28 => "Ent",
+            0x29 => "Esc",
+            0x2A => "Bsp",
+            0x2B => "Tab",
+            0x2C => "Space",
+            0x2D => "-",
+            0x2E => "=",
+            0x2F => "[",
+            0x30 => "]",
+            0x31 => "\\",
+            0x33 => ";",
+            0x34 => "'",
+            0x35 => "`",
+            0x36 => ",",
+            0x37 => ".",
+            0x38 => "/",
+            0x39 => "Cap",
+            >= 0x3A and <= 0x45 => "F" + (usage - 0x39),
+            0x46 => "PrtSc",
+            0x47 => "ScrLk",
+            0x48 => "Pause",
+            0x49 => "Ins",
+            0x4A => "Home",
+            0x4B => "PgUp",
+            0x4C => "Del",
+            0x4D => "End",
+            0x4E => "PgDn",
+            0x4F => "→",
+            0x50 => "←",
+            0x51 => "↓",
+            0x52 => "↑",
+            0x53 => "Num",
+            0x54 => "Num /",
+            0x55 => "Num *",
+            0x56 => "Num -",
+            0x57 => "Num +",
+            0x58 => "Num ⏎",
+            >= 0x59 and <= 0x61 => "Num " + (usage - 0x58),
+            0x62 => "Num 0",
+            0x63 => "Num .",
+            0x65 => "Menu",
+            0xE0 => "Ctrl",
+            0xE1 => "Shift",
+            0xE2 => "Alt",
+            0xE3 => "Win",
+            0xE4 => "RCtrl",
+            0xE5 => "RShift",
+            0xE6 => "RAlt",
+            _ => "·"
+        };
+    }
+
+    /// <summary>One addressable key: where it is, what it lights, and what colour it holds.</summary>
+    public class KeyLampViewModel : ViewModelBase
+    {
+        private bool _isSelected;
+        private string _colorHex = "#000000";
+
+        /// <summary>
+        /// Every lamp under this key. Usually one, but a wide key carries several - Space has five
+        /// on 8D87 - and colouring the key means colouring all of them.
+        /// </summary>
+        public IReadOnlyList<ushort> LampIds { get; init; } = Array.Empty<ushort>();
+
+        public byte KeyUsage { get; init; }
+        public string Label { get; init; } = string.Empty;
+
+        /// <summary>
+        /// True for a light bar zone rather than a key.
+        ///
+        /// The zones live in the same collection as the keys on purpose: selection, painting and the
+        /// colour picker then work across both with no second implementation, and a drag can span
+        /// the keyboard and the bar in one gesture. Only <see cref="ApplyAsync"/> cares about the
+        /// difference, because the two go to different devices over different transports.
+        /// </summary>
+        public bool IsLightBar { get; init; }
+
+        /// <summary>Light bar zone index, 0 leftmost. Meaningless unless <see cref="IsLightBar"/>.</summary>
+        public int ZoneIndex { get; init; }
+
+        public double X { get; init; }
+        public double Y { get; init; }
+        public double Width { get; init; }
+        public double Height { get; init; }
+
+        /// <summary>
+        /// Carries the full identity, since the cap only has room for an abbreviation. This is what
+        /// makes an unnamed key usable: the dot on the cap says nothing, the tooltip says exactly
+        /// which lamp and usage it is.
+        /// </summary>
+        public string Tooltip
+        {
+            get
+            {
+                if (IsLightBar)
+                    return $"Light bar zone {ZoneIndex + 1} of 4, left to right";
+
+                string lamps = LampIds.Count == 1
+                    ? $"lamp {LampIds[0]}"
+                    : $"lamps {string.Join(", ", LampIds)}";
+
+                return KeyUsage == 0
+                    ? $"{lamps} — no key bound"
+                    : $"{lamps} — usage 0x{KeyUsage:X2}{(Label == "·" ? " (unnamed)" : $" ({Label})")}";
+            }
+        }
+
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set { if (_isSelected == value) return; _isSelected = value; OnPropertyChanged(); }
+        }
+
+        public string ColorHex
+        {
+            get => _colorHex;
+            set
+            {
+                if (_colorHex == value) return;
+                _colorHex = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(KeyBrush));
+                OnPropertyChanged(nameof(LabelBrush));
+            }
+        }
+
+        public System.Windows.Media.SolidColorBrush KeyBrush
+        {
+            get
+            {
+                try
+                {
+                    return new System.Windows.Media.SolidColorBrush(
+                        (System.Windows.Media.Color)System.Windows.Media.ColorConverter.ConvertFromString(ColorHex));
+                }
+                catch
+                {
+                    return new System.Windows.Media.SolidColorBrush(System.Windows.Media.Colors.Black);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Black text on a light key, white on a dark one. A single fixed label colour makes the
+        /// caps unreadable at one end of the range or the other, and this editor spends most of its
+        /// time at the dark end.
+        /// </summary>
+        public System.Windows.Media.SolidColorBrush LabelBrush
+        {
+            get
+            {
+                var c = KeyBrush.Color;
+                double luminance = ((0.299 * c.R) + (0.587 * c.G) + (0.114 * c.B)) / 255.0;
+                return new System.Windows.Media.SolidColorBrush(
+                    luminance > 0.55 ? System.Windows.Media.Colors.Black : System.Windows.Media.Colors.White);
+            }
+        }
+    }
+}

--- a/src/OmenCoreApp/ViewModels/KeyboardMapViewModel.cs
+++ b/src/OmenCoreApp/ViewModels/KeyboardMapViewModel.cs
@@ -12,8 +12,16 @@ using OmenCore.Utils;
 namespace OmenCore.ViewModels
 {
     /// <summary>
-    /// Per-key editor backed by the keyboard's MEASURED lamp map - every key at the position the
-    /// device reported, rather than a grid of assumed shape.
+    /// Per-LED editor backed by the keyboard's own layout - every light the colour map can address,
+    /// at the position HP's layout table puts it, rather than a grid of assumed shape.
+    ///
+    /// IT IS BUILT FROM THE LAYOUT, NOT FROM LAMPARRAY, and the difference is the whole point. The
+    /// device's LampArray reports 120 lamps on 8D87; the MCU colour map has 176 LEDs. They are not
+    /// the same enumeration and they do not nest: an F key is one lamp but two LEDs, Num0 is two
+    /// lamps but three LEDs, and the Omen, Calculator, Settings, Power, Fn and Copilot keys are LEDs
+    /// with no lamp at all. Drawing from lamps therefore hid one LED of every dual-legend key, drew
+    /// Num0 as two cells that fought over the same three LEDs, and omitted eight keys entirely.
+    /// Where no layout is known the lamp map is still used, because a coarse editor beats none.
     ///
     /// This exists alongside the 6 x 14 grid editor rather than replacing it: that one is a fixed
     /// abstraction that works on any per-key model, while this needs a backend that has actually
@@ -43,6 +51,13 @@ namespace OmenCore.ViewModels
         private const double PixelsPerMm = 2.6;
         private const double KeySizeMm = 15.0;
         private const double MinKeyWidth = 14.0;
+
+        // Layout mode. The table's units are HP's own UI pixels, which differ per keyboard, so the
+        // board is normalised to its bounds and scaled to a fixed width - matching what the lamp
+        // path produces, so switching between them does not resize the window. KeyInset leaves a
+        // hairline between neighbouring caps; the rectangles butt up against each other exactly.
+        private const double TargetCanvasWidth = 900.0;
+        private const double KeyInset = 1.0;
 
         private string _brushColorHex = "#FF0000";
         private string _status = string.Empty;
@@ -244,6 +259,7 @@ namespace OmenCore.ViewModels
             // because they are different hardware on different transports - HID lamps for the
             // keyboard, HP's WMI command or the bar's own LampArray for the bar.
             var colors = new Dictionary<ushort, System.Drawing.Color>();
+            var leds = new Dictionary<int, System.Drawing.Color>();
             var barZones = new (byte R, byte G, byte B)[LightBarZoneCount];
             bool anyBar = false;
 
@@ -258,9 +274,19 @@ namespace OmenCore.ViewModels
                     continue;
                 }
 
-                // Flattened back to lamps, because that is what the keyboard addresses. A wide key
-                // contributes each of its lamps with the same colour.
                 var color = ToDrawingColor(parsed);
+
+                // Layout mode addresses the colour map directly, one position per cell. That is what
+                // lets the two halves of a dual-legend key differ - flattening to lamps cannot, since
+                // both halves are one lamp.
+                if (key.IsLed)
+                {
+                    foreach (int position in key.LedPositions) leds[position] = color;
+                    continue;
+                }
+
+                // Fallback: flattened back to lamps, because that is what the keyboard addresses.
+                // A wide key contributes each of its lamps with the same colour.
                 foreach (ushort lampId in key.LampIds) colors[lampId] = color;
             }
 
@@ -268,6 +294,11 @@ namespace OmenCore.ViewModels
             // so setting it after would need a second full repaint to take effect.
             await _keyboard.SetPerKeyBrightnessAsync(Brightness);
 
+            // Black, not the brush: every cell in the editor is in the dictionary, so the background
+            // only reaches positions the layout does not claim - padding, and anything the table
+            // omits. Painting those with a colour would light bytes nobody chose.
+            bool ledsOk = leds.Count == 0 ||
+                          await _keyboard.SetLedColorsAsync(leds, System.Drawing.Color.Black);
             bool keysOk = colors.Count == 0 || await _keyboard.SetKeyColorsAsync(colors);
             bool barOk = !anyBar || _keyboard.SetLightBarColors(barZones, (byte)Brightness);
 
@@ -275,18 +306,21 @@ namespace OmenCore.ViewModels
             // in the LampArray spec, so the software cannot confirm a key changed - only that the
             // device took the report. The bar's colours ARE readable, but not through this call.
             var parts = new List<string>();
+            if (leds.Count > 0) parts.Add($"{leds.Count} LEDs {(ledsOk ? "accepted" : "REFUSED")}");
             if (colors.Count > 0) parts.Add($"{colors.Count} keys {(keysOk ? "accepted" : "REFUSED")}");
             if (anyBar) parts.Add($"4 bar zones {(barOk ? "accepted" : "REFUSED")}");
 
             Status = string.Join(", ", parts) + ". Only looking confirms it.";
-            _logging.Info($"[KeyboardMap] Apply: {colors.Count} keys keysOk={keysOk}, " +
-                          $"bar={anyBar} barOk={barOk}");
+            _logging.Info($"[KeyboardMap] Apply: {leds.Count} LEDs ledsOk={ledsOk}, " +
+                          $"{colors.Count} keys keysOk={keysOk}, bar={anyBar} barOk={barOk}");
         }
 
         // ── Loading ────────────────────────────────────────────────────────────────
 
         private void Load()
         {
+            if (LoadFromLayout()) return;
+
             var map = _keyboard?.GetMeasuredKeyMap() ?? Array.Empty<HidLampArray.LampInfo>();
             if (map.Count == 0)
             {
@@ -384,6 +418,158 @@ namespace OmenCore.ViewModels
 
             _logging.Info($"[KeyboardMap] Loaded {keyCount} keys from the measured lamp map" +
                           (HasLightBar ? ", plus 4 light bar zones" : string.Empty));
+        }
+
+        /// <summary>
+        /// Draw the board from the layout table: one cell per LED, grouped inside its key's cap.
+        /// False when this board has no layout, which sends the caller to the lamp map instead.
+        /// </summary>
+        private bool LoadFromLayout()
+        {
+            var layout = _keyboard?.GetKeyboardLayout();
+            if (layout == null || layout.Keys.Count == 0 || layout.Bounds.Length != 4) return false;
+
+            double left = layout.Bounds[0], top = layout.Bounds[1];
+            double spanX = Math.Max(1, layout.Bounds[2] - left);
+            double spanY = Math.Max(1, layout.Bounds[3] - top);
+
+            // One scale for both axes, so the keyboard keeps its proportions instead of being
+            // stretched to whatever aspect the canvas happens to have.
+            double scale = TargetCanvasWidth / spanX;
+            CanvasWidth = spanX * scale;
+            CanvasHeight = spanY * scale;
+
+            int ledCells = 0;
+
+            foreach (var key in layout.Keys)
+            {
+                if (key.Rect.Length != 4 || key.Leds.Length == 0) continue;
+
+                double x = (key.Rect[0] - left) * scale;
+                double y = (key.Rect[1] - top) * scale;
+                double w = Math.Max(1, (key.Rect[2] * scale) - KeyInset);
+                double h = Math.Max(1, (key.Rect[3] * scale) - KeyInset);
+
+                bool horizontal = SplitsHorizontally(key.Leds.Length, key.Rect[2], key.Rect[3]);
+                int n = key.Leds.Length;
+
+                for (int i = 0; i < n; i++)
+                {
+                    // Sub-cells are laid out in COLOUR-MAP ORDER along the cap, and that order is
+                    // not a physical position - the layout table carries no sub-key geometry at all.
+                    // So cell 1 is the key's first LED, not its left or top one. On Esc the first is
+                    // the one under the legend and the second the one below it; nothing guarantees
+                    // another row runs the same way. Light one and look.
+                    double cx = horizontal ? x + (w * i / n) : x;
+                    double cy = horizontal ? y : y + (h * i / n);
+                    double cw = horizontal ? w / n : w;
+                    double ch = horizontal ? h : h / n;
+
+                    Keys.Add(new KeyLampViewModel
+                    {
+                        LedPositions = new[] { key.Leds[i] },
+                        HpKeyName = key.Name,
+                        LedOrdinal = i + 1,
+                        LedCount = n,
+
+                        // Only the first sub-cell is captioned. A cap split five ways is a few
+                        // pixels wide and five copies of "Space" is unreadable; the tooltip names
+                        // the key and the exact map position for every cell.
+                        Label = i == 0 ? (key.Label ?? ShortName(key.Name)) : string.Empty,
+
+                        X = cx,
+                        Y = cy,
+                        Width = cw,
+                        Height = ch,
+                        ColorHex = BrushColorHex
+                    });
+
+                    ledCells++;
+                }
+            }
+
+            if (ledCells == 0) return false;
+
+            AddLightBarZones(KeySizeMm * PixelsPerMm);
+
+            string verified = layout.Verified
+                ? string.Empty
+                : " This layout has not been confirmed on hardware.";
+
+            Status = $"{ledCells} LEDs across {layout.Keys.Count} keys ({layout.Id})" +
+                     (HasLightBar ? " and 4 light bar zones." : ".") +
+                     " Click to select, or drag a box. Hold Ctrl to add." + verified;
+
+            _logging.Info($"[KeyboardMap] Loaded {ledCells} LED cells from layout {layout.Id} " +
+                          $"({layout.Keys.Count} keys, verified={layout.Verified})" +
+                          (HasLightBar ? ", plus 4 light bar zones" : string.Empty));
+
+            return true;
+        }
+
+        /// <summary>
+        /// Which way a key's LEDs are drawn across its cap.
+        ///
+        /// TWO LEDs ALWAYS STACK. A two-LED key is a dual-legend key - a digit over its shifted
+        /// glyph, an F number over its media icon - and the two legends are printed one above the
+        /// other whatever the cap's aspect ratio says. Esc is 26 x 19, wider than tall, and its two
+        /// LEDs are one under the legend and one below it, so splitting on aspect would draw that
+        /// pair side by side and it would be wrong on the entire top and number rows.
+        ///
+        /// Three or more is a long cap, and those run along it: Space five across, the numpad's
+        /// Plus and Enter four down their tall rectangles.
+        /// </summary>
+        internal static bool SplitsHorizontally(int leds, double width, double height) =>
+            leds > 2 && width >= height;
+
+        /// <summary>
+        /// HP's key name trimmed to something that fits a cap: "KeyBracketsL" is the table's name,
+        /// "[" is what is printed on the keyboard. Built-in layouts ship no labels of their own -
+        /// only the external keyboard does - so this fills that gap rather than showing raw names.
+        /// </summary>
+        internal static string ShortName(string name)
+        {
+            string bare = name.StartsWith("Key", StringComparison.Ordinal) ? name[3..] : name;
+
+            return bare switch
+            {
+                "Back" => "Bsp",
+                "BracketsL" => "[",
+                "BracketsR" => "]",
+                "Backslash" => "\\",
+                "Colon" => ";",
+                "Quote" => "'",
+                "Tilde" => "`",
+                "Comma" => ",",
+                "Dot" => ".",
+                "Slash" => "/",
+                "Hyphen" => "-",
+                "Equal" => "=",
+                "Caps" => "Cap",
+                "Enter" => "Ent",
+                "ShiftL" => "Shift",
+                "ShiftR" => "RShift",
+                "CtrlL" => "Ctrl",
+                "CtrlR" => "RCtrl",
+                "AltL" => "Alt",
+                "AltR" => "RAlt",
+                "ArrUP" => "↑",
+                "ArrDown" => "↓",
+                "ArrLeft" => "←",
+                "ArrRight" => "→",
+                "NumPad" => "Num",
+                "NumSlash" => "Num /",
+                "NumStar" => "Num *",
+                "NumDash" => "Num -",
+                "NumPlus" => "Num +",
+                "NumEnter" => "Num ⏎",
+                "NumDel" => "Num .",
+                "FNL" => "Fn",
+                "Copliot" => "Copilot",   // HP's spelling in the table; the key is Copilot
+                "Setting" => "Set",
+                "Calc" => "Calc",
+                _ => bare
+            };
         }
 
         /// <summary>
@@ -595,8 +781,26 @@ namespace OmenCore.ViewModels
         /// <summary>
         /// Every lamp under this key. Usually one, but a wide key carries several - Space has five
         /// on 8D87 - and colouring the key means colouring all of them.
+        ///
+        /// Empty in layout mode, where <see cref="LedPositions"/> is the address instead.
         /// </summary>
         public IReadOnlyList<ushort> LampIds { get; init; } = Array.Empty<ushort>();
+
+        /// <summary>
+        /// Positions in the MCU's colour map that this cell paints. One entry in layout mode - the
+        /// cell IS one LED, which is the point of it - and empty on the lamp-map fallback.
+        /// </summary>
+        public IReadOnlyList<int> LedPositions { get; init; } = Array.Empty<int>();
+
+        /// <summary>True when this cell addresses the colour map directly rather than a lamp.</summary>
+        public bool IsLed => LedPositions.Count > 0;
+
+        /// <summary>HP's name for the key this LED sits under, e.g. "KeySpace". Layout mode only.</summary>
+        public string HpKeyName { get; init; } = string.Empty;
+
+        /// <summary>Which of the key's LEDs this is, 1-based, and how many the key has.</summary>
+        public int LedOrdinal { get; init; }
+        public int LedCount { get; init; }
 
         public byte KeyUsage { get; init; }
         public string Label { get; init; } = string.Empty;
@@ -630,6 +834,15 @@ namespace OmenCore.ViewModels
             {
                 if (IsLightBar)
                     return $"Light bar zone {ZoneIndex + 1} of 4, left to right";
+
+                if (IsLed)
+                {
+                    // The map position is the useful half of this: it is what the probe's
+                    // --positions takes, so a cell in the editor and a cell on the command line
+                    // are the same thing and can be checked against each other.
+                    string which = LedCount > 1 ? $", LED {LedOrdinal} of {LedCount}" : string.Empty;
+                    return $"{HpKeyName}{which} — colour map position {LedPositions[0]}";
+                }
 
                 string lamps = LampIds.Count == 1
                     ? $"lamp {LampIds[0]}"

--- a/src/OmenCoreApp/ViewModels/LightingViewModel.cs
+++ b/src/OmenCoreApp/ViewModels/LightingViewModel.cs
@@ -646,6 +646,53 @@ namespace OmenCore.ViewModels
 
         public bool IsPerKeyHardwareCapable => _keyboardLightingService?.IsPerKeyCapableHardware ?? false;
 
+        private KeyboardMapViewModel? _keyboardMap;
+
+        /// <summary>
+        /// The measured-layout editor, built lazily because constructing it interrogates the
+        /// keyboard for its lamp map and that should not happen while the view is being composed.
+        /// </summary>
+        public KeyboardMapViewModel KeyboardMap =>
+            _keyboardMap ??= new KeyboardMapViewModel(_keyboardLightingService, _logging);
+
+        /// <summary>Whether the backend read a real key layout off this keyboard.</summary>
+        public bool HasMeasuredKeyMap => KeyboardMap.IsAvailable;
+
+        /// <summary>
+        /// The fixed 6 x 14 editor is shown only where there is no measured layout to show instead.
+        /// Both at once would be two editors for one keyboard, disagreeing about what is on it.
+        /// </summary>
+        public bool IsFixedGridEditorVisible => IsPerKeyLightingAvailable && !HasMeasuredKeyMap;
+
+        private DeviceLightingViewModel? _deviceLighting;
+
+        /// <summary>The keyboard's built-in effect engine and the light bar - hardware-rendered
+        /// surfaces, as opposed to the host-painted per-key picture above.</summary>
+        public DeviceLightingViewModel DeviceLighting =>
+            _deviceLighting ??= new DeviceLightingViewModel(_keyboardLightingService, _logging);
+
+        public bool HasDeviceEffects => DeviceLighting.SupportsDeviceEffects;
+        public bool HasLightBar => DeviceLighting.IsLightBarAvailable;
+
+        private Hardware.ModelCapabilities? _capabilities;
+
+        private Hardware.ModelCapabilities Capabilities =>
+            _capabilities ??= Hardware.ModelCapabilityDatabase.GetCapabilities(Hardware.OmenBoard.Product);
+
+        /// <summary>
+        /// Whether this chassis has a four-zone KEYBOARD, which is what the zone editor edits.
+        ///
+        /// Read from the capability database rather than inferred, and the distinction it keeps
+        /// straight is the one that made this board so confusing to diagnose: on a per-key machine
+        /// the four-zone commands still succeed, but they land on the LIGHT BAR. So the zone editor
+        /// appeared to work while the keyboard never changed, and every report of it read as "the
+        /// keyboard is broken" rather than "this is the wrong surface".
+        ///
+        /// Hiding it here is only safe because the light bar now has a card of its own. Before
+        /// that, this editor was the only way to reach the bar at all.
+        /// </summary>
+        public bool HasFourZoneKeyboard => Capabilities.HasFourZoneRgb;
+
         public string PerKeyCapabilitySummary =>
             BuildPerKeyCapabilitySummary(IsPerKeyLightingAvailable, IsPerKeyHardwareCapable);
 

--- a/src/OmenCoreApp/ViewModels/LightingViewModel.cs
+++ b/src/OmenCoreApp/ViewModels/LightingViewModel.cs
@@ -2652,14 +2652,30 @@ namespace OmenCore.ViewModels
         
         #region Temperature-Responsive Lighting Methods
         
+        // Turning a reactive toggle on paints straight away rather than waiting for the next
+        // monitoring sample. Without this the feature looks broken: the poll cadence is 2-10 s
+        // depending on window state, and the temperature band usually does not change when the
+        // toggle is flipped, so the same-colour refresh interval could hold the first paint back
+        // for 30 s. "No effect" and "an effect that starts within half a minute" are the same
+        // thing from the user's chair.
         private void StartTemperatureMonitoring()
         {
-            if (_hardwareMonitoringService != null)
-            {
-                _logging.Info("Started temperature-responsive lighting monitoring");
-            }
+            if (!WarnIfMonitoringUnavailable("temperature-responsive")) return;
+
+            _logging.Info("Started temperature-responsive lighting monitoring");
+            var sample = _hardwareMonitoringService!.Samples.LastOrDefault();
+            if (sample == null) return;
+
+            // Clear the rate limiter's memory so this paint is not suppressed as a repeat of one
+            // made while the toggle was last on.
+            _lastTemperatureLightingApplyUtc = DateTime.MinValue;
+            _lastTemperatureLightingColorHex = null;
+
+            var colorHex = GetTemperatureLightingColor(sample);
+            if (ShouldApplyTemperatureLighting(colorHex))
+                _ = ApplyTemperatureBasedLightingAsync(colorHex);
         }
-        
+
         private void StopTemperatureMonitoring()
         {
             if (_hardwareMonitoringService != null)
@@ -2667,15 +2683,22 @@ namespace OmenCore.ViewModels
                 _logging.Info("Stopped temperature-responsive lighting monitoring");
             }
         }
-        
+
         private void StartPerformanceModeMonitoring()
         {
-            if (_performanceModeService != null)
+            if (_performanceModeService == null)
             {
-                _logging.Info("Started performance mode synced lighting monitoring");
+                _logging.Warn("Performance mode synced lighting enabled with no performance mode " +
+                              "service; it will not respond to mode changes");
+                return;
             }
+
+            _logging.Info("Started performance mode synced lighting monitoring");
+            var mode = _performanceModeService.GetCurrentMode();
+            if (!string.IsNullOrEmpty(mode))
+                _ = ApplyPerformanceModeLightingAsync(mode);
         }
-        
+
         private void StopPerformanceModeMonitoring()
         {
             if (_performanceModeService != null)
@@ -2683,21 +2706,39 @@ namespace OmenCore.ViewModels
                 _logging.Info("Stopped performance mode synced lighting monitoring");
             }
         }
-        
+
         private void StartThrottlingMonitoring()
         {
-            if (_hardwareMonitoringService != null)
-            {
-                _logging.Info("Started throttling indicator lighting monitoring");
-            }
+            if (!WarnIfMonitoringUnavailable("throttling indicator")) return;
+
+            _logging.Info("Started throttling indicator lighting monitoring");
+
+            // Unlike the other two this one is conditional on the machine's state, so there is
+            // nothing to paint unless it is throttling right now. Silence here is correct.
+            var sample = _hardwareMonitoringService!.Samples.LastOrDefault();
+            if (sample?.IsThrottling == true && ShouldApplyThrottlingLighting())
+                _ = ApplyThrottlingLightingAsync(sample);
         }
-        
+
         private void StopThrottlingMonitoring()
         {
             if (_hardwareMonitoringService != null)
             {
                 _logging.Info("Stopped throttling indicator lighting monitoring");
             }
+        }
+
+        /// <summary>
+        /// True when hardware monitoring is wired up. A null service used to be silent, which is
+        /// how three reactive features shipped inert — the toggle moved, nothing subscribed.
+        /// </summary>
+        private bool WarnIfMonitoringUnavailable(string feature)
+        {
+            if (_hardwareMonitoringService != null) return true;
+
+            _logging.Warn($"{feature} lighting enabled with no hardware monitoring service; " +
+                          "it will not respond to temperature changes");
+            return false;
         }
         
         private void OnMonitoringSampleUpdated(object? sender, MonitoringSample sample)

--- a/src/OmenCoreApp/ViewModels/LightingViewModel.cs
+++ b/src/OmenCoreApp/ViewModels/LightingViewModel.cs
@@ -2785,44 +2785,70 @@ namespace OmenCore.ViewModels
             return true;
         }
 
+        /// <summary>
+        /// Paint one colour across every lighting surface these reactive features drive.
+        ///
+        /// Temperature, throttling and performance mode differ only in which colour they pick and
+        /// which effect string the RGB manager gets; the fan-out itself is the same, and used to be
+        /// three copies of it. <paramref name="rgbEffect"/> is the one genuine difference — the
+        /// throttling indicator pulses where the others hold steady.
+        /// </summary>
+        private async Task FanOutLightingColorAsync(string colorHex, string rgbEffect, string reason)
+        {
+            var color = ParseDrawingColor(colorHex);
+
+            if (_keyboardLightingService?.IsAvailable == true)
+            {
+                await _keyboardLightingService.SetAllZoneColors(new[] { color, color, color, color });
+            }
+
+            // The light bar is a separate device on a separate transport, so it takes its own call.
+            // It was missing from all three features, which left temperature-responsive lighting
+            // driving every RGB peripheral in the house while the strip on the front of the chassis
+            // — the one light the user is actually looking at — never moved.
+            //
+            // Brightness comes from the light bar card when the user has opened it, so the reactive
+            // colour does not quietly undo a brightness they chose. This deliberately reads the
+            // backing field: touching the property would construct that view-model, and hence probe
+            // hardware, from a monitoring callback.
+            if (_keyboardLightingService?.IsLightBarAvailable == true)
+            {
+                _keyboardLightingService.SetLightBarColors(
+                    new[] { (color.R, color.G, color.B) },
+                    (byte)(_deviceLighting?.BarBrightness ?? 100));
+            }
+
+            if (_rgbManager != null)
+            {
+                await _rgbManager.ApplyEffectToAllAsync(rgbEffect);
+            }
+
+            if (_corsairService != null && CorsairDevices.Count > 0)
+            {
+                await _corsairService.ApplyLightingToAllAsync(colorHex);
+            }
+
+            if (_logitechService != null && LogitechDevices.Count > 0)
+            {
+                foreach (var device in LogitechDevices)
+                {
+                    await _logitechService.ApplyStaticColorAsync(device, colorHex, LogitechBrightness);
+                }
+            }
+
+            if (_razerService?.IsAvailable == true && _razerDevices.Count > 0)
+            {
+                await Task.Run(() => _razerService.SetStaticColor(color.R, color.G, color.B));
+            }
+
+            _logging.Info($"Applied {reason} lighting: {colorHex}");
+        }
+
         private async Task ApplyTemperatureBasedLightingAsync(string colorHex)
         {
             try
             {
-                // Apply to keyboard lighting
-                if (_keyboardLightingService?.IsAvailable == true)
-                {
-                    var color = ParseDrawingColor(colorHex);
-                    await _keyboardLightingService.SetAllZoneColors(new[] { color, color, color, color });
-                }
-                
-                // Apply to system RGB
-                if (_rgbManager != null)
-                {
-                    await _rgbManager.ApplyEffectToAllAsync($"color:{colorHex}");
-                }
-                
-                // Apply to Corsair devices
-                if (_corsairService != null && CorsairDevices.Count > 0)
-                {
-                    await _corsairService.ApplyLightingToAllAsync(colorHex);
-                }
-                
-                // Apply to Logitech devices
-                if (_logitechService != null && LogitechDevices.Count > 0)
-                {
-                    foreach (var device in LogitechDevices)
-                    {
-                        await _logitechService.ApplyStaticColorAsync(device, colorHex, LogitechBrightness);
-                    }
-                }
-                
-                // Apply to Razer devices
-                if (_razerService?.IsAvailable == true && _razerDevices.Count > 0)
-                {
-                    var color = System.Drawing.ColorTranslator.FromHtml(colorHex);
-                    await Task.Run(() => _razerService.SetStaticColor(color.R, color.G, color.B));
-                }
+                await FanOutLightingColorAsync(colorHex, $"color:{colorHex}", "temperature-based");
             }
             catch (Exception ex)
             {
@@ -2833,47 +2859,13 @@ namespace OmenCore.ViewModels
                 _temperatureLightingApplyInFlight = false;
             }
         }
-        
+
         private async Task ApplyThrottlingLightingAsync(MonitoringSample sample)
         {
             try
             {
-                // Apply throttling color to indicate thermal/power throttling
-                var color = ParseDrawingColor(ThrottlingColorHex);
-                
-                // Apply to keyboard lighting with pulsing effect
-                if (_keyboardLightingService?.IsAvailable == true)
-                {
-                    await _keyboardLightingService.SetAllZoneColors(new[] { color, color, color, color });
-                }
-                
-                // Apply to system RGB with pulsing
-                if (_rgbManager != null)
-                {
-                    await _rgbManager.ApplyEffectToAllAsync($"pulse:{ThrottlingColorHex}:1000");
-                }
-                
-                // Apply to Corsair devices
-                if (_corsairService != null && CorsairDevices.Count > 0)
-                {
-                    await _corsairService.ApplyLightingToAllAsync(ThrottlingColorHex);
-                }
-                
-                // Apply to Logitech devices
-                if (_logitechService != null && LogitechDevices.Count > 0)
-                {
-                    foreach (var device in LogitechDevices)
-                    {
-                        await _logitechService.ApplyStaticColorAsync(device, ThrottlingColorHex, LogitechBrightness);
-                    }
-                }
-                
-                // Apply to Razer devices
-                if (_razerService?.IsAvailable == true && _razerDevices.Count > 0)
-                {
-                    var razerColor = System.Drawing.ColorTranslator.FromHtml(ThrottlingColorHex);
-                    await Task.Run(() => _razerService.SetStaticColor(razerColor.R, razerColor.G, razerColor.B));
-                }
+                await FanOutLightingColorAsync(
+                    ThrottlingColorHex, $"pulse:{ThrottlingColorHex}:1000", "throttling indicator");
             }
             catch (Exception ex)
             {
@@ -2884,69 +2876,20 @@ namespace OmenCore.ViewModels
                 _throttlingLightingApplyInFlight = false;
             }
         }
-        
+
         private async Task ApplyPerformanceModeLightingAsync(string modeName)
         {
             try
             {
-                string colorHex;
-                
-                // Map performance mode to color
-                switch (modeName.ToLower())
+                var colorHex = modeName.ToLower() switch
                 {
-                    case "balanced":
-                        colorHex = BalancedModeColorHex;
-                        break;
-                    case "performance":
-                    case "high performance":
-                        colorHex = PerformanceModeColorHex;
-                        break;
-                    case "quiet":
-                    case "power saver":
-                        colorHex = QuietModeColorHex;
-                        break;
-                    default:
-                        colorHex = CustomModeColorHex;
-                        break;
-                }
-                
-                var color = ParseDrawingColor(colorHex);
-                
-                // Apply to keyboard lighting
-                if (_keyboardLightingService?.IsAvailable == true)
-                {
-                    await _keyboardLightingService.SetAllZoneColors(new[] { color, color, color, color });
-                }
-                
-                // Apply to system RGB
-                if (_rgbManager != null)
-                {
-                    await _rgbManager.ApplyEffectToAllAsync($"color:{colorHex}");
-                }
-                
-                // Apply to Corsair devices
-                if (_corsairService != null && CorsairDevices.Count > 0)
-                {
-                    await _corsairService.ApplyLightingToAllAsync(colorHex);
-                }
-                
-                // Apply to Logitech devices
-                if (_logitechService != null && LogitechDevices.Count > 0)
-                {
-                    foreach (var device in LogitechDevices)
-                    {
-                        await _logitechService.ApplyStaticColorAsync(device, colorHex, LogitechBrightness);
-                    }
-                }
-                
-                // Apply to Razer devices
-                if (_razerService?.IsAvailable == true && _razerDevices.Count > 0)
-                {
-                    var razerColor = System.Drawing.ColorTranslator.FromHtml(colorHex);
-                    await Task.Run(() => _razerService.SetStaticColor(razerColor.R, razerColor.G, razerColor.B));
-                }
-                
-                _logging.Info($"Applied performance mode lighting for '{modeName}' with color {colorHex}");
+                    "balanced" => BalancedModeColorHex,
+                    "performance" or "high performance" => PerformanceModeColorHex,
+                    "quiet" or "power saver" => QuietModeColorHex,
+                    _ => CustomModeColorHex
+                };
+
+                await FanOutLightingColorAsync(colorHex, $"color:{colorHex}", $"performance mode '{modeName}'");
             }
             catch (Exception ex)
             {

--- a/src/OmenCoreApp/ViewModels/MainViewModel.cs
+++ b/src/OmenCoreApp/ViewModels/MainViewModel.cs
@@ -3421,6 +3421,12 @@ namespace OmenCore.ViewModels
                         _configService,
                         _razerService,
                         rgbManager,
+                        // Without these two the reactive lighting features are inert: the
+                        // view-model subscribes to SampleUpdated and ModeApplied in its
+                        // constructor, so a null service means the toggles turn on a feature
+                        // that is never told a temperature or a mode change.
+                        hardwareMonitoringService: _hardwareMonitoringService,
+                        performanceModeService: _performanceModeService,
                         sceneService: _rgbSceneService,
                         screenSamplingService: _screenSamplingService,
                         audioReactiveRgbService: _audioReactiveRgbService);

--- a/src/OmenCoreApp/ViewModels/MainViewModel.cs
+++ b/src/OmenCoreApp/ViewModels/MainViewModel.cs
@@ -547,6 +547,126 @@ namespace OmenCore.ViewModels
         /// </summary>
         public string? CapabilityWarning { get; private set; }
 
+        // ═══════════════════════════════════════════════════════════════════════════════════
+        // Power adapter (Legacy 0x0F) - read-only, refreshed when the Diagnostics tab opens
+        // ═══════════════════════════════════════════════════════════════════════════════════
+
+        private HpWmiBios.AdapterInfo? _adapterInfo;
+
+        /// <summary>
+        /// True when the board answered the adapter query at least once. Boards that don't implement
+        /// it keep the whole panel hidden rather than showing an empty or misleading one.
+        /// </summary>
+        public bool HasPowerAdapterInfo => _adapterInfo is HpWmiBios.AdapterInfo info && info.HasVerdict;
+
+        /// <summary>
+        /// One-line adapter summary, e.g. "330 W - meets this machine's requirement".
+        /// </summary>
+        public string PowerAdapterSummary
+        {
+            get
+            {
+                if (_adapterInfo is not HpWmiBios.AdapterInfo info)
+                    return "Not reported by this board";
+
+                // On battery there is no adapter to describe, and the wattage byte reads 0 - pairing
+                // that with "running on battery" would render as the nonsensical "0 W - running on
+                // battery".
+                if (info.Status == HpWmiBios.SmartAdapterStatus.BatteryPower)
+                    return "None — running on battery";
+
+                var watts = info.PowerRatingKnown
+                    ? $"{info.PowerRatingWatts} W"
+                    : "Wattage not reported";
+
+                var verdict = info.Status switch
+                {
+                    HpWmiBios.SmartAdapterStatus.MeetsRequirement => "meets this machine's requirement",
+                    HpWmiBios.SmartAdapterStatus.BelowRequirement => "below this machine's requirement",
+                    HpWmiBios.SmartAdapterStatus.BatteryPower => "running on battery",
+                    HpWmiBios.SmartAdapterStatus.NotFunctioning => "not functioning correctly",
+                    HpWmiBios.SmartAdapterStatus.ConnectedTypeC => "USB-C Power Delivery",
+                    HpWmiBios.SmartAdapterStatus.NotSupported => "adapter detection not supported",
+                    _ => info.Status.ToString()
+                };
+
+                return $"{watts} — {verdict}";
+            }
+        }
+
+        /// <summary>
+        /// The wattage this SKU shipped with, when the firmware reports it. Shown next to the
+        /// connected wattage so the user can see both halves of the comparison the firmware makes.
+        /// </summary>
+        public string PowerAdapterRequirement
+        {
+            get
+            {
+                var shipping = _wmiBios?.SystemDesign?.ShippingAdapterPowerRatingWatts ?? 0;
+                return shipping > 0 ? $"{shipping} W" : "Not reported";
+            }
+        }
+
+        /// <summary>
+        /// A plain explanation when the supply is under-rated, or null when there is nothing to say.
+        ///
+        /// This exists because the symptom is otherwise unattributable: on boards that clamp GPU power
+        /// on an under-rated supply, the user sees a GPU pinned far below its rating and nothing
+        /// anywhere in the app connects that to the adapter they plugged in.
+        /// </summary>
+        public string? PowerAdapterExplanation
+        {
+            get
+            {
+                if (_adapterInfo is not HpWmiBios.AdapterInfo info || !info.HasVerdict)
+                    return null;
+
+                if (info.Status == HpWmiBios.SmartAdapterStatus.BatteryPower)
+                {
+                    return "Running on battery. Expect reduced CPU and GPU power limits until an adapter is connected.";
+                }
+
+                if (!info.IsLowWattage)
+                    return null;
+
+                var shipping = _wmiBios?.SystemDesign?.ShippingAdapterPowerRatingWatts ?? 0;
+                var connected = info.PowerRatingKnown ? $"{info.PowerRatingWatts} W" : "an unrecognised";
+                var required = shipping > 0 ? $" This machine shipped with a {shipping} W adapter." : string.Empty;
+
+                return $"The firmware reports {connected} adapter as below this machine's requirement.{required} " +
+                       "Some HP firmware reduces CPU and GPU power limits in this state, which can look like a fault " +
+                       "in OmenCore or in the GPU driver but is the platform protecting an under-rated supply. " +
+                       "If performance is lower than expected, check the adapter before anything else.";
+            }
+        }
+
+        /// <summary>True when <see cref="PowerAdapterExplanation"/> has something to show.</summary>
+        public bool HasPowerAdapterExplanation => PowerAdapterExplanation != null;
+
+        /// <summary>
+        /// Re-read the adapter state. Read-only WMI query; called when the Diagnostics tab is opened
+        /// rather than polled, because the value only changes when someone physically plugs or
+        /// unplugs something and this costs a WMI round trip.
+        /// </summary>
+        public void RefreshPowerAdapterStatus()
+        {
+            try
+            {
+                _adapterInfo = _wmiBios?.GetAdapter();
+            }
+            catch (Exception ex)
+            {
+                _logging.Debug($"Adapter status refresh failed: {ex.Message}");
+                _adapterInfo = null;
+            }
+
+            OnPropertyChanged(nameof(HasPowerAdapterInfo));
+            OnPropertyChanged(nameof(PowerAdapterSummary));
+            OnPropertyChanged(nameof(PowerAdapterRequirement));
+            OnPropertyChanged(nameof(PowerAdapterExplanation));
+            OnPropertyChanged(nameof(HasPowerAdapterExplanation));
+        }
+
         /// <summary>
         /// Monitoring diagnostics line indicating whether a model-specific CPU temperature override is active.
         /// </summary>

--- a/src/OmenCoreApp/ViewModels/MainViewModel.cs
+++ b/src/OmenCoreApp/ViewModels/MainViewModel.cs
@@ -1730,7 +1730,7 @@ namespace OmenCore.ViewModels
 
             _keyboardLightingService = new KeyboardLightingService(_logging, ec, _wmiBios, _configService, _systemInfoService, _ecOperationCoordinator);
             _systemOptimizationService = systemOptimizationService ?? new SystemOptimizationService(_logging);
-            _gpuSwitchService = gpuSwitchService ?? new GpuSwitchService(_logging);
+            _gpuSwitchService = gpuSwitchService ?? new GpuSwitchService(_logging, _wmiBios);
             
             // Keyboard diagnostics (must be after _keyboardLightingService is created)
             KeyboardDiagnostics = new KeyboardDiagnosticsViewModel(_corsairDeviceService, _logitechDeviceService, _keyboardLightingService, _razerService, _logging);

--- a/src/OmenCoreApp/Views/DiagnosticsView.xaml
+++ b/src/OmenCoreApp/Views/DiagnosticsView.xaml
@@ -83,6 +83,41 @@
                 </Grid>
             </GroupBox>
 
+            <!-- Power adapter (Legacy 0x0F). Hidden entirely on boards that don't report it, rather
+                 than shown empty. Read-only: nothing here writes to the firmware. -->
+            <GroupBox Header="Power Adapter" Style="{StaticResource ModernGroupBox}" Margin="0,12,0,0"
+                      Visibility="{Binding HasPowerAdapterInfo, Converter={StaticResource BoolToVisibility}}">
+                <StackPanel Margin="8">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0">
+                            <TextBlock Text="Connected adapter" FontSize="11" Foreground="{StaticResource TextTertiaryBrush}"/>
+                            <TextBlock Text="{Binding PowerAdapterSummary}" FontSize="14" FontWeight="SemiBold"
+                                       Foreground="{StaticResource TextPrimaryBrush}" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                        </StackPanel>
+                        <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="16,0,0,0">
+                            <TextBlock Text="Shipped with" FontSize="11" Foreground="{StaticResource TextTertiaryBrush}"
+                                       HorizontalAlignment="Right"/>
+                            <TextBlock Text="{Binding PowerAdapterRequirement}" FontSize="14" FontWeight="SemiBold"
+                                       Foreground="{StaticResource TextSecondaryBrush}" HorizontalAlignment="Right" Margin="0,2,0,0"/>
+                        </StackPanel>
+                    </Grid>
+
+                    <Border Background="#2D2D1F" BorderBrush="{StaticResource WarningBrush}" BorderThickness="1"
+                            CornerRadius="6" Padding="10,8" Margin="0,12,0,0"
+                            Visibility="{Binding HasPowerAdapterExplanation, Converter={StaticResource BoolToVisibility}}">
+                        <TextBlock Text="{Binding PowerAdapterExplanation}" FontSize="11"
+                                   Foreground="{StaticResource TextSecondaryBrush}" TextWrapping="Wrap"/>
+                    </Border>
+
+                    <TextBlock Text="Read from the BIOS each time this tab is opened. This is the machine's own view of the supply attached to it, not a measurement."
+                               FontSize="11" Foreground="{StaticResource TextTertiaryBrush}" TextWrapping="Wrap" Margin="0,10,0,0"/>
+                </StackPanel>
+            </GroupBox>
+
             <!-- Model Capabilities (what this specific detected model does/doesn't support) -->
             <GroupBox Header="Model Capabilities" Style="{StaticResource ModernGroupBox}" Margin="0,12,0,0">
                 <StackPanel Margin="8">

--- a/src/OmenCoreApp/Views/DiagnosticsView.xaml.cs
+++ b/src/OmenCoreApp/Views/DiagnosticsView.xaml.cs
@@ -11,6 +11,24 @@ namespace OmenCore.Views
         public DiagnosticsView()
         {
             InitializeComponent();
+            Loaded += OnLoaded;
+        }
+
+        /// <summary>
+        /// Refresh the adapter panel when the tab is shown. Read-only WMI query, and doing it here
+        /// rather than on a timer means the cost is paid only when someone is looking at it - while
+        /// still being current, since the value changes only on a physical plug/unplug.
+        /// </summary>
+        private void OnLoaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            // Dispatched at Background priority rather than run inline: GetAdapter() is a WMI round
+            // trip, and on a board that does not implement the command it falls through to the legacy
+            // System.Management path, which has no timeout at all. Inline, that turns clicking this
+            // tab into a multi-second freeze on a machine with a degraded WMI repository. Let the tab
+            // paint first.
+            Dispatcher.InvokeAsync(
+                () => (DataContext as ViewModels.MainViewModel)?.RefreshPowerAdapterStatus(),
+                System.Windows.Threading.DispatcherPriority.Background);
         }
 
         private void OpenDiagnosticsFolder_Click(object sender, System.Windows.RoutedEventArgs e)

--- a/src/OmenCoreApp/Views/FanDiagnosticsView.xaml
+++ b/src/OmenCoreApp/Views/FanDiagnosticsView.xaml
@@ -68,9 +68,15 @@
                     Visibility="{Binding GuidedTestResult, Converter={StaticResource StringNotEmptyToVisibilityConverter}}">
                 <StackPanel>
                     <TextBlock Text="Verification Results" FontWeight="SemiBold" />
-                    <TextBlock Text="{Binding GuidedTestResult}" FontFamily="Consolas" FontSize="11" 
-                               Foreground="{StaticResource TextSecondaryBrush}" Margin="0,8,0,0"
-                               TextWrapping="Wrap"/>
+                    <!-- A read-only TextBox, not a TextBlock: WPF TextBlock text cannot be
+                         selected, so dragging across these results did nothing and the click
+                         fell through to the surrounding panel. This keeps the same flat look
+                         while letting the text be selected and copied by hand. -->
+                    <TextBox Text="{Binding GuidedTestResult, Mode=OneWay}" FontFamily="Consolas" FontSize="11"
+                             Foreground="{StaticResource TextSecondaryBrush}" Margin="0,8,0,0"
+                             TextWrapping="Wrap" IsReadOnly="True" IsReadOnlyCaretVisible="False"
+                             Background="Transparent" BorderThickness="0" Padding="0"
+                             HorizontalScrollBarVisibility="Disabled"/>
                     <Button Content="Copy Results" Command="{Binding CopyGuidedResultCommand}" 
                             Style="{StaticResource ModernButton}" Margin="0,8,0,0" 
                             Visibility="{Binding GuidedTestResult, Converter={StaticResource StringNotEmptyToVisibilityConverter}}"/>

--- a/src/OmenCoreApp/Views/KeyboardMapEditor.xaml
+++ b/src/OmenCoreApp/Views/KeyboardMapEditor.xaml
@@ -1,0 +1,170 @@
+<UserControl x:Class="OmenCore.Views.KeyboardMapEditor"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             mc:Ignorable="d"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+    <StackPanel>
+
+        <!-- Shown only for a keyboard matched from HP's device table rather than measured here. The
+             editor still works - the layout comes off the device - but the user is told which
+             footing they are on rather than being given inference dressed as measurement. -->
+        <Border Background="#22E0A030" BorderBrush="#E0A030" BorderThickness="1" CornerRadius="6"
+                Padding="10" Margin="0,0,0,10"
+                Visibility="{Binding HasVerificationWarning, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <TextBlock Text="{Binding VerificationWarning}" FontSize="11" Foreground="#F0C070"
+                       TextWrapping="Wrap"/>
+        </Border>
+
+        <!-- Brush + actions -->
+        <Grid Margin="0,0,0,10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Grid.Column="0" Text="Brush:" FontSize="12" Foreground="#B0B0B0"
+                       VerticalAlignment="Center" Margin="0,0,8,0"/>
+
+            <!-- The swatch is the picker button. Clicking a colour to change it is the gesture
+                 people try first, so the hex box stays for typing an exact value. -->
+            <Button Grid.Column="1" Command="{Binding PickColorCommand}" Cursor="Hand"
+                    Padding="0" BorderThickness="0" Background="Transparent" Margin="0,0,8,0"
+                    ToolTip="Choose a colour" AutomationProperties.Name="Choose brush colour">
+                <Border Width="26" Height="26" CornerRadius="4"
+                        Background="{Binding BrushColorBrush}" BorderBrush="#666" BorderThickness="1"/>
+            </Button>
+
+            <TextBox Grid.Column="2" Style="{StaticResource ModernTextBox}"
+                     Width="86" Margin="0,0,8,0" MaxLength="7"
+                     Text="{Binding BrushColorHex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+
+            <!-- Every button carries an explicit style. Without one they fall back to the WPF
+                 default - white text on light grey, unreadable against this theme, which is what
+                 shipped in the first cut of this control. -->
+            <StackPanel Grid.Column="3" Orientation="Horizontal">
+                <Button Content="Pick colour…" Command="{Binding PickColorCommand}"
+                        Style="{StaticResource ModernButton}" Padding="12,6" Margin="0,0,6,0"/>
+                <Button Content="Paint selected" Command="{Binding PaintSelectionCommand}"
+                        Style="{StaticResource AccentButton}" Padding="12,6" Margin="0,0,6,0"/>
+                <Button Content="Select all" Command="{Binding SelectAllCommand}"
+                        Style="{StaticResource ModernButton}" Padding="12,6" Margin="0,0,6,0"/>
+                <Button Content="Clear selection" Command="{Binding ClearSelectionCommand}"
+                        Style="{StaticResource ModernButton}" Padding="12,6" Margin="0,0,6,0"/>
+                <Button Content="All black" Command="{Binding ClearAllColorsCommand}"
+                        Style="{StaticResource ModernButton}" Padding="12,6" Margin="0,0,6,0"/>
+            </StackPanel>
+
+            <Button Grid.Column="5" Content="Apply to keyboard" Command="{Binding ApplyCommand}"
+                    Style="{StaticResource AccentButton}" Padding="16,6" FontWeight="SemiBold"
+                    AutomationProperties.Name="Apply per-key colours to the keyboard"/>
+        </Grid>
+
+        <!-- Brightness. Not the MCU's - that command is refused by this firmware - but the
+             LampArray's per-lamp intensity channel, which scales a host-painted picture and is the
+             only brightness lever this keyboard has. -->
+        <Grid Margin="0,0,0,10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="200"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Grid.Column="0" Text="Brightness:" FontSize="12" Foreground="#B0B0B0"
+                       VerticalAlignment="Center" Margin="0,0,8,0"/>
+            <Slider Grid.Column="1" Minimum="0" Maximum="100" VerticalAlignment="Center"
+                    Value="{Binding Brightness, Mode=TwoWay}"
+                    AutomationProperties.Name="Per-key lighting brightness"/>
+            <TextBlock Grid.Column="2" Text="{Binding Brightness}" FontSize="12" Width="34"
+                       Foreground="#E0E0E0" VerticalAlignment="Center" Margin="8,0,0,0"/>
+            <TextBlock Grid.Column="3" FontSize="11" Foreground="#707070" VerticalAlignment="Center"
+                       TextWrapping="Wrap"
+                       Text="Applies on the next Apply. It scales the colours you paint — a running keyboard effect cannot be dimmed."/>
+        </Grid>
+
+        <!-- The keyboard itself. Viewbox so the logical layout, computed in millimetres, scales to
+             whatever width the panel gets without any resize maths in the view-model. -->
+        <Border Background="#0D0D0D" CornerRadius="8" Padding="10" BorderBrush="#333" BorderThickness="1.5">
+            <Viewbox Stretch="Uniform" StretchDirection="DownOnly" HorizontalAlignment="Left">
+                <Grid x:Name="MapRoot"
+                      Width="{Binding CanvasWidth}" Height="{Binding CanvasHeight}"
+                      Background="Transparent"
+                      MouseLeftButtonDown="OnMouseDown"
+                      MouseMove="OnMouseMove"
+                      MouseLeftButtonUp="OnMouseUp">
+
+                    <ItemsControl ItemsSource="{Binding Keys}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <Canvas IsItemsHost="True"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding X}"/>
+                                <Setter Property="Canvas.Top" Value="{Binding Y}"/>
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Width="{Binding Width}" Height="{Binding Height}"
+                                        CornerRadius="4" Margin="1"
+                                        Background="{Binding KeyBrush}"
+                                        ToolTip="{Binding Tooltip}">
+                                    <Border.Style>
+                                        <Style TargetType="Border">
+                                            <Setter Property="BorderBrush" Value="#3A3A3A"/>
+                                            <Setter Property="BorderThickness" Value="1"/>
+                                            <Style.Triggers>
+                                                <!-- Bar zones are rounder and lighter-edged, so the
+                                                     strip reads as a different device from the keys
+                                                     above it even at a glance. -->
+                                                <DataTrigger Binding="{Binding IsLightBar}" Value="True">
+                                                    <Setter Property="CornerRadius" Value="7"/>
+                                                    <Setter Property="BorderBrush" Value="#555555"/>
+                                                </DataTrigger>
+                                                <!-- Selection is a ring, not a fill: the fill IS the
+                                                     colour being edited, so tinting it to show
+                                                     selection would misreport what is about to be
+                                                     sent to the keyboard. -->
+                                                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                    <Setter Property="BorderBrush" Value="#FFFFFF"/>
+                                                    <Setter Property="BorderThickness" Value="2"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
+
+                                    <TextBlock Text="{Binding Label}" FontSize="8"
+                                               Foreground="{Binding LabelBrush}"
+                                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                                               TextTrimming="CharacterEllipsis"/>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- Rubber band. Sits above the keys and never takes hit tests, so a drag that
+                         starts over a key still reaches the canvas handlers. -->
+                    <Canvas IsHitTestVisible="False">
+                        <Rectangle x:Name="Band" Visibility="Collapsed"
+                                   Stroke="#FFFFFF" StrokeThickness="1" StrokeDashArray="3 2"
+                                   Fill="#22FFFFFF"/>
+                    </Canvas>
+                </Grid>
+            </Viewbox>
+        </Border>
+
+        <TextBlock Text="{Binding Status}" FontSize="11" Foreground="#909090"
+                   Margin="2,8,0,0" TextWrapping="Wrap"/>
+        <TextBlock FontSize="11" Foreground="#707070" Margin="2,2,0,0" TextWrapping="Wrap"
+                   Text="Click a key to select or deselect it. Drag a box to select a region — it can span the keyboard and the light bar. Hold Ctrl or Shift while dragging to add to the selection."/>
+    </StackPanel>
+</UserControl>

--- a/src/OmenCoreApp/Views/KeyboardMapEditor.xaml.cs
+++ b/src/OmenCoreApp/Views/KeyboardMapEditor.xaml.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using OmenCore.ViewModels;
+
+namespace OmenCore.Views
+{
+    /// <summary>
+    /// Mouse handling for the per-key editor: click to toggle a key, drag to rubber-band a region.
+    ///
+    /// Only the INPUT lives here. Which keys a band catches is
+    /// <see cref="KeyboardMapViewModel.SelectWithin"/>'s decision, because that is the part worth
+    /// being able to reason about without a window on screen - a wrong bounds check there does not
+    /// throw, it silently selects the neighbouring key.
+    ///
+    /// A click and a drag are the same gesture until the mouse moves, so both are started here and
+    /// only told apart on mouse-up, by distance. Committing at press time would make every drag
+    /// begin by toggling whatever key it started on.
+    /// </summary>
+    public partial class KeyboardMapEditor : UserControl
+    {
+        /// <summary>
+        /// Movement below this, in logical pixels, is a click rather than a drag. Set above a
+        /// trackpad's incidental travel: on a touchpad a "click" routinely moves a pixel or two,
+        /// and treating that as a zero-area drag would clear the selection instead of toggling.
+        /// </summary>
+        private const double DragThreshold = 4.0;
+
+        private Point _origin;
+        private bool _tracking;
+
+        public KeyboardMapEditor()
+        {
+            InitializeComponent();
+        }
+
+        private KeyboardMapViewModel? Model => DataContext as KeyboardMapViewModel;
+
+        private void OnMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (Model == null) return;
+
+            _origin = e.GetPosition(MapRoot);
+            _tracking = true;
+
+            Band.Visibility = Visibility.Collapsed;
+            MapRoot.CaptureMouse();
+        }
+
+        private void OnMouseMove(object sender, MouseEventArgs e)
+        {
+            if (!_tracking || e.LeftButton != MouseButtonState.Pressed) return;
+
+            var current = e.GetPosition(MapRoot);
+            if (!HasMoved(current)) return;
+
+            double left = Math.Min(_origin.X, current.X);
+            double top = Math.Min(_origin.Y, current.Y);
+
+            Canvas.SetLeft(Band, left);
+            Canvas.SetTop(Band, top);
+            Band.Width = Math.Abs(current.X - _origin.X);
+            Band.Height = Math.Abs(current.Y - _origin.Y);
+            Band.Visibility = Visibility.Visible;
+        }
+
+        private void OnMouseUp(object sender, MouseButtonEventArgs e)
+        {
+            if (!_tracking || Model == null) return;
+
+            _tracking = false;
+            MapRoot.ReleaseMouseCapture();
+            Band.Visibility = Visibility.Collapsed;
+
+            var end = e.GetPosition(MapRoot);
+            bool additive = (Keyboard.Modifiers & (ModifierKeys.Control | ModifierKeys.Shift)) != 0;
+
+            if (HasMoved(end))
+            {
+                Model.SelectWithin(_origin.X, _origin.Y, end.X, end.Y, additive);
+                return;
+            }
+
+            // A click. Resolve it through the visual tree rather than by hit-testing coordinates
+            // against the layout: the element under the cursor is what the user believes they
+            // clicked, and it stays correct however the Viewbox has scaled things.
+            if (e.OriginalSource is FrameworkElement { DataContext: KeyLampViewModel key })
+                Model.ToggleKey(key);
+            else if (!additive)
+                Model.SelectWithin(0, 0, 0, 0, additive: false); // empty band clears
+        }
+
+        private bool HasMoved(Point p) =>
+            Math.Abs(p.X - _origin.X) > DragThreshold || Math.Abs(p.Y - _origin.Y) > DragThreshold;
+    }
+}

--- a/src/OmenCoreApp/Views/LightingView.xaml
+++ b/src/OmenCoreApp/Views/LightingView.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:controls="clr-namespace:OmenCore.Controls"
+             xmlns:views="clr-namespace:OmenCore.Views"
              xmlns:utils="clr-namespace:OmenCore.Utils"
              mc:Ignorable="d" 
              d:DesignHeight="700" d:DesignWidth="1000">
@@ -1262,6 +1263,13 @@
 
                         <StackPanel Visibility="{Binding IsHpOmenKeyboardCardContentVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
                         
+                        <!-- Four-zone keyboard controls. Hidden on chassis whose capability entry says
+                             there is no four-zone KEYBOARD: on a per-key machine these commands still
+                             succeed, but they land on the light bar, so the editor appeared to work
+                             while the keyboard never changed. The light bar has its own card now, so
+                             hiding this no longer removes the only way to reach it. -->
+                        <StackPanel Visibility="{Binding HasFourZoneKeyboard, Converter={StaticResource BooleanToVisibilityConverter}}">
+
                         <!-- Quick Color Buttons -->
                         <TextBlock Text="⚡ QUICK COLORS (click to apply to all zones)" 
                                    FontSize="11" FontWeight="SemiBold"
@@ -1468,6 +1476,9 @@
                             </StackPanel>
                         </Grid>
                         
+                        </StackPanel>
+                        <!-- end four-zone keyboard controls -->
+
                         <!-- Preset Selection and Apply Buttons -->
                         <Grid Margin="0,8,0,0">
                             <Grid.ColumnDefinitions>
@@ -1553,8 +1564,18 @@
                                                TextWrapping="Wrap"/>
                                 </Border>
 
+                                <!-- Measured-layout editor. Shown only where the backend has read a real
+                                     lamp map off the device; everywhere else this is collapsed and the
+                                     fixed grid below is exactly what it always was. -->
+                                <StackPanel Visibility="{Binding HasMeasuredKeyMap, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                    <TextBlock Text="Measured layout — every key at the position the keyboard reported"
+                                               FontSize="11" Foreground="{StaticResource TextSecondaryBrush}"
+                                               Margin="0,0,0,8" TextWrapping="Wrap"/>
+                                    <views:KeyboardMapEditor DataContext="{Binding KeyboardMap}"/>
+                                </StackPanel>
+
                                 <!-- Per-key editor when supported -->
-                                <StackPanel Visibility="{Binding IsPerKeyLightingAvailable, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <StackPanel Visibility="{Binding IsFixedGridEditorVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
                                     <!-- Brush color row -->
                                     <Grid Margin="0,0,0,10">
                                         <Grid.ColumnDefinitions>
@@ -1630,6 +1651,114 @@
                     </StackPanel>
                 </Border>
 
+                <!-- Keyboard effect engine. Rendered by the keyboard itself: one frame is sent and the
+                     device animates it with OmenCore closed. Shown only where a backend can reach it. -->
+                <Border Style="{StaticResource SurfaceCard}" Padding="24" Margin="0,0,0,16"
+                        DataContext="{Binding DeviceLighting}"
+                        Visibility="{Binding SupportsDeviceEffects, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <StackPanel>
+                        <TextBlock Text="Keyboard effects" FontSize="20" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextPrimaryBrush}" Margin="0,0,0,4"/>
+                        <TextBlock Text="Run by the keyboard's own controller. These keep running when OmenCore is closed, and replace any per-key colours."
+                                   FontSize="12" Foreground="{StaticResource TextSecondaryBrush}"
+                                   TextWrapping="Wrap" Margin="0,0,0,16"/>
+
+                        <WrapPanel Margin="0,0,0,12">
+                            <StackPanel Margin="0,0,16,8">
+                                <TextBlock Text="Effect" FontSize="11" Foreground="{StaticResource TextSecondaryBrush}"/>
+                                <ComboBox Width="160" Style="{StaticResource ModernComboBox}"
+                                          ItemsSource="{Binding Effects}"
+                                          SelectedItem="{Binding SelectedEffect, Mode=TwoWay}"/>
+                            </StackPanel>
+                            <StackPanel Margin="0,0,16,8">
+                                <TextBlock Text="Theme" FontSize="11" Foreground="{StaticResource TextSecondaryBrush}"/>
+                                <ComboBox Width="120" Style="{StaticResource ModernComboBox}"
+                                          ItemsSource="{Binding Themes}"
+                                          SelectedItem="{Binding SelectedTheme, Mode=TwoWay}"
+                                          IsEnabled="{Binding UseCustomColors, Converter={StaticResource InverseBooleanConverter}}"/>
+                            </StackPanel>
+                            <StackPanel Margin="0,0,16,8">
+                                <TextBlock Text="Speed" FontSize="11" Foreground="{StaticResource TextSecondaryBrush}"/>
+                                <ComboBox Width="100" Style="{StaticResource ModernComboBox}"
+                                          ItemsSource="{Binding Speeds}" SelectedItem="{Binding Speed, Mode=TwoWay}"/>
+                            </StackPanel>
+                            <StackPanel Margin="0,0,16,8">
+                                <TextBlock Text="Direction" FontSize="11" Foreground="{StaticResource TextSecondaryBrush}"/>
+                                <ComboBox Width="130" Style="{StaticResource ModernComboBox}"
+                                          ItemsSource="{Binding Directions}" SelectedItem="{Binding Direction, Mode=TwoWay}"/>
+                            </StackPanel>
+                        </WrapPanel>
+
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <CheckBox Content="Custom colours" IsChecked="{Binding UseCustomColors, Mode=TwoWay}"
+                                      Foreground="{StaticResource TextPrimaryBrush}" VerticalAlignment="Center"
+                                      Margin="0,0,16,0"/>
+                            <TextBox Width="80" Margin="0,0,8,0" MaxLength="7"
+                                     Text="{Binding PrimaryColorHex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                     IsEnabled="{Binding UseCustomColors}"/>
+                            <TextBox Width="80" Margin="0,0,16,0" MaxLength="7"
+                                     Text="{Binding SecondaryColorHex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                     IsEnabled="{Binding UseCustomColors}"/>
+                            <Button Content="Apply effect" Style="{StaticResource ModernButton}" Padding="16,6"
+                                    Command="{Binding ApplyEffectCommand}" Margin="0,0,8,0"/>
+                            <Button Content="What's on it now?" Style="{StaticResource ModernButton}" Padding="12,6"
+                                    Command="{Binding ReadEffectCommand}"/>
+                        </StackPanel>
+
+                        <TextBlock Text="{Binding EffectAdvice}" FontSize="11" Foreground="#E0A030"
+                                   TextWrapping="Wrap" Margin="0,0,0,4"/>
+                        <TextBlock Text="{Binding Status}" FontSize="11"
+                                   Foreground="{StaticResource TextSecondaryBrush}" TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Light bar. A different device on a different transport, so a separate card. -->
+                <Border Style="{StaticResource SurfaceCard}" Padding="24" Margin="0,0,0,16"
+                        DataContext="{Binding DeviceLighting}"
+                        Visibility="{Binding IsLightBarAvailable, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <StackPanel>
+                        <TextBlock Text="Light bar" FontSize="20" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextPrimaryBrush}" Margin="0,0,0,4"/>
+                        <TextBlock Text="The strip on the front of the chassis — four zones, left to right. Separate from the keyboard."
+                                   FontSize="12" Foreground="{StaticResource TextSecondaryBrush}"
+                                   TextWrapping="Wrap" Margin="0,0,0,16"/>
+
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                            <TextBlock Text="Colour" FontSize="12" Foreground="{StaticResource TextSecondaryBrush}"
+                                       VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <TextBox Width="80" Margin="0,0,16,0" MaxLength="7"
+                                     Text="{Binding BarColorHex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                            <Button Content="Apply colour" Style="{StaticResource ModernButton}" Padding="14,6"
+                                    Command="{Binding ApplyLightBarColorCommand}" Margin="0,0,8,0"/>
+                            <Button Content="Off" Style="{StaticResource ModernButton}" Padding="14,6"
+                                    Command="{Binding LightBarOffCommand}"/>
+                        </StackPanel>
+
+                        <!-- Brightness and animations are WMI-only, so they are hidden rather than
+                             shown disabled when OmenCore is not elevated. -->
+                        <StackPanel Visibility="{Binding SupportsLightBarEffects, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                                <TextBlock Text="Brightness" FontSize="12" Foreground="{StaticResource TextSecondaryBrush}"
+                                           VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                <Slider Width="160" Minimum="0" Maximum="100" VerticalAlignment="Center"
+                                        Value="{Binding BarBrightness, Mode=TwoWay}" Margin="0,0,8,0"/>
+                                <TextBlock Text="{Binding BarBrightness}" FontSize="12" Width="34"
+                                           Foreground="{StaticResource TextPrimaryBrush}" VerticalAlignment="Center"/>
+                                <ComboBox Width="140" Style="{StaticResource ModernComboBox}" Margin="16,0,8,0"
+                                          ItemsSource="{Binding LightBarEffects}"
+                                          SelectedItem="{Binding SelectedBarEffect, Mode=TwoWay}"/>
+                                <Button Content="Run animation" Style="{StaticResource ModernButton}" Padding="14,6"
+                                        Command="{Binding ApplyLightBarEffectCommand}"/>
+                            </StackPanel>
+                        </StackPanel>
+
+                        <TextBlock Text="{Binding LightBarLimitation}" FontSize="11" Foreground="#E0A030"
+                                   TextWrapping="Wrap" Margin="0,0,0,4"/>
+                        <TextBlock Text="{Binding BarStatus}" FontSize="11"
+                                   Foreground="{StaticResource TextSecondaryBrush}" TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Border>
+
                 <!-- Advanced Lighting Effects -->
                 <Border Style="{StaticResource SurfaceCard}" Padding="24" Margin="0,0,0,16">
                     <StackPanel>
@@ -1649,7 +1778,7 @@
                                     <TextBlock Text="🌡️ Temperature-Responsive Lighting"
                                                FontSize="14" FontWeight="SemiBold"
                                                Foreground="{StaticResource TextPrimaryBrush}"/>
-                                    <TextBlock Text="Keyboard and RGB devices change color based on CPU/GPU temperature"
+                                    <TextBlock Text="Keyboard, light bar and RGB devices change color based on CPU/GPU temperature"
                                                FontSize="11"
                                                Foreground="{StaticResource TextSecondaryBrush}"
                                                Margin="0,2,0,0"/>
@@ -1748,7 +1877,7 @@
                                     <TextBlock Text="⚡ Performance Mode Synced Lighting"
                                                FontSize="14" FontWeight="SemiBold"
                                                Foreground="{StaticResource TextPrimaryBrush}"/>
-                                    <TextBlock Text="RGB devices change color based on current performance mode"
+                                    <TextBlock Text="Keyboard, light bar and RGB devices change color based on current performance mode"
                                                FontSize="11"
                                                Foreground="{StaticResource TextSecondaryBrush}"
                                                Margin="0,2,0,0"/>

--- a/tools/LightingProbe/Autonomous.cs
+++ b/tools/LightingProbe/Autonomous.cs
@@ -1,0 +1,96 @@
+// Drives the LampArray control report ON ITS OWN, with no colour writes at all.
+//
+// This isolates a question the self-test cannot answer. There, AutonomousMode = 0 is sent and
+// then colours are written on top, so "the keyboard shows the device's own effect" has two
+// possible causes: the control report was ignored, or it worked and the colour writes are losing
+// a race. Sending the control report alone separates them - if the device's effect stops, the
+// report works; if it carries on, the report is being accepted and ignored.
+//
+// It is also the way back. The self-test hands the device back with AutonomousMode = 1 on exit,
+// which on a keyboard that was NOT running an effect beforehand does not restore anything - it
+// starts one. --autonomous off is the undo.
+//
+// Also tries to READ the control report. The HID spec does not require it to be readable, and a
+// device that answers is worth knowing about: it would let a caller restore the mode it found
+// rather than assuming one.
+
+using OmenCore.Hardware;
+
+namespace OmenCore.Tools.LightingProbe;
+
+internal static class Autonomous
+{
+    internal static int Run(string[] args)
+    {
+        int i = Array.IndexOf(args, "--autonomous");
+        string? mode = i >= 0 && i + 1 < args.Length ? args[i + 1].ToLowerInvariant() : null;
+
+        if (mode is not ("on" or "off"))
+        {
+            Console.WriteLine("Usage: LightingProbe --autonomous <on|off> [--hold <seconds>]");
+            Console.WriteLine();
+            Console.WriteLine("  off  take the lamps away from the device's own effect engine");
+            Console.WriteLine("  on   hand them back (this is what starts a built-in effect)");
+            return 1;
+        }
+
+        int hold = 0;
+        int h = Array.IndexOf(args, "--hold");
+        if (h >= 0 && h + 1 < args.Length && int.TryParse(args[h + 1], out int parsed))
+            hold = Math.Clamp(parsed, 0, 120);
+
+        bool autonomous = mode == "on";
+
+        Console.WriteLine("=== LampArray autonomous mode ===\n");
+
+        var arrays = HidLampArray.OpenAll();
+        var keyboard = arrays.FirstOrDefault(a => a.Kind == 1 && a.LampCount > 8);
+        if (keyboard == null)
+        {
+            Console.WriteLine("  No keyboard-kind LampArray found.");
+            foreach (var a in arrays) a.Dispose();
+            return 1;
+        }
+
+        try
+        {
+            Console.WriteLine($"  {keyboard.VendorId:X4}:{keyboard.ProductId:X4}, {keyboard.LampCount} lamps\n");
+
+            var before = keyboard.TryReadAutonomousMode();
+            Console.WriteLine($"  control report readable : {(before.HasValue ? $"yes, AutonomousMode = {(before.Value ? 1 : 0)}" : "no")}");
+
+            bool ok = keyboard.SetAutonomousMode(autonomous);
+            Console.WriteLine($"  set AutonomousMode = {(autonomous ? 1 : 0)}   : {(ok ? "accepted" : "REFUSED")}");
+
+            var after = keyboard.TryReadAutonomousMode();
+            if (after.HasValue)
+            {
+                Console.WriteLine($"  reads back              : {(after.Value ? 1 : 0)}");
+                if (after.Value != autonomous)
+                {
+                    Console.WriteLine("  -> ACCEPTED BUT NOT APPLIED. The device took the report and kept its own");
+                    Console.WriteLine("     setting, which is the whole reason this mode exists separately.");
+                }
+            }
+
+            if (hold > 0)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"  Holding {hold}s with NO colour writes. Look at the keyboard:");
+                Console.WriteLine(autonomous
+                    ? "    an effect should be running."
+                    : "    the device's own effect should have STOPPED. Whatever the lamps show now\n" +
+                      "    is static - dark, or the last colours written to them.");
+                Thread.Sleep(hold * 1000);
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("  Nothing else was written. No colour was set.");
+            return 0;
+        }
+        finally
+        {
+            foreach (var a in arrays) a.Dispose();
+        }
+    }
+}

--- a/tools/LightingProbe/LampMap.cs
+++ b/tools/LightingProbe/LampMap.cs
@@ -1,0 +1,149 @@
+// Walks the whole lamp array and builds an id -> key map.
+//
+// This exists to answer a question the four-lamp sample in --lamps cannot: whether a complete map
+// is obtainable at all. On board 8D87's keyboard the lamp-attributes response IGNORES the
+// requested id and free-runs, so "ask for lamp N, get lamp N" does not hold and a caller that
+// assumed it would mislabel every key. Reading sequentially and keying on the id the DEVICE
+// returned recovers the map anyway - and this mode reports coverage so that claim is checked
+// rather than asserted.
+//
+// Each lamp carries the HID usage of the key it sits under, so the map is a table lookup rather
+// than a calibration exercise.
+//
+// READ ONLY. No colour is written.
+
+using OmenCore.Hardware;
+
+namespace OmenCore.Tools.LightingProbe;
+
+internal static class LampMap
+{
+    internal static int Run()
+    {
+        Console.WriteLine("=== Lamp -> key map ===\n");
+
+        var arrays = HidLampArray.OpenAll();
+        var keyboard = arrays.FirstOrDefault(a => a.Kind == 1 && a.LampCount > 8);
+        if (keyboard == null)
+        {
+            Console.WriteLine("  No keyboard-kind LampArray found.");
+            foreach (var a in arrays) a.Dispose();
+            return 1;
+        }
+
+        try
+        {
+            Console.WriteLine($"  {keyboard.VendorId:X4}:{keyboard.ProductId:X4}, {keyboard.LampCount} lamps\n");
+
+            // Key on the id the device reported, not the one requested. Walk one extra pass so a
+            // free-running device that starts partway through still comes back around.
+            var byId = new SortedDictionary<ushort, HidLampArray.LampInfo>();
+            int requests = keyboard.LampCount * 2;
+            int mismatched = 0;
+
+            for (int i = 0; i < requests && byId.Count < keyboard.LampCount; i++)
+            {
+                var info = keyboard.GetLampInfo((ushort)(i % keyboard.LampCount));
+                if (info == null) continue;
+                if (info.Value.LampId != (ushort)(i % keyboard.LampCount)) mismatched++;
+                byId[info.Value.LampId] = info.Value;
+            }
+
+            Console.WriteLine($"  requests issued   : up to {requests}");
+            Console.WriteLine($"  distinct lamps    : {byId.Count} of {keyboard.LampCount}");
+            Console.WriteLine($"  id mismatches     : {mismatched}  (response id != requested id)");
+            Console.WriteLine();
+
+            if (byId.Count < keyboard.LampCount)
+            {
+                Console.WriteLine("  INCOMPLETE. Some lamps never came back, so a map built this way would have");
+                Console.WriteLine("  holes. Do not treat a partial map as a complete one.");
+            }
+            else
+            {
+                Console.WriteLine("  Complete: every lamp id was seen, so keying on the reported id recovers the");
+                Console.WriteLine("  full map even though the device ignores the requested one.");
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("  id   x(mm)  y(mm)   HID usage  key");
+            Console.WriteLine("  ---  -----  -----   ---------  ---");
+            foreach (var (id, info) in byId)
+            {
+                Console.WriteLine($"  {id,3}  {info.XMicrometres / 1000.0,5:F0}  {info.YMicrometres / 1000.0,5:F0}   " +
+                                  $"0x{info.KeyUsage:X2}       {KeyName(info.KeyUsage)}");
+            }
+
+            int bound = byId.Values.Count(v => v.KeyUsage != 0);
+            Console.WriteLine();
+            Console.WriteLine($"  {bound} of {byId.Count} lamps carry a key binding.");
+            return byId.Count == keyboard.LampCount ? 0 : 2;
+        }
+        finally
+        {
+            foreach (var a in arrays) a.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// HID Keyboard/Keypad usage page (0x07) names, for the usages a laptop keyboard actually
+    /// uses. Unknown usages print as hex rather than being guessed at.
+    /// </summary>
+    private static string KeyName(byte usage) => usage switch
+    {
+        0x00 => "(unbound)",
+        >= 0x04 and <= 0x1D => ((char)('A' + (usage - 0x04))).ToString(),
+        >= 0x1E and <= 0x26 => ((char)('1' + (usage - 0x1E))).ToString(),
+        0x27 => "0",
+        0x28 => "Enter",
+        0x29 => "Esc",
+        0x2A => "Backspace",
+        0x2B => "Tab",
+        0x2C => "Space",
+        0x2D => "-",
+        0x2E => "=",
+        0x2F => "[",
+        0x30 => "]",
+        0x31 => "\\",
+        0x33 => ";",
+        0x34 => "'",
+        0x35 => "`",
+        0x36 => ",",
+        0x37 => ".",
+        0x38 => "/",
+        0x39 => "CapsLock",
+        >= 0x3A and <= 0x45 => $"F{usage - 0x39}",
+        0x46 => "PrtSc",
+        0x47 => "ScrollLock",
+        0x48 => "Pause",
+        0x49 => "Insert",
+        0x4A => "Home",
+        0x4B => "PgUp",
+        0x4C => "Delete",
+        0x4D => "End",
+        0x4E => "PgDn",
+        0x4F => "Right",
+        0x50 => "Left",
+        0x51 => "Down",
+        0x52 => "Up",
+        0x53 => "NumLock",
+        0x54 => "Keypad /",
+        0x55 => "Keypad *",
+        0x56 => "Keypad -",
+        0x57 => "Keypad +",
+        0x58 => "Keypad Enter",
+        >= 0x59 and <= 0x61 => $"Keypad {usage - 0x58}",
+        0x62 => "Keypad 0",
+        0x63 => "Keypad .",
+        0x65 => "Menu",
+        0xE0 => "LCtrl",
+        0xE1 => "LShift",
+        0xE2 => "LAlt",
+        0xE3 => "LGui",
+        0xE4 => "RCtrl",
+        0xE5 => "RShift",
+        0xE6 => "RAlt",
+        0xE7 => "RGui",
+        _ => $"0x{usage:X2}"
+    };
+}

--- a/tools/LightingProbe/Lamps.cs
+++ b/tools/LightingProbe/Lamps.cs
@@ -1,0 +1,249 @@
+// Reads the HID LampArray descriptors off every attached lighting device.
+//
+// HID usage page 0x59 ("Lighting And Illumination") is the standardised per-key RGB surface -
+// the same one Windows Dynamic Lighting drives. A keyboard that implements it needs no protocol
+// reverse engineering at all, which is a very different starting point from guessing at a
+// vendor command set.
+//
+// READ ONLY. Feature reports 1 and 3 are read; report 2 is a request that must be written
+// before 3 can be read, and it selects which lamp to describe - it changes no lighting state.
+// Reports 4, 5 and 6 (the ones that actually set colour) are not touched.
+
+using System.Runtime.InteropServices;
+
+namespace OmenCore.Tools.LightingProbe;
+
+internal static class Lamps
+{
+    // HID Lighting And Illumination report ids.
+    private const byte ReportLampArrayAttributes = 1;
+    private const byte ReportLampAttributesRequest = 2;
+    private const byte ReportLampAttributesResponse = 3;
+
+    private const ushort LightingUsagePage = 0x59;
+    private const ushort LampArrayUsage = 0x01;
+
+    internal static int Run()
+    {
+        Console.WriteLine("=== HID LampArray ===\n");
+
+        var found = 0;
+        foreach (string path in Native.EnumerateHidPaths())
+        {
+            using var dev = HidDevice.TryOpen(path, forWrite: true);
+            if (dev == null) continue;
+            if (dev.UsagePage != LightingUsagePage || dev.Usage != LampArrayUsage) continue;
+
+            found++;
+            Console.WriteLine($"  {dev.Product}  (VID 0x{dev.VendorId:X4} PID 0x{dev.ProductId:X4})");
+            Console.WriteLine($"    path            : {path}");
+            Console.WriteLine($"    feature report  : {dev.FeatureReportLength} bytes");
+
+            var attrs = dev.ReadArrayAttributes();
+            if (attrs == null)
+            {
+                Console.WriteLine("    attributes      : unreadable\n");
+                continue;
+            }
+
+            Console.WriteLine($"    LampCount       : {attrs.Value.LampCount}");
+            Console.WriteLine($"    Kind            : {KindName(attrs.Value.Kind)} ({attrs.Value.Kind})");
+            Console.WriteLine($"    BoundingBox     : {attrs.Value.WidthUm / 1000.0:F0} x " +
+                              $"{attrs.Value.HeightUm / 1000.0:F0} x {attrs.Value.DepthUm / 1000.0:F0} mm");
+            Console.WriteLine($"    MinUpdateInterval: {attrs.Value.MinUpdateIntervalUs / 1000.0:F0} ms");
+
+            // Sample a few lamps. Note the returned LampId is printed rather than assumed: on the
+            // board this was written against, the response ignored the requested id and free-ran,
+            // so pairing a response with a request without checking would mislabel every lamp.
+            Console.WriteLine("    sample lamps (id is what the DEVICE reported, not what was asked):");
+            int sampleCount = Math.Min(4, (int)attrs.Value.LampCount);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                var lamp = dev.ReadLampAttributes((ushort)i);
+                if (lamp == null) { Console.WriteLine($"      request {i}: unreadable"); continue; }
+
+                var l = lamp.Value;
+                Console.WriteLine($"      request {i,3} -> id {l.LampId,3}  pos ({l.XUm / 1000.0:F0},{l.YUm / 1000.0:F0},{l.ZUm / 1000.0:F0}) mm  " +
+                                  $"levels r={l.Red} g={l.Green} b={l.Blue} i={l.Intensity}  " +
+                                  $"programmable={l.IsProgrammable}  key usage 0x{l.InputBinding:X2}");
+            }
+
+            Console.WriteLine();
+        }
+
+        if (found == 0)
+        {
+            Console.WriteLine("  No HID LampArray found.");
+            Console.WriteLine("  Either nothing here implements usage page 0x59, or the device is held");
+            Console.WriteLine("  exclusively by another process.\n");
+            return 0;
+        }
+
+        Console.WriteLine("  Writing colour is NOT attempted here, and that is a decision rather than an");
+        Console.WriteLine("  omission. Windows Dynamic Lighting takes ownership of LampArray devices when it");
+        Console.WriteLine("  is enabled, and it refreshes them continuously - so a write can land and be");
+        Console.WriteLine("  overwritten before anyone sees it. There is also no colour readback anywhere in");
+        Console.WriteLine("  the LampArray spec, so 'did that key turn red' has no software answer: only a");
+        Console.WriteLine("  person looking at the keyboard can confirm it.");
+        return 0;
+    }
+
+    private static string KindName(uint kind) => kind switch
+    {
+        1 => "Keyboard", 2 => "Mouse", 3 => "GameController", 4 => "Peripheral",
+        5 => "Scene", 6 => "Notification", 7 => "Chassis", 8 => "Wearable",
+        9 => "Furniture", 10 => "Art", _ => "unknown"
+    };
+
+    internal readonly record struct ArrayAttributes(
+        ushort LampCount, uint WidthUm, uint HeightUm, uint DepthUm, uint Kind, uint MinUpdateIntervalUs);
+
+    internal readonly record struct LampAttributes(
+        ushort LampId, uint XUm, uint YUm, uint ZUm, uint LatencyUs, uint Purposes,
+        byte Red, byte Green, byte Blue, byte Intensity, bool IsProgrammable, byte InputBinding);
+
+    private sealed class HidDevice : IDisposable
+    {
+        private readonly IntPtr _handle;
+        internal ushort VendorId, ProductId, UsagePage, Usage, FeatureReportLength;
+        internal string Product = string.Empty;
+
+        private HidDevice(IntPtr handle) => _handle = handle;
+
+        internal static HidDevice? TryOpen(string path, bool forWrite)
+        {
+            // Feature reports need write access only for the lamp-attributes REQUEST, which
+            // selects a lamp to describe. Fall back to read-only if the device is busy.
+            IntPtr h = Native.CreateFileW(path, forWrite ? Native.GenericReadWrite : Native.GenericRead,
+                                          Native.ShareReadWrite, IntPtr.Zero, Native.OpenExisting, 0, IntPtr.Zero);
+            if (h == Native.InvalidHandle && forWrite)
+                h = Native.CreateFileW(path, Native.GenericRead, Native.ShareReadWrite,
+                                       IntPtr.Zero, Native.OpenExisting, 0, IntPtr.Zero);
+            if (h == Native.InvalidHandle) return null;
+
+            var dev = new HidDevice(h);
+            var attr = new Native.HiddAttributes { Size = Marshal.SizeOf<Native.HiddAttributes>() };
+            if (!Native.HidD_GetAttributes(h, ref attr)) { dev.Dispose(); return null; }
+            dev.VendorId = attr.VendorID;
+            dev.ProductId = attr.ProductID;
+
+            if (!Native.HidD_GetPreparsedData(h, out IntPtr pp)) { dev.Dispose(); return null; }
+            try
+            {
+                var caps = new Native.HidpCaps();
+                Native.HidP_GetCaps(pp, ref caps);
+                dev.UsagePage = caps.UsagePage;
+                dev.Usage = caps.Usage;
+                dev.FeatureReportLength = caps.FeatureReportByteLength;
+            }
+            finally { Native.HidD_FreePreparsedData(pp); }
+
+            var buf = new byte[256];
+            if (Native.HidD_GetProductString(h, buf, buf.Length))
+                dev.Product = System.Text.Encoding.Unicode.GetString(buf).Split('\0')[0];
+
+            return dev;
+        }
+
+        internal ArrayAttributes? ReadArrayAttributes()
+        {
+            int len = Math.Max((int)FeatureReportLength, 32);
+            var b = new byte[len];
+            b[0] = ReportLampArrayAttributes;
+            if (!Native.HidD_GetFeature(_handle, b, len)) return null;
+
+            return new ArrayAttributes(
+                BitConverter.ToUInt16(b, 1),
+                BitConverter.ToUInt32(b, 3),
+                BitConverter.ToUInt32(b, 7),
+                BitConverter.ToUInt32(b, 11),
+                BitConverter.ToUInt32(b, 15),
+                BitConverter.ToUInt32(b, 19));
+        }
+
+        internal LampAttributes? ReadLampAttributes(ushort lampId)
+        {
+            int len = Math.Max((int)FeatureReportLength, 32);
+
+            var req = new byte[len];
+            req[0] = ReportLampAttributesRequest;
+            req[1] = (byte)(lampId & 0xFF);
+            req[2] = (byte)(lampId >> 8);
+            if (!Native.HidD_SetFeature(_handle, req, len)) return null;
+
+            var b = new byte[len];
+            b[0] = ReportLampAttributesResponse;
+            if (!Native.HidD_GetFeature(_handle, b, len)) return null;
+
+            return new LampAttributes(
+                BitConverter.ToUInt16(b, 1),
+                BitConverter.ToUInt32(b, 3),
+                BitConverter.ToUInt32(b, 7),
+                BitConverter.ToUInt32(b, 11),
+                BitConverter.ToUInt32(b, 15),
+                BitConverter.ToUInt32(b, 19),
+                b[23], b[24], b[25], b[26], b[27] != 0, b[28]);
+        }
+
+        public void Dispose()
+        {
+            if (_handle != IntPtr.Zero && _handle != Native.InvalidHandle) Native.CloseHandle(_handle);
+        }
+    }
+
+    private static class Native
+    {
+        internal const uint GenericRead = 0x80000000;
+        internal const uint GenericReadWrite = 0xC0000000;
+        internal const uint ShareReadWrite = 0x03;
+        internal const uint OpenExisting = 3;
+        internal static readonly IntPtr InvalidHandle = new(-1);
+
+        private static readonly Guid HidInterfaceGuid = new("4d1e55b2-f16f-11cf-88cb-001111000030");
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct HiddAttributes { public int Size; public ushort VendorID, ProductID, VersionNumber; }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct HidpCaps
+        {
+            public ushort Usage, UsagePage, InputReportByteLength, OutputReportByteLength, FeatureReportByteLength;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 17)] public ushort[] Reserved;
+            public ushort NumberLinkCollectionNodes, NumberInputButtonCaps, NumberInputValueCaps,
+                          NumberInputDataIndices, NumberOutputButtonCaps, NumberOutputValueCaps,
+                          NumberOutputDataIndices, NumberFeatureButtonCaps, NumberFeatureValueCaps,
+                          NumberFeatureDataIndices;
+        }
+
+        [DllImport("hid.dll")] internal static extern bool HidD_GetAttributes(IntPtr h, ref HiddAttributes a);
+        [DllImport("hid.dll")] internal static extern bool HidD_GetPreparsedData(IntPtr h, out IntPtr p);
+        [DllImport("hid.dll")] internal static extern bool HidD_FreePreparsedData(IntPtr p);
+        [DllImport("hid.dll")] internal static extern int HidP_GetCaps(IntPtr p, ref HidpCaps c);
+        [DllImport("hid.dll")] internal static extern bool HidD_GetFeature(IntPtr h, byte[] b, int len);
+        [DllImport("hid.dll")] internal static extern bool HidD_SetFeature(IntPtr h, byte[] b, int len);
+        [DllImport("hid.dll", CharSet = CharSet.Unicode)]
+        internal static extern bool HidD_GetProductString(IntPtr h, byte[] buf, int len);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern IntPtr CreateFileW(string path, uint access, uint share, IntPtr sa,
+                                                  uint disposition, uint flags, IntPtr template);
+        [DllImport("kernel32.dll")] internal static extern bool CloseHandle(IntPtr h);
+
+        /// <summary>
+        /// HID interface paths, built from the PnP device ids rather than SetupAPI - it is far
+        /// less P/Invoke for the same result, and this is a diagnostic tool.
+        /// </summary>
+        internal static IEnumerable<string> EnumerateHidPaths()
+        {
+            using var searcher = new System.Management.ManagementObjectSearcher(
+                "SELECT PNPDeviceID FROM Win32_PnPEntity WHERE PNPDeviceID LIKE 'HID%'");
+
+            foreach (System.Management.ManagementObject o in searcher.Get())
+            {
+                string? id = o["PNPDeviceID"]?.ToString();
+                if (string.IsNullOrEmpty(id)) continue;
+                yield return $@"\\?\{id.Replace('\\', '#')}#{{{HidInterfaceGuid}}}";
+            }
+        }
+    }
+}

--- a/tools/LightingProbe/LightBar.cs
+++ b/tools/LightingProbe/LightBar.cs
@@ -1,0 +1,278 @@
+// The light bar - a different device from the keyboard, on a different transport.
+//
+// This drives OmenCore's HpWmiBios light bar methods, which speak HP's own SetLightColor over WMI
+// (class Keyboard 0x00020009, command 0x0B). Four zones, zone 0 LEFTMOST, one command carrying
+// static colour, animation, brightness and off.
+//
+// THERE IS A SECOND PATH and it is worth knowing about before choosing this one. The bar also
+// enumerates as a HID LampArray - "HID VHF Driver" 0461:0001, Kind Scene, 4 lamps at ids 0..3
+// across a 323 x 5 mm strip - which is Windows exposing it through the Virtual HID Framework. So
+// Windows Dynamic Lighting can drive it, which is why it sometimes changes without being asked.
+// The WMI path used here is the measured one and the only one with brightness and animations.
+//
+// WHAT READS BACK, AND WHAT DOES NOT. Colour reads back, per zone, through Default 0x04.
+// Animation and brightness do NOT - HP's own animation getter (Keyboard 0x0C) answers FAIL on this
+// board. That is the OPPOSITE of the keyboard MCU, where the effect record reads back and colour
+// does not. Carrying an assumption from one device to the other gets it wrong in both directions.
+//
+// Requires elevation, like every WMI BIOS call.
+
+using OmenCore.Hardware;
+
+namespace OmenCore.Tools.LightingProbe;
+
+internal static class LightBar
+{
+    internal static int Run(string[] args)
+    {
+        bool commit = args.Contains("--commit");
+
+        Console.WriteLine("=== Light bar ===\n");
+
+        // Pass logging so a refusal is diagnosable rather than a bare False.
+        var logging = new OmenCore.Services.LoggingService();
+        logging.Initialize();
+        using var bios = new HpWmiBios(logging);
+        if (!bios.IsAvailable)
+        {
+            // Not a dead end. Colour is reachable over HID without elevation; brightness and the
+            // nine animations are not reachable any other way than WMI, so say which is which
+            // rather than just refusing.
+            Console.WriteLine("  HP WMI BIOS unavailable (needs administrator).");
+            Console.WriteLine("  Falling back to the light bar's HID LampArray, which does not.\n");
+            return HidFallback(args, commit);
+        }
+
+        // Always snapshot first. Colour is the one light bar property that reads back, and it is
+        // the whole difference between a bad colour being one command to undo and an evening spent
+        // guessing what it used to be.
+        var before = bios.GetLightBarColors();
+        Console.WriteLine($"  before   : {Format(before)}");
+
+        string? animation = Arg(args, "--lightbar-effect");
+        string? colors = Arg(args, "--lightbar");
+        string? brightnessArg = Arg(args, "--lightbar-brightness");
+        byte brightness = byte.TryParse(brightnessArg, out byte b) ? Math.Clamp(b, (byte)0, (byte)100) : (byte)100;
+
+        if (args.Contains("--lightbar-off"))
+        {
+            Console.WriteLine("  plan     : all zones off");
+            if (!commit) return DryRun();
+
+            Console.WriteLine($"  accepted : {bios.SetLightBarOff()}");
+            Console.WriteLine($"  after    : {Format(bios.GetLightBarColors())}");
+            return 0;
+        }
+
+        if (animation != null)
+        {
+            if (!Enum.TryParse(animation, ignoreCase: true, out HpWmiBios.LightBarEffect effect))
+            {
+                Console.WriteLine($"  Unknown --lightbar-effect '{animation}'. One of: " +
+                                  string.Join(", ", Enum.GetNames<HpWmiBios.LightBarEffect>()));
+                return 1;
+            }
+
+            var themeName = Arg(args, "--lightbar-theme") ?? (colors != null ? "Custom" : "Galaxy");
+            if (!Enum.TryParse(themeName, ignoreCase: true, out HpWmiBios.LightBarTheme theme))
+            {
+                Console.WriteLine($"  Unknown --lightbar-theme '{themeName}'. One of: " +
+                                  string.Join(", ", Enum.GetNames<HpWmiBios.LightBarTheme>()));
+                return 1;
+            }
+
+            var speedName = Arg(args, "--lightbar-speed") ?? "Medium";
+            Enum.TryParse(speedName, ignoreCase: true, out HpWmiBios.LightBarSpeed speed);
+
+            byte tribe = byte.TryParse(Arg(args, "--tribe"), out byte t) ? t : (byte)0;
+            byte bass = byte.TryParse(Arg(args, "--bass"), out byte s) ? s : (byte)0;
+
+            Console.WriteLine($"  plan     : {effect}, theme {theme}, speed {speed}, brightness {brightness}");
+            if (effect == HpWmiBios.LightBarEffect.Swipe && theme != HpWmiBios.LightBarTheme.Custom)
+                Console.WriteLine("             Swipe has no preset palette - expect BLACK. Add --lightbar with colours.");
+            if (effect == HpWmiBios.LightBarEffect.AudioPulse && tribe == 0 && bass == 0)
+                Console.WriteLine("             Audio Pulse IS its levels - expect BLACK. Add --tribe 100 --bass 100.");
+
+            if (!commit) return DryRun();
+
+            bool ok = bios.SetLightBarAnimation(effect, theme, speed,
+                                                HpWmiBios.LightBarDirection.Left, brightness,
+                                                ParseColors(colors), tribe, bass);
+            Console.WriteLine($"  accepted : {ok}");
+            Console.WriteLine();
+            Console.WriteLine("  THERE IS NO READBACK FOR ANIMATION STATE. Accepted means the firmware took");
+            Console.WriteLine("  the frame and nothing more. Look at the bar.");
+            return ok ? 0 : 1;
+        }
+
+        if (colors == null && brightnessArg == null)
+        {
+            Console.WriteLine();
+            Console.WriteLine("  Read-only. To write:");
+            Console.WriteLine("    --lightbar FF0000,00FF00,0000FF,FFFFFE --commit");
+            Console.WriteLine("    --lightbar 0000FF --lightbar-brightness 30 --commit");
+            Console.WriteLine("    --lightbar-effect Wave --lightbar-theme Ocean --commit");
+            Console.WriteLine("    --lightbar-off --commit");
+            return 0;
+        }
+
+        var wanted = ParseColors(colors);
+        if (wanted.Count == 0)
+        {
+            // Brightness with no colours means "same picture, dimmer", which needs the colours
+            // back - and they are readable, so there is no reason to make the caller retype them.
+            wanted = before.Where(z => z != null).Select(z => z!.Value).ToList();
+            if (wanted.Count == 0)
+            {
+                Console.WriteLine("  --lightbar-brightness alone needs the current colours, and the read failed.");
+                return 1;
+            }
+        }
+
+        Console.WriteLine($"  plan     : {string.Join("  ", wanted.Select(c => $"#{c.R:X2}{c.G:X2}{c.B:X2}"))}" +
+                          $"   brightness {brightness}");
+
+        if (wanted.Any(c => c is { R: 0xFF, G: 0xFF, B: 0xFF }))
+            Console.WriteLine("             note: #FFFFFF is substituted to #FFFFFE - asking for it gives PINK.");
+
+        if (!commit) return DryRun();
+
+        bool wrote = bios.SetLightBarColors(wanted, brightness);
+        Console.WriteLine($"  accepted : {wrote}");
+
+        var after = bios.GetLightBarColors();
+        Console.WriteLine($"  after    : {Format(after)}");
+        Console.WriteLine();
+
+        // Three outcomes, not two. A binary matches/does-not-match verdict reports a firmware
+        // adjustment as a failure, which is the interesting case and the one worth naming.
+        string beforeText = Format(before), afterText = Format(after);
+        string wantedText = string.Join("  ", wanted.Select(c => $"#{c.R:X2}{c.G:X2}{c.B:X2}"));
+
+        if (afterText.StartsWith(wantedText, StringComparison.OrdinalIgnoreCase))
+            Console.WriteLine("  Readback matches the request.");
+        else if (afterText == beforeText)
+            Console.WriteLine("  READBACK IS UNCHANGED from before the write. It did not take.");
+        else
+            Console.WriteLine("  Readback changed but differs from the request - the firmware adjusted it.");
+
+        Console.WriteLine();
+        Console.WriteLine("  Brightness has no readback on this path; only looking confirms it.");
+        return wrote ? 0 : 1;
+    }
+
+    /// <summary>
+    /// Drive the bar over its own LampArray, with no elevation.
+    ///
+    /// Colour only. Brightness and the nine built-in animations live behind HP's WMI surface and
+    /// there is no HID equivalent, so this cannot be a drop-in replacement - it is the subset that
+    /// happens not to need administrator.
+    /// </summary>
+    private static int HidFallback(string[] args, bool commit)
+    {
+        using var bar = HidLampArray.OpenLightBar();
+        if (bar == null)
+        {
+            // Two different failures, and telling them apart is the whole value of the message: an
+            // ungated board is a decision this code made, a missing device is the hardware's answer.
+            if (!OmenBoard.SupportsHidLightBar())
+            {
+                Console.WriteLine($"  Board '{OmenBoard.Product}' is not on the HID light bar list, so this path is");
+                Console.WriteLine("  gated off. It is confirmed on 8D87 only. If this machine has a light bar,");
+                Console.WriteLine("  run --lamps and report a Scene-kind array with a bar-shaped bounding box.");
+            }
+            else
+            {
+                Console.WriteLine("  No bar-shaped Scene LampArray found. Nothing can reach the light bar on");
+                Console.WriteLine("  this machine without elevation.");
+            }
+
+            return 1;
+        }
+
+        Console.WriteLine($"  device   : {bar.VendorId:X4}:{bar.ProductId:X4}, {bar.LampCount} lamps, " +
+                          $"min update {bar.MinUpdateInterval.TotalMilliseconds:F0} ms");
+
+        if (args.Contains("--lightbar-effect") || Arg(args, "--lightbar-brightness") != null)
+        {
+            Console.WriteLine();
+            Console.WriteLine("  Brightness and animations are NOT available on this path - they exist only");
+            Console.WriteLine("  behind HP's WMI commands, which need administrator. Colour is all HID offers.");
+        }
+
+        if (args.Contains("--lightbar-off"))
+        {
+            Console.WriteLine("  plan     : all four lamps black");
+            if (!commit) return DryRun();
+            Console.WriteLine($"  accepted : {bar.SetAll(0, 0, 0)}");
+            return 0;
+        }
+
+        var wanted = ParseColors(Arg(args, "--lightbar"));
+        if (wanted.Count == 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("  Read-only. There is no colour readback over HID, so there is nothing to show");
+            Console.WriteLine("  you here - the WMI path is the one that can read the bar back.");
+            Console.WriteLine();
+            Console.WriteLine("  To write, unelevated:  --lightbar FF0000,00FF00,0000FF,FFFFFE --commit");
+            return 0;
+        }
+
+        // Zone 0 is leftmost, and lamp ids run 0..3 in the same direction, so the mapping is the
+        // identity. Stated rather than assumed, because it is the kind of thing that is quietly
+        // reversed on another board.
+        var lamps = new List<HidLampArray.LampColor>();
+        for (ushort zone = 0; zone < bar.LampCount; zone++)
+        {
+            var c = wanted[Math.Min(zone, wanted.Count - 1)];
+            lamps.Add(new HidLampArray.LampColor(zone, c.R, c.G, c.B));
+        }
+
+        Console.WriteLine($"  plan     : {string.Join("  ", lamps.Select(l => $"#{l.R:X2}{l.G:X2}{l.B:X2}"))}");
+
+        if (!commit) return DryRun();
+
+        bar.SetAutonomousMode(false);
+        bool ok = bar.SetLamps(lamps);
+        Console.WriteLine($"  accepted : {ok}");
+        Console.WriteLine();
+        Console.WriteLine("  No colour readback on this path, so accepted is the whole software claim.");
+        Console.WriteLine("  Look at the bar.");
+        return ok ? 0 : 1;
+    }
+
+    private static int DryRun()
+    {
+        Console.WriteLine("\n  DRY RUN. Nothing written. Add --commit to send it.");
+        return 0;
+    }
+
+    private static string Format((byte R, byte G, byte B)?[] zones) =>
+        string.Join("  ", zones.Select(z => z == null ? "??????" : $"#{z.Value.R:X2}{z.Value.G:X2}{z.Value.B:X2}"));
+
+    private static List<(byte R, byte G, byte B)> ParseColors(string? spec)
+    {
+        var list = new List<(byte, byte, byte)>();
+        if (string.IsNullOrWhiteSpace(spec)) return list;
+
+        foreach (string part in spec.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            string h = part.TrimStart('#');
+            if (h.Length != 6) continue;
+            try
+            {
+                list.Add((Convert.ToByte(h[..2], 16), Convert.ToByte(h[2..4], 16), Convert.ToByte(h[4..], 16)));
+            }
+            catch { /* malformed swatches are dropped; the printed plan shows what survived */ }
+        }
+
+        return list.Take(HpWmiBios.LightBarZoneCount).ToList();
+    }
+
+    private static string? Arg(string[] args, string name)
+    {
+        int i = Array.IndexOf(args, name);
+        return i >= 0 && i + 1 < args.Length ? args[i + 1] : null;
+    }
+}

--- a/tools/LightingProbe/LightingProbe.csproj
+++ b/tools/LightingProbe/LightingProbe.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OmenCoreApp\OmenCoreApp.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/LightingProbe/MapEditor.cs
+++ b/tools/LightingProbe/MapEditor.cs
@@ -1,0 +1,176 @@
+// Drive KeyboardMapViewModel - the type the UI binds to - against real hardware.
+//
+// The per-key editor's failures were all in the VIEW-MODEL rather than the transport: keys
+// initialised black so the first Apply blanked the keyboard, the selection ring hid the colour it
+// had just painted, brightness never reached the lamps. None of that shows up in a transport test or
+// in a unit test with no keyboard. So this runs the same objects the window runs, in the order a
+// user clicks them. WRITES, so it is behind --commit like everything else.
+
+using System.Linq;
+using OmenCore.Services;
+using OmenCore.ViewModels;
+
+namespace OmenCore.Tools.LightingProbe;
+
+internal static class MapEditor
+{
+    internal static int Run(string[] args)
+    {
+        bool commit = args.Contains("--commit");
+
+        Console.WriteLine("=== Per-key editor view-model, against hardware ===\n");
+
+        // Initialize starts the writer thread; without it every log line is queued and discarded,
+        // which cost a round of "the code did not run" when it had run and said so into a void.
+        var logging = new LoggingService();
+        logging.Initialize();
+
+        // Pass the WMI BIOS, as the app does. Without it the bar is unreachable and its zones read as
+        // nulls - which looked like a broken readback, and was this harness constructing the service
+        // differently from the window it stands in for.
+        var bios = new OmenCore.Hardware.HpWmiBios(logging);
+
+        // Backend probing happens in the constructor, so the service is live once this returns.
+        var keyboard = new KeyboardLightingService(logging, wmiBios: bios);
+        var vm = new KeyboardMapViewModel(keyboard, logging);
+
+        Console.WriteLine($"  IsPerKey            : {keyboard.IsPerKey}");
+        Console.WriteLine($"  SupportsDeviceEffects: {keyboard.SupportsDeviceEffects}");
+        Console.WriteLine($"  GetMeasuredKeyMap   : {keyboard.GetMeasuredKeyMap().Count} lamps");
+        Console.WriteLine($"  available           : {vm.IsAvailable}");
+
+        if (!vm.IsAvailable)
+        {
+            Console.WriteLine("\n  No measured lamp map, so the editor would be hidden in the UI.");
+            Console.WriteLine("  The three lines above localise it: the backend logs 120 mapped lamps,");
+            Console.WriteLine("  so a zero here is the service layer, not the hardware.");
+            return 1;
+        }
+
+        int barZones = vm.Keys.Count(k => k.IsLightBar);
+        Console.WriteLine($"  keys      : {vm.Keys.Count - barZones} " +
+                          $"(from {keyboard.GetMeasuredKeyMap().Count} lamps)");
+        Console.WriteLine($"  light bar : {(vm.HasLightBar ? "present" : "not available")}, " +
+                          $"{barZones} zones in the map");
+
+        foreach (var zone in vm.Keys.Where(k => k.IsLightBar))
+        {
+            Console.WriteLine($"    {zone.Label}  x {zone.X,5:F0} .. {zone.X + zone.Width,5:F0}  " +
+                              $"y {zone.Y,5:F0}  {zone.ColorHex} (read from the bar)");
+        }
+        Console.WriteLine($"  canvas    : {vm.CanvasWidth:F0} x {vm.CanvasHeight:F0}");
+        // Brightness is settable here so the lever is exercised rather than merely reported. It is
+        // the LampArray intensity channel - the only brightness this keyboard has, the MCU command
+        // being refused - and it only takes effect on the next colour write.
+        int at = Array.IndexOf(args, "--brightness");
+        if (at >= 0 && at + 1 < args.Length && int.TryParse(args[at + 1], out int level))
+            vm.Brightness = level;
+
+        Console.WriteLine($"  brightness: {vm.Brightness}");
+        Console.WriteLine($"  status    : {vm.Status}");
+
+        // The grouping is the fix for the crushed modifier column, so show the widest keys: if
+        // Space is five separate keys rather than one, it is visible right here.
+        Console.WriteLine("\n  widest keys (multi-lamp keys should be the wide ones):");
+        foreach (var key in vm.Keys.Where(k => !k.IsLightBar).OrderByDescending(k => k.Width).Take(8))
+        {
+            Console.WriteLine($"    {key.Label,-6} {key.LampIds.Count} lamp(s), " +
+                              $"{key.Width:F0} wide at ({key.X:F0}, {key.Y:F0})");
+        }
+
+        // The left three columns were crushed because filler lamps - usage 0x03, ~9 mm from their
+        // neighbour, one per left-hand row - were drawn at a full key width and overlapped three
+        // deep. Check no key now overlaps the next one in its row.
+        Console.WriteLine("\n  left-edge keys, first three rows (filler lamps should be slivers):");
+        foreach (var key in vm.Keys.Where(k => k.X < 90).OrderBy(k => k.Y).ThenBy(k => k.X).Take(10))
+        {
+            Console.WriteLine($"    {key.Label,-6} x {key.X,5:F0} .. {key.X + key.Width,5:F0}  " +
+                              $"({key.Width,4:F0} wide, {key.LampIds.Count} lamp)");
+        }
+
+        int overlaps = 0;
+        foreach (var row in vm.Keys.GroupBy(k => Math.Round(k.Y)))
+        {
+            var ordered = row.OrderBy(k => k.X).ToList();
+            for (int i = 0; i + 1 < ordered.Count; i++)
+            {
+                // One pixel of tolerance: the drawn caps carry a 1 px margin each side.
+                if (ordered[i].X + ordered[i].Width > ordered[i + 1].X + 1)
+                {
+                    overlaps++;
+                    Console.WriteLine($"    overlap: {ordered[i].Label} ends {ordered[i].X + ordered[i].Width:F0}, " +
+                                      $"{ordered[i + 1].Label} starts {ordered[i + 1].X:F0} " +
+                                      $"(row y={Math.Round(ordered[i].Y)})");
+                }
+            }
+        }
+
+        Console.WriteLine($"\n  overlaps  : {overlaps}");
+        Console.WriteLine(overlaps == 0
+            ? "              none - no key is drawn over its neighbour"
+            : "              KEYS OVERLAP - the layout will look crushed");
+
+        // Rows must share a Y after snapping, or the keyboard looks wobbly. The bar sits on its own
+        // Y below the keys and is not a keyboard row, so it is excluded from the count.
+        var rows = vm.Keys.Where(k => !k.IsLightBar)
+                          .Select(k => Math.Round(k.Y)).Distinct().OrderBy(y => y).ToList();
+        Console.WriteLine($"\n  rows      : {rows.Count} distinct Y values ({string.Join(", ", rows)})");
+        Console.WriteLine(rows.Count is >= 5 and <= 8
+            ? "              plausible for a 6-row laptop keyboard with a numpad"
+            : "              SUSPICIOUS - snapping may not be working");
+
+        // Every key starts at the brush colour, not black. A black default means the first Apply
+        // blanks whatever the user did not paint.
+        int black = vm.Keys.Count(k => k.ColorHex is "#000000" or "000000");
+        Console.WriteLine($"\n  initial   : {vm.Keys.Count - black} keys at the brush colour, {black} black");
+        Console.WriteLine(black == 0
+            ? "              good - a first Apply will not blank the keyboard"
+            : "              WARNING - those keys would go dark on the first Apply");
+
+        // Now the gesture a user actually makes: drag a band, paint it, check the selection was
+        // dropped so the colour is visible.
+        // Set the background the keys will hold, before the band is painted over it.
+        vm.BrushColorHex = "#200000";
+        ((System.Windows.Input.ICommand)vm.SelectAllCommand).Execute(null);
+        ((System.Windows.Input.ICommand)vm.PaintSelectionCommand).Execute(null);
+        Console.WriteLine($"\n  background: all keys #200000 (dim red)");
+
+        Console.WriteLine("  --- simulating a drag across the top-left region, then Paint ---");
+        vm.SelectWithin(0, 0, vm.CanvasWidth / 4, vm.CanvasHeight / 3, additive: false);
+        Console.WriteLine($"  selected  : {vm.SelectedCount} keys");
+
+        // Paint the band a DIFFERENT colour from the background the keys started at, or the test
+        // proves nothing: green keys on a green keyboard look identical whether the band landed or
+        // not. Keys initialise at the brush colour, so the brush has to change between the two.
+        vm.BrushColorHex = "#00FF00";
+        ((System.Windows.Input.ICommand)vm.PaintSelectionCommand).Execute(null);
+
+        int green = vm.Keys.Count(k => k.ColorHex.Equals("#00FF00", StringComparison.OrdinalIgnoreCase));
+        Console.WriteLine($"  painted   : {green} keys now #00FF00");
+        Console.WriteLine($"  selection : {vm.SelectedCount} still selected " +
+                          (vm.SelectedCount == 0
+                              ? "(good - the ring is gone so the colour shows)"
+                              : "(BAD - the white ring hides the colour just painted)"));
+        Console.WriteLine($"  status    : {vm.Status}");
+
+        if (!commit)
+        {
+            Console.WriteLine("\n  DRY RUN. The map was built and painted in memory; nothing was sent.");
+            Console.WriteLine("  Add --commit to push it to the keyboard.");
+            return 0;
+        }
+
+        Console.WriteLine("\n  --- Apply ---");
+        ((System.Windows.Input.ICommand)vm.ApplyCommand).Execute(null);
+        System.Threading.Thread.Sleep(400);
+        Console.WriteLine($"  status    : {vm.Status}");
+
+        Console.WriteLine("\n  LOOK AT THE KEYBOARD.");
+        Console.WriteLine($"    expect: the top-left ~12 keys BRIGHT GREEN, every other key DIM RED");
+        Console.WriteLine("    all dark        -> the write is not reaching the lamps");
+        Console.WriteLine("    an animation    -> the device effect engine still owns the keys");
+        Console.WriteLine("    partly coloured -> the lamp map is incomplete");
+
+        return 0;
+    }
+}

--- a/tools/LightingProbe/MapEditor.cs
+++ b/tools/LightingProbe/MapEditor.cs
@@ -34,9 +34,15 @@ internal static class MapEditor
         var keyboard = new KeyboardLightingService(logging, wmiBios: bios);
         var vm = new KeyboardMapViewModel(keyboard, logging);
 
+        var layout = keyboard.GetKeyboardLayout();
+
         Console.WriteLine($"  IsPerKey            : {keyboard.IsPerKey}");
         Console.WriteLine($"  SupportsDeviceEffects: {keyboard.SupportsDeviceEffects}");
         Console.WriteLine($"  GetMeasuredKeyMap   : {keyboard.GetMeasuredKeyMap().Count} lamps");
+        Console.WriteLine($"  GetKeyboardLayout   : " + (layout == null
+            ? "none - this board is not in the catalogue"
+            : $"{layout.Id}, {layout.Keys.Count} keys, {layout.Leds} LEDs" +
+              (layout.Verified ? " (confirmed on hardware)" : " (NOT confirmed on hardware)")));
         Console.WriteLine($"  available           : {vm.IsAvailable}");
 
         if (!vm.IsAvailable)
@@ -48,8 +54,17 @@ internal static class MapEditor
         }
 
         int barZones = vm.Keys.Count(k => k.IsLightBar);
-        Console.WriteLine($"  keys      : {vm.Keys.Count - barZones} " +
-                          $"(from {keyboard.GetMeasuredKeyMap().Count} lamps)");
+        var cells = vm.Keys.Where(k => !k.IsLightBar).ToList();
+
+        // Which enumeration the editor drew from. They are not interchangeable: the layout has one
+        // cell per LED, the lamp map one per lamp, and there are 176 of the first against 120 of the
+        // second on this board. Every count below means a different thing depending on this line.
+        bool byLed = cells.Count > 0 && cells[0].IsLed;
+
+        Console.WriteLine($"  drawn from: {(byLed ? "the layout table, one cell per LED" : "the lamp map, one cell per lamp")}");
+        Console.WriteLine($"  cells     : {cells.Count} " + (byLed
+            ? $"(the layout declares {layout?.Leds} LEDs)"
+            : $"(from {keyboard.GetMeasuredKeyMap().Count} lamps)"));
         Console.WriteLine($"  light bar : {(vm.HasLightBar ? "present" : "not available")}, " +
                           $"{barZones} zones in the map");
 
@@ -71,21 +86,22 @@ internal static class MapEditor
 
         // The grouping is the fix for the crushed modifier column, so show the widest keys: if
         // Space is five separate keys rather than one, it is visible right here.
-        Console.WriteLine("\n  widest keys (multi-lamp keys should be the wide ones):");
-        foreach (var key in vm.Keys.Where(k => !k.IsLightBar).OrderByDescending(k => k.Width).Take(8))
+        Console.WriteLine(byLed
+            ? "\n  widest cells (a wide cap's LEDs, so these should be single-LED slices):"
+            : "\n  widest keys (multi-lamp keys should be the wide ones):");
+        foreach (var key in cells.OrderByDescending(k => k.Width).Take(8))
         {
-            Console.WriteLine($"    {key.Label,-6} {key.LampIds.Count} lamp(s), " +
-                              $"{key.Width:F0} wide at ({key.X:F0}, {key.Y:F0})");
+            Console.WriteLine($"    {Describe(key),-28} {key.Width:F0} wide at ({key.X:F0}, {key.Y:F0})");
         }
 
         // The left three columns were crushed because filler lamps - usage 0x03, ~9 mm from their
         // neighbour, one per left-hand row - were drawn at a full key width and overlapped three
         // deep. Check no key now overlaps the next one in its row.
-        Console.WriteLine("\n  left-edge keys, first three rows (filler lamps should be slivers):");
-        foreach (var key in vm.Keys.Where(k => k.X < 90).OrderBy(k => k.Y).ThenBy(k => k.X).Take(10))
+        Console.WriteLine("\n  left-edge cells, first three rows (filler lamps should be slivers):");
+        foreach (var key in cells.Where(k => k.X < 90).OrderBy(k => k.Y).ThenBy(k => k.X).Take(10))
         {
-            Console.WriteLine($"    {key.Label,-6} x {key.X,5:F0} .. {key.X + key.Width,5:F0}  " +
-                              $"({key.Width,4:F0} wide, {key.LampIds.Count} lamp)");
+            Console.WriteLine($"    {Describe(key),-28} x {key.X,5:F0} .. {key.X + key.Width,5:F0}  " +
+                              $"({key.Width,4:F0} wide)");
         }
 
         int overlaps = 0;
@@ -112,17 +128,47 @@ internal static class MapEditor
 
         // Rows must share a Y after snapping, or the keyboard looks wobbly. The bar sits on its own
         // Y below the keys and is not a keyboard row, so it is excluded from the count.
-        var rows = vm.Keys.Where(k => !k.IsLightBar)
-                          .Select(k => Math.Round(k.Y)).Distinct().OrderBy(y => y).ToList();
+        var rows = cells.Select(k => Math.Round(k.Y)).Distinct().OrderBy(y => y).ToList();
         Console.WriteLine($"\n  rows      : {rows.Count} distinct Y values ({string.Join(", ", rows)})");
-        Console.WriteLine(rows.Count is >= 5 and <= 8
-            ? "              plausible for a 6-row laptop keyboard with a numpad"
-            : "              SUSPICIOUS - snapping may not be working");
+
+        if (byLed)
+        {
+            // A cap divides into its LEDs, and a vertical division puts a cell at a Y no key row
+            // sits at. So distinct Ys outnumber rows here BY DESIGN, and the 5-to-8 check that
+            // guards the lamp path would fail on a correct build. Coverage is the check that means
+            // something in this mode - see below.
+            Console.WriteLine("              more than one per row, as expected - a stacked cap puts "
+                              + "its second LED on its own Y");
+        }
+        else
+        {
+            Console.WriteLine(rows.Count is >= 5 and <= 8
+                ? "              plausible for a 6-row laptop keyboard with a numpad"
+                : "              SUSPICIOUS - snapping may not be working");
+        }
+
+        // The check the layout path exists for: every byte of the colour map is reachable from the
+        // editor, and no two cells claim the same one. A duplicate is the bug that made half of
+        // Num0 inert - two cells resolving to one LED, the second silently overwriting the first.
+        if (byLed && layout != null)
+        {
+            var positions = cells.SelectMany(k => k.LedPositions).ToList();
+            var duplicated = positions.GroupBy(p => p).Where(g => g.Count() > 1).Select(g => g.Key).ToList();
+            var missing = Enumerable.Range(0, layout.Leds).Except(positions).ToList();
+
+            Console.WriteLine($"\n  coverage  : {positions.Distinct().Count()} of {layout.Leds} "
+                              + $"colour-map positions, {duplicated.Count} claimed twice");
+            Console.WriteLine(duplicated.Count == 0 && missing.Count == 0
+                ? "              every LED addressable exactly once"
+                : $"              GAPS OR COLLISIONS - missing [{string.Join(", ", missing.Take(12))}], "
+                  + $"duplicated [{string.Join(", ", duplicated.Take(12))}]");
+        }
 
         // Every key starts at the brush colour, not black. A black default means the first Apply
-        // blanks whatever the user did not paint.
-        int black = vm.Keys.Count(k => k.ColorHex is "#000000" or "000000");
-        Console.WriteLine($"\n  initial   : {vm.Keys.Count - black} keys at the brush colour, {black} black");
+        // blanks whatever the user did not paint. Bar zones are excluded: those read their colour
+        // back off the hardware, so a dark one is the bar being dark, not a bad default.
+        int black = cells.Count(k => k.ColorHex is "#000000" or "000000");
+        Console.WriteLine($"\n  initial   : {cells.Count - black} keys at the brush colour, {black} black");
         Console.WriteLine(black == 0
             ? "              good - a first Apply will not blank the keyboard"
             : "              WARNING - those keys would go dark on the first Apply");
@@ -173,4 +219,16 @@ internal static class MapEditor
 
         return 0;
     }
+
+    /// <summary>
+    /// Name a cell the way its tooltip does, so probe output and the window agree.
+    ///
+    /// The two modes address different things and printing one shape for both is what made this
+    /// harness report "0 lamp" against a correct layout-driven build: the cells were right, the
+    /// field being printed was simply not the one they carry.
+    /// </summary>
+    private static string Describe(OmenCore.ViewModels.KeyLampViewModel key) =>
+        key.IsLed
+            ? $"{key.HpKeyName} LED {key.LedOrdinal}/{key.LedCount} @{key.LedPositions[0]}"
+            : $"{key.Label} ({key.LampIds.Count} lamp{(key.LampIds.Count == 1 ? "" : "s")})";
 }

--- a/tools/LightingProbe/PerKey.cs
+++ b/tools/LightingProbe/PerKey.cs
@@ -1,0 +1,476 @@
+// Drive OmenCore's per-key backend on real hardware.
+//
+// This runs DojoPerKeyBackend - the shipping type, through the shipping IKeyboardBackend surface -
+// rather than a copy of the protocol. A mistake in what ships shows up here, which is the whole
+// point of a probe living in this repo instead of a scratch file.
+//
+// The keyboard has TWO interfaces and they do different jobs, so the commands split the same way:
+//
+//   --zones RRGGBB,...       STATIC colour, painted per key over mi_04. No readback anywhere.
+//   --effect <name>          a DEVICE-SIDE animation over mi_03. One frame, rendered by the MCU,
+//                            and it holds after this process exits. Readable back.
+//
+// WRITES ARE GATED. --commit is required by everything that changes the keyboard; without it the
+// frame is composed, decoded and printed, and nothing is sent. --read-effect is exempt, because a
+// read is the safe thing and making it awkward makes people guess instead.
+//
+// WHAT "ACCEPTED" MEANS. The MCU answers EC AC to a frame it parsed. That is not the keyboard
+// saying anything lit - during a stuck state on 8D87 every frame OGH sent was acknowledged and the
+// keyboard stayed dark. Close a claim with the readback AND with looking at the keyboard.
+//
+// TWO EFFECTS RENDER BLACK ON PURPOSE and both look like a bug:
+//   Swipe        has no preset palette. With a preset selected it shows nothing; give it colours.
+//   AudioPulse   IS its two level bytes. At 0 it is black by definition. --pulse feeds them.
+
+using System.Drawing;
+using OmenCore.Hardware;
+using OmenCore.Services;
+using OmenCore.Services.KeyboardLighting;
+
+namespace OmenCore.Tools.LightingProbe;
+
+internal static class PerKey
+{
+    private static readonly (string Name, DojoKeyboardMcu.Effect Wire)[] Effects =
+    {
+        ("colorcycle", DojoKeyboardMcu.Effect.ColorCycle),
+        ("starlight",  DojoKeyboardMcu.Effect.Starlight),
+        ("breathing",  DojoKeyboardMcu.Effect.Breathing),
+        ("ghosting",   DojoKeyboardMcu.Effect.Ghosting),
+        ("ripple",     DojoKeyboardMcu.Effect.Ripple),
+        ("wave",       DojoKeyboardMcu.Effect.Wave),
+        ("omenx",      DojoKeyboardMcu.Effect.OmenX),
+        ("raindrop",   DojoKeyboardMcu.Effect.Raindrop),
+        ("audiopulse", DojoKeyboardMcu.Effect.AudioPulse),
+        ("confetti",   DojoKeyboardMcu.Effect.Confetti),
+        ("sun",        DojoKeyboardMcu.Effect.Sun),
+        ("swipe",      DojoKeyboardMcu.Effect.Swipe),
+    };
+
+    private static readonly (string Name, DojoKeyboardMcu.ShowMode Mode)[] Themes =
+    {
+        ("single", DojoKeyboardMcu.ShowMode.SingleCustomColor),
+        ("multi", DojoKeyboardMcu.ShowMode.MultipleCustomColors),
+        ("volcano", DojoKeyboardMcu.ShowMode.Volcano),
+        ("jungle", DojoKeyboardMcu.ShowMode.Jungle),
+        ("ocean", DojoKeyboardMcu.ShowMode.Ocean),
+        ("rainbow", DojoKeyboardMcu.ShowMode.Rainbow),
+    };
+
+    internal static int Run(string[] args)
+    {
+        bool commit = args.Contains("--commit");
+
+        var logging = new LoggingService();
+        using var backend = new DojoPerKeyBackend(logging);
+
+        Console.WriteLine("=== OmenCore per-key backend ===\n");
+
+        if (!backend.InitializeAsync().GetAwaiter().GetResult())
+        {
+            Console.WriteLine("  Backend unavailable. Neither mi_03 (MCU) nor mi_04 (LampArray) opened.");
+            Console.WriteLine("  Candidates seen:");
+            var candidates = DojoKeyboardMcu.DescribeCandidates();
+            if (candidates.Count == 0) Console.WriteLine("    none - no Darfon keyboard on this machine");
+            foreach (string line in candidates) Console.WriteLine($"    {line}");
+            return 1;
+        }
+
+        Console.WriteLine($"  backend  : {backend.Name}");
+        Console.WriteLine($"  keys     : {backend.KeyCount} addressable lamps");
+        Console.WriteLine($"  effects  : {(backend.SupportsDeviceEffects ? "available (mi_03 open)" : "UNAVAILABLE - mi_03 did not open")}");
+        Console.WriteLine();
+
+        // Read first, always, and print it whether or not anything is about to be written. It is
+        // the only "before" this keyboard offers, and restoring what was there needs it.
+        PrintEffect("as found", backend.ReadDeviceEffect());
+        Console.WriteLine();
+
+        if (args.Contains("--read-effect")) return 0;
+
+        int rc = 0;
+        if (Arg(args, "--brightness") != null) rc |= Brightness(backend, args, commit);
+        if (Arg(args, "--backlight") != null) rc |= Backlight(backend, args, commit);
+        if (Arg(args, "--zones") != null) rc |= Zones(backend, args, commit);
+        if (Arg(args, "--keys") != null) rc |= Keys(backend, args, commit);
+        if (Arg(args, "--effect") != null) rc |= SetEffect(backend, args, commit);
+        if (args.Contains("--restore-default")) rc |= RestoreDefault(backend, commit);
+        if (args.Contains("--persist")) rc |= Persist(backend, commit);
+
+        return rc;
+    }
+
+    // ── Effects ────────────────────────────────────────────────────────────────────
+
+    private static int SetEffect(DojoPerKeyBackend backend, string[] args, bool commit)
+    {
+        string name = Arg(args, "--effect")!.Trim().ToLowerInvariant();
+        var match = Effects.FirstOrDefault(e => e.Name == name);
+        if (match.Name == null)
+        {
+            Console.WriteLine($"  Unknown --effect '{name}'. One of: {string.Join(", ", Effects.Select(e => e.Name))}");
+            return 1;
+        }
+
+        var colors = ParseColors(Arg(args, "--colors"));
+        string themeName = (Arg(args, "--theme") ?? (colors.Count > 0 ? "" : "jungle")).Trim().ToLowerInvariant();
+
+        DojoKeyboardMcu.ShowMode showMode;
+        byte colorNumber;
+
+        if (colors.Count > 0 && themeName.Length == 0)
+        {
+            showMode = colors.Count > 1
+                ? DojoKeyboardMcu.ShowMode.MultipleCustomColors
+                : DojoKeyboardMcu.ShowMode.SingleCustomColor;
+
+            // Zero-based. Four custom colours send 3, which is the field's single sharpest edge.
+            colorNumber = (byte)(colors.Count - 1);
+        }
+        else
+        {
+            var theme = Themes.FirstOrDefault(t => t.Name == themeName);
+            if (theme.Name == null)
+            {
+                Console.WriteLine($"  Unknown --theme '{themeName}'. One of: {string.Join(", ", Themes.Select(t => t.Name))}");
+                return 1;
+            }
+            showMode = theme.Mode;
+            colorNumber = DojoKeyboardMcu.ColorNumberPreset;
+        }
+
+        var record = new DojoKeyboardMcu.EffectRecord
+        {
+            Effect = match.Wire,
+            ShowMode = showMode,
+            ColorNumber = colorNumber,
+            Speed = ParseSpeed(Arg(args, "--speed")),
+            Brightness = 0,
+            Direction = ParseDirection(Arg(args, "--direction")),
+            RippleSize = ParseByte(Arg(args, "--size"), 1),
+            RaindropFrequency = (byte)ParseSpeed(Arg(args, "--speed")),
+            InnerBrightness = ParseByte(Arg(args, "--inner"), 0),
+            OuterBrightness = ParseByte(Arg(args, "--outer"), 0),
+            Colors = colors.ToArray()
+        };
+
+        Console.WriteLine("  plan     : install effect");
+        PrintEffect("requested", record);
+
+        if (!commit)
+        {
+            Console.WriteLine("\n  DRY RUN. Nothing written. Add --commit to send it.");
+            return 0;
+        }
+
+        var result = backend.SetDeviceEffect(record);
+        Console.WriteLine();
+        Console.WriteLine($"  accepted : {result.BackendReportedSuccess}" +
+                          (result.FailureReason == null ? "" : $"   ({result.FailureReason})"));
+        Console.WriteLine($"  readback : {(result.SupportsVerification ? (result.VerificationPassed ? "matches" : "DISAGREES") : "the MCU did not answer")}");
+        Console.WriteLine();
+        PrintEffect("now", backend.ReadDeviceEffect());
+
+        Console.WriteLine();
+        Console.WriteLine("  LOOK AT THE KEYBOARD. The readback says the MCU installed it, not that");
+        Console.WriteLine("  anything is visible - and the effect holds after this process exits, so");
+        Console.WriteLine("  there is no rush.");
+
+        return result.BackendReportedSuccess ? 0 : 1;
+    }
+
+    // ── Static colour ──────────────────────────────────────────────────────────────
+
+    private static int Zones(DojoPerKeyBackend backend, string[] args, bool commit)
+    {
+        var colors = ParseColors(Arg(args, "--zones"));
+        if (colors.Count == 0)
+        {
+            Console.WriteLine("  --zones takes 1-4 RRGGBB values, comma separated.");
+            return 1;
+        }
+
+        // One colour means "the whole keyboard", which is what a caller typing one colour means.
+        var zones = new Color[4];
+        for (int i = 0; i < 4; i++)
+        {
+            var c = colors[Math.Min(i, colors.Count - 1)];
+            zones[i] = Color.FromArgb(c.R, c.G, c.B);
+        }
+
+        Console.WriteLine("  plan     : paint " + backend.KeyCount + " lamps, zoned left to right by physical position");
+        Console.WriteLine("             " + string.Join("  ", zones.Select(z => $"#{z.R:X2}{z.G:X2}{z.B:X2}")));
+
+        if (!commit)
+        {
+            Console.WriteLine("\n  DRY RUN. Nothing written. Add --commit to send it.");
+            return 0;
+        }
+
+        var result = backend.SetZoneColorsAsync(zones).GetAwaiter().GetResult();
+        Console.WriteLine();
+        Console.WriteLine($"  accepted : {result.BackendReportedSuccess}" +
+                          (result.FailureReason == null ? "" : $"   ({result.FailureReason})"));
+        Console.WriteLine();
+        Console.WriteLine("  There is NO colour readback on this interface, so accepted is the whole");
+        Console.WriteLine("  software claim. Only looking settles it.");
+        Console.WriteLine();
+        Console.WriteLine("    four bands, left to right  -> per-key colour works and the zoning is right");
+        Console.WriteLine("    scattered patches          -> colour works, the zone mapping is wrong");
+        Console.WriteLine("    the effect still running   -> host control did not take the lamps away from");
+        Console.WriteLine("                                  the MCU. Try --effect off first.");
+        Console.WriteLine("    rainbow, repainting        -> Windows Dynamic Lighting owns it; turn it off");
+        Console.WriteLine();
+        Console.WriteLine("  The keyboard is NOT handed back to its own effects - that is deliberate, and");
+        Console.WriteLine("  it is what makes the picture survive this process exiting. To undo:");
+        Console.WriteLine("    LightingProbe --effect wave --theme rainbow --commit    (or --restore-default)");
+
+        return result.BackendReportedSuccess ? 0 : 1;
+    }
+
+    /// <summary>
+    /// Colour named keys and LEAVE EVERYTHING ELSE ALONE.
+    ///
+    /// The difference from --key is the whole point. --key blanks the rest of the keyboard, which
+    /// is the right shape for proving a lamp index is correct and the wrong shape for using the
+    /// feature: a caller lighting WASD does not want the other 116 keys turned off. Nothing here
+    /// touches a lamp that was not named.
+    /// </summary>
+    private static int Keys(DojoPerKeyBackend backend, string[] args, bool commit)
+    {
+        var map = backend.GetKeyMap();
+        if (map.Count == 0)
+        {
+            Console.WriteLine("  No lamp map; the LampArray interface did not open.");
+            return 1;
+        }
+
+        var wanted = new Dictionary<ushort, Color>();
+        var unresolved = new List<string>();
+
+        foreach (string pair in (Arg(args, "--keys") ?? "")
+                     .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            string[] halves = pair.Split('=', 2);
+            string name = halves[0].Trim();
+            string hex = halves.Length > 1 ? halves[1] : Arg(args, "--color") ?? "FF0000";
+
+            var color = ParseColors(hex).FirstOrDefault();
+            if (color == default && hex.TrimStart('#').ToUpperInvariant() != "000000")
+            {
+                unresolved.Add($"{name} (bad colour '{hex}')");
+                continue;
+            }
+
+            if (!SetKey.TryParseUsage(name, out byte usage))
+            {
+                unresolved.Add($"{name} (unknown key)");
+                continue;
+            }
+
+            // One usage can sit under several lamps - Space spans five on this keyboard, Shift
+            // three. Lighting "Space" means lighting all of them, so every match is taken rather
+            // than the first.
+            var hits = map.Where(l => l.KeyUsage == usage).ToList();
+            if (hits.Count == 0)
+            {
+                unresolved.Add($"{name} (usage 0x{usage:X2} carried by no lamp)");
+                continue;
+            }
+
+            foreach (var lamp in hits)
+                wanted[lamp.LampId] = Color.FromArgb(color.R, color.G, color.B);
+        }
+
+        foreach (string bad in unresolved) Console.WriteLine($"  skipped  : {bad}");
+
+        if (wanted.Count == 0)
+        {
+            Console.WriteLine("  Nothing to write. Format: --keys W=FF0000,A=00FF00,S=0000FF,D=FFFF00");
+            return 1;
+        }
+
+        Console.WriteLine($"  plan     : colour {wanted.Count} lamp(s), leaving the other {map.Count - wanted.Count} untouched");
+
+        if (!commit)
+        {
+            Console.WriteLine("\n  DRY RUN. Nothing written. Add --commit to send it.");
+            return 0;
+        }
+
+        bool ok = backend.SetKeyColors(wanted);
+        Console.WriteLine($"  accepted : {ok}");
+        Console.WriteLine();
+        Console.WriteLine("  Untouched lamps keep whatever they were showing - so if an effect was");
+        Console.WriteLine("  running, the rest of the keyboard is now a frozen frame of it.");
+
+        return ok ? 0 : 1;
+    }
+
+    // ── The rest ───────────────────────────────────────────────────────────────────
+
+    private static int Brightness(DojoPerKeyBackend backend, string[] args, bool commit)
+    {
+        int level = int.TryParse(Arg(args, "--brightness"), out int n) ? Math.Clamp(n, 0, 100) : 100;
+        bool mcuOnly = args.Contains("--mcu-only");
+
+        Console.WriteLine(mcuOnly
+            ? $"  plan     : brightness {level}  (MCU command 0x0C ALONE - no lamp repaint)"
+            : $"  plan     : brightness {level}  (MCU command 0x0C, plus the LampArray intensity channel)");
+
+        if (!commit)
+        {
+            Console.WriteLine("\n  DRY RUN. Nothing written. Add --commit to send it.");
+            return 0;
+        }
+
+        bool ok = mcuOnly
+            ? backend.SetMcuBrightnessOnly((byte)level)
+            : backend.SetBrightnessAsync(level).GetAwaiter().GetResult();
+
+        Console.WriteLine($"  accepted : {ok}");
+        Console.WriteLine();
+
+        if (mcuOnly)
+        {
+            Console.WriteLine("  Nothing else was sent, so whatever the keyboard does now is 0x0C's doing.");
+            Console.WriteLine("  Run this while a DEVICE EFFECT is displayed - over a host-painted picture");
+            Console.WriteLine("  the lamps carry their own intensity and the attribution is muddied again.");
+        }
+        else
+        {
+            Console.WriteLine("  TWO levers moved: 0x0C and the lamp intensity. Over a static picture the");
+            Console.WriteLine("  repaint alone explains any dimming, so this CANNOT tell you whether 0x0C");
+            Console.WriteLine("  works. Add --mcu-only, over a running effect, to attribute it.");
+        }
+
+        return ok ? 0 : 1;
+    }
+
+    private static int Backlight(DojoPerKeyBackend backend, string[] args, bool commit)
+    {
+        string want = Arg(args, "--backlight")!.Trim().ToLowerInvariant();
+        if (want is not ("on" or "off"))
+        {
+            Console.WriteLine("  --backlight takes on or off.");
+            return 1;
+        }
+
+        Console.WriteLine($"  plan     : backlight {want}  (leaves the installed effect in place)");
+
+        if (!commit)
+        {
+            Console.WriteLine("\n  DRY RUN. Nothing written. Add --commit to send it.");
+            return 0;
+        }
+
+        bool ok = backend.SetBacklightEnabledAsync(want == "on").GetAwaiter().GetResult();
+        Console.WriteLine($"  accepted : {ok}");
+        return ok ? 0 : 1;
+    }
+
+    private static int RestoreDefault(DojoPerKeyBackend backend, bool commit)
+    {
+        Console.WriteLine("  plan     : restore HP's firmware default lighting");
+
+        if (!commit)
+        {
+            Console.WriteLine("\n  DRY RUN. Nothing written. Add --commit to send it.");
+            return 0;
+        }
+
+        bool ok = backend.RestoreFirmwareDefaults();
+        Console.WriteLine($"  accepted : {ok}");
+        Console.WriteLine();
+        PrintEffect("now", backend.ReadDeviceEffect());
+        return ok ? 0 : 1;
+    }
+
+    private static int Persist(DojoPerKeyBackend backend, bool commit)
+    {
+        Console.WriteLine("  plan     : store the current lighting to the MCU's flash");
+        Console.WriteLine("             THIS IS A FLASH WRITE. It is what makes an effect survive a power");
+        Console.WriteLine("             cycle, and it is not something to repeat casually.");
+
+        if (!commit)
+        {
+            Console.WriteLine("\n  DRY RUN. Nothing written. Add --commit to send it.");
+            return 0;
+        }
+
+        bool ok = backend.StoreToFlash();
+        Console.WriteLine($"  accepted : {ok}");
+        return ok ? 0 : 1;
+    }
+
+    // ── Printing and parsing ───────────────────────────────────────────────────────
+
+    private static void PrintEffect(string label, DojoKeyboardMcu.EffectRecord? record)
+    {
+        if (record == null)
+        {
+            Console.WriteLine($"  {label,-9}: the MCU did not answer the readback");
+            return;
+        }
+
+        var r = record.Value;
+        string colors = string.Join(" ", (r.Colors ?? Array.Empty<(byte R, byte G, byte B)>())
+            .Select(c => $"#{c.R:X2}{c.G:X2}{c.B:X2}"));
+
+        string palette = r.ColorNumber == DojoKeyboardMcu.ColorNumberPreset
+            ? $"preset {r.ShowMode}"
+            : $"{r.ColorNumber + 1} custom colour(s), {colors}";
+
+        Console.WriteLine($"  {label,-9}: {r.Effect} ({(byte)r.Effect}), {palette}");
+        Console.WriteLine($"             speed {r.Speed}, direction {r.Direction}, size {r.RippleSize}, " +
+                          $"raindrop {r.RaindropFrequency}, brightness {r.Brightness}, " +
+                          $"inner {r.InnerBrightness}, outer {r.OuterBrightness}");
+    }
+
+    private static List<(byte R, byte G, byte B)> ParseColors(string? spec)
+    {
+        var list = new List<(byte, byte, byte)>();
+        if (string.IsNullOrWhiteSpace(spec)) return list;
+
+        foreach (string part in spec.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            string h = part.TrimStart('#');
+            if (h.Length != 6) continue;
+            try
+            {
+                list.Add((Convert.ToByte(h[..2], 16), Convert.ToByte(h[2..4], 16), Convert.ToByte(h[4..], 16)));
+            }
+            catch { /* a malformed swatch is skipped, and the printed plan shows what survived */ }
+        }
+
+        return list.Take(4).ToList();
+    }
+
+    private static DojoKeyboardMcu.EffectSpeed ParseSpeed(string? s) => (s ?? "medium").Trim().ToLowerInvariant() switch
+    {
+        "slow" or "0" => DojoKeyboardMcu.EffectSpeed.Slow,
+        "fast" or "2" => DojoKeyboardMcu.EffectSpeed.Fast,
+        _ => DojoKeyboardMcu.EffectSpeed.Medium
+    };
+
+    private static DojoKeyboardMcu.EffectDirection ParseDirection(string? s) => (s ?? "right").Trim().ToLowerInvariant() switch
+    {
+        "inward" => DojoKeyboardMcu.EffectDirection.Inward,
+        "outward" => DojoKeyboardMcu.EffectDirection.Outward,
+        "left" => DojoKeyboardMcu.EffectDirection.RightToLeft,
+        "up" => DojoKeyboardMcu.EffectDirection.Up,
+        "down" => DojoKeyboardMcu.EffectDirection.Down,
+        "cw" => DojoKeyboardMcu.EffectDirection.Clockwise,
+        "ccw" => DojoKeyboardMcu.EffectDirection.CounterClockwise,
+        _ => DojoKeyboardMcu.EffectDirection.LeftToRight
+    };
+
+    private static byte ParseByte(string? s, byte fallback) =>
+        byte.TryParse(s, out byte b) ? b : fallback;
+
+    private static string? Arg(string[] args, string name)
+    {
+        int i = Array.IndexOf(args, name);
+        return i >= 0 && i + 1 < args.Length ? args[i + 1] : null;
+    }
+}

--- a/tools/LightingProbe/Program.cs
+++ b/tools/LightingProbe/Program.cs
@@ -10,6 +10,11 @@
 //   LightingProbe.exe --autonomous <on|off>  device effect engine on/off  [no colour written]
 //   LightingProbe.exe --self-test   drive a pattern a human can check       [WRITES colours]
 //   LightingProbe.exe --key <key>   light ONE key, blank the rest    [WRITES, needs --commit]
+//   LightingProbe.exe --read-effect     what the keyboard MCU is holding        [read-only]
+//   LightingProbe.exe --effect <name>   install a device-side animation  [WRITES, --commit]
+//   LightingProbe.exe --zones <colors>  static per-key colour, 4 bands  [WRITES, --commit]
+//   LightingProbe.exe --keys W=FF0000,A=00FF00   colour named keys only  [WRITES, --commit]
+//   LightingProbe.exe --lightbar <colors>        the LIGHT BAR, not the keyboard  [--commit]
 //
 // The default modes write nothing: no colour is set, no brightness is changed, no BIOS state is
 // modified. --self-test and --key are the exceptions, and they exist because the LampArray spec has
@@ -31,16 +36,38 @@
 // exits. So per-key control does not need a repaint thread. The 30 Hz loop in --self-test was a
 // workaround for a stuck keyboard plus a strobe bug in this tool, not for the protocol.
 //
-// The vendor per-key path on interface mi_03 is NOT here. It speaks HP's own DojoPerKeyRGB format
-// straight to the MCU and verifies nothing in this repo, so it lives with the machine
-// investigation that produced it: omen-max-16/tools/hid/. What it found matters to this code
-// though - that MCU acknowledges every colour write and displays none of them, and the mi_04
-// LampArray below accepts writes it does not honour - so neither path can light this keyboard yet.
+// BOTH INTERFACES WORK, and they do different jobs. mi_04 (the LampArray, above) is the static
+// per-key colour path. mi_03 is the MCU's own command surface, where the animation engine lives:
+// all twelve effects OMEN Gaming Hub offers are one command-3 frame each, rendered device-side. It
+// is reached through --effect / --read-effect below, which drive OmenCore's DojoPerKeyBackend - the
+// shipping type - rather than a copy of the protocol. Map and evidence:
+// omen-max-16/reference/keyboard-mcu.md.
+//
+// An earlier note here said the MCU acknowledges colour writes and displays none of them, and that
+// neither path could light this keyboard. Both halves were artefacts of a stuck EC state that has
+// since been cleared, and of reading the wrong HP SDK for the protocol.
 
 using OmenCore.Tools.LightingProbe;
 
 if (args.Contains("--self-test"))
     return SelfTest.Run(args);
+
+// Drives the per-key editor's view-model, whose failures were all above the transport.
+if (args.Contains("--map-editor"))
+    return MapEditor.Run(args);
+
+// The light bar is a different device on a different transport, so it gets its own entry rather
+// than a flag inside the keyboard path.
+if (args.Any(a => a.StartsWith("--lightbar", StringComparison.Ordinal)))
+    return LightBar.Run(args);
+
+// Ahead of --key: --read-effect and friends are the MCU path, and --key is the LampArray one.
+if (args.Contains("--effect") || args.Contains("--read-effect") || args.Contains("--zones") ||
+    args.Contains("--keys") || args.Contains("--brightness") || args.Contains("--backlight") ||
+    args.Contains("--restore-default") || args.Contains("--persist"))
+{
+    return PerKey.Run(args);
+}
 
 if (args.Contains("--key"))
     return SetKey.Run(args);

--- a/tools/LightingProbe/Program.cs
+++ b/tools/LightingProbe/Program.cs
@@ -9,14 +9,27 @@
 //   LightingProbe.exe --map         walk every lamp and build an id -> key map [read-only]
 //   LightingProbe.exe --autonomous <on|off>  device effect engine on/off  [no colour written]
 //   LightingProbe.exe --self-test   drive a pattern a human can check       [WRITES colours]
+//   LightingProbe.exe --key <key>   light ONE key, blank the rest    [WRITES, needs --commit]
 //
 // The default modes write nothing: no colour is set, no brightness is changed, no BIOS state is
-// modified. --self-test is the exception, and it exists because the LampArray spec has no colour
-// readback - so whether a write reached the keys is a question only a person looking at the
-// keyboard can answer. It restores the device to its own effects on the way out.
+// modified. --self-test and --key are the exceptions, and they exist because the LampArray spec has
+// no colour readback - so whether a write reached the keys is a question only a person looking at
+// the keyboard can answer. Both restore the device to its own effects on the way out.
 //
-//   --hold <seconds>   how long --self-test holds the pattern (default 10)
+//   --hold <seconds>   run a repaint loop for N seconds (--self-test defaults to 10; --key does
+//                      ONE write unless this is given)
 //   --static           --self-test writes once and leaves it, with no hold loop
+//   --key <key>        key name (F4, Esc, A, Space), HID usage (0x3D), or a bare lamp id
+//   --color RRGGBB     colour for --key (default FF0000)
+//   --commit           required by --key; without it the key is resolved and nothing is sent
+//
+// --key is the narrower test: bands prove reports land somewhere, one lit key proves the lamp INDEX
+// is right, which is what a per-key feature needs. Run --map first for the authoritative table.
+//
+// Measured 2026-08-06 on 8D87, after the keyboard was recovered from its stuck state: --key F4
+// lights exactly F4, the map is correct, and ONE report is enough - it stays lit after the process
+// exits. So per-key control does not need a repaint thread. The 30 Hz loop in --self-test was a
+// workaround for a stuck keyboard plus a strobe bug in this tool, not for the protocol.
 //
 // The vendor per-key path on interface mi_03 is NOT here. It speaks HP's own DojoPerKeyRGB format
 // straight to the MCU and verifies nothing in this repo, so it lives with the machine
@@ -28,6 +41,9 @@ using OmenCore.Tools.LightingProbe;
 
 if (args.Contains("--self-test"))
     return SelfTest.Run(args);
+
+if (args.Contains("--key"))
+    return SetKey.Run(args);
 
 if (args.Contains("--map"))
     return LampMap.Run();

--- a/tools/LightingProbe/Program.cs
+++ b/tools/LightingProbe/Program.cs
@@ -1,0 +1,45 @@
+// LightingProbe - hardware verification harness for OmenCore's keyboard lighting detection.
+//
+// Drives the shipping OmenCore.Hardware types directly, so what is verified is what ships.
+// Requires administrator rights for the WMI half.
+//
+//   LightingProbe.exe               both sections below                     [read-only]
+//   LightingProbe.exe --wmi         BIOS lighting topology and capability   [read-only]
+//   LightingProbe.exe --lamps       HID LampArray descriptors               [read-only]
+//   LightingProbe.exe --map         walk every lamp and build an id -> key map [read-only]
+//   LightingProbe.exe --autonomous <on|off>  device effect engine on/off  [no colour written]
+//   LightingProbe.exe --self-test   drive a pattern a human can check       [WRITES colours]
+//
+// The default modes write nothing: no colour is set, no brightness is changed, no BIOS state is
+// modified. --self-test is the exception, and it exists because the LampArray spec has no colour
+// readback - so whether a write reached the keys is a question only a person looking at the
+// keyboard can answer. It restores the device to its own effects on the way out.
+//
+//   --hold <seconds>   how long --self-test holds the pattern (default 10)
+//   --static           --self-test writes once and leaves it, with no hold loop
+//
+// The vendor per-key path on interface mi_03 is NOT here. It speaks HP's own DojoPerKeyRGB format
+// straight to the MCU and verifies nothing in this repo, so it lives with the machine
+// investigation that produced it: omen-max-16/tools/hid/. What it found matters to this code
+// though - that MCU acknowledges every colour write and displays none of them, and the mi_04
+// LampArray below accepts writes it does not honour - so neither path can light this keyboard yet.
+
+using OmenCore.Tools.LightingProbe;
+
+if (args.Contains("--self-test"))
+    return SelfTest.Run(args);
+
+if (args.Contains("--map"))
+    return LampMap.Run();
+
+if (args.Contains("--autonomous"))
+    return Autonomous.Run(args);
+
+bool wmi = args.Contains("--wmi");
+bool lamps = args.Contains("--lamps");
+if (!wmi && !lamps) { wmi = lamps = true; }
+
+int rc = 0;
+if (wmi) rc |= Wmi.Run();
+if (lamps) rc |= Lamps.Run();
+return rc;

--- a/tools/LightingProbe/SelfTest.cs
+++ b/tools/LightingProbe/SelfTest.cs
@@ -1,0 +1,149 @@
+// The one thing software cannot check: whether a colour actually reached the keys.
+//
+// There is no colour readback anywhere in the HID LampArray spec, so this mode cannot report
+// success. What it can do is drive an unmistakable, self-describing pattern and tell a person
+// exactly what they should be seeing - which turns "did the write work" into a question someone
+// can answer in two seconds by looking down.
+//
+// The pattern is chosen so that a PARTIAL success is still readable. Solid red everywhere would
+// look identical whether one report landed or all fifteen did.
+//
+// WRITES lamp colours. Restores host control and asks the device to resume its own effects on
+// the way out, so nothing is left in a state a reboot would be needed to clear.
+
+using OmenCore.Hardware;
+
+namespace OmenCore.Tools.LightingProbe;
+
+internal static class SelfTest
+{
+    internal static int Run(string[] args)
+    {
+        // --static writes the pattern once and leaves it, with no hold loop. It answers a
+        // different question from the loop: whether a SINGLE write sticks. If it does, the loop
+        // was only ever needed to out-run the device's own effect.
+        bool staticOnce = args.Contains("--static");
+
+        int holdSeconds = 10;
+        int i = Array.IndexOf(args, "--hold");
+        if (i >= 0 && i + 1 < args.Length && int.TryParse(args[i + 1], out int parsed))
+            holdSeconds = Math.Clamp(parsed, 2, 120);
+
+        Console.WriteLine("=== LampArray self-test ===\n");
+        Console.WriteLine("This WRITES colours to the keyboard. Nothing it does survives a reboot,");
+        Console.WriteLine("and the device is handed back to its own effects at the end.\n");
+
+        var arrays = HidLampArray.OpenAll();
+        var keyboard = arrays.FirstOrDefault(a => a.Kind == 1 && a.LampCount > 8);
+
+        if (keyboard == null)
+        {
+            Console.WriteLine("No keyboard-kind LampArray with more than 8 lamps found.");
+            foreach (var a in arrays)
+                Console.WriteLine($"  (saw kind {a.Kind}, {a.LampCount} lamps, {a.VendorId:X4}:{a.ProductId:X4})");
+            foreach (var a in arrays) a.Dispose();
+            return 1;
+        }
+
+        Console.WriteLine($"Target: {keyboard.VendorId:X4}:{keyboard.ProductId:X4}, " +
+                          $"{keyboard.LampCount} lamps, min update {keyboard.MinUpdateInterval.TotalMilliseconds:F0} ms\n");
+
+        try
+        {
+            bool tookControl = keyboard.SetAutonomousMode(false);
+            Console.WriteLine($"  host control requested : {(tookControl ? "accepted" : "REFUSED")}");
+
+            // Thirds, in three unmistakable colours. If only the first report lands, the keyboard
+            // is one third red and the rest untouched - which looks different from every-report
+            // landing, and different again from nothing landing.
+            ushort last = (ushort)(keyboard.LampCount - 1);
+            ushort third = (ushort)(keyboard.LampCount / 3);
+            ushort twoThirds = (ushort)(keyboard.LampCount * 2 / 3);
+
+            bool a = keyboard.SetRange(0, third, 255, 0, 0);
+            bool b = keyboard.SetRange((ushort)(third + 1), twoThirds, 0, 255, 0);
+            bool c = keyboard.SetRange((ushort)(twoThirds + 1), last, 0, 0, 255);
+
+            Console.WriteLine($"  red   lamps {$"{0}-{third}",-9} : {Accepted(a)}");
+            Console.WriteLine($"  green lamps {$"{third + 1}-{twoThirds}",-9} : {Accepted(b)}");
+            Console.WriteLine($"  blue  lamps {$"{twoThirds + 1}-{last}",-9} : {Accepted(c)}");
+            // Exercise the multi-update report too. It has a different layout from the range
+            // update - a packed id array followed by a packed channel array, with both sized for
+            // eight lamps whether or not all eight are used - so "range update works" says
+            // nothing about it. Sixteen lamps forces a second batch, which is also where the
+            // update-complete flag handling would show up if it were wrong.
+            var white = new List<HidLampArray.LampColor>();
+            ushort whiteCount = keyboard.LampCount < 16 ? keyboard.LampCount : (ushort)16;
+            for (ushort id = 0; id < whiteCount; id++)
+                white.Add(new HidLampArray.LampColor(id, 255, 255, 255));
+
+            bool multi = keyboard.SetLamps(white);
+            Console.WriteLine($"  white lamps 0-{white.Count - 1,-6} : {Accepted(multi)}   (multi-update, {(white.Count + 7) / 8} batches)");
+            Console.WriteLine();
+            Console.WriteLine("  \"accepted\" means the device took the report without stalling, which says the");
+            Console.WriteLine("  report layout is right. It does NOT say the keys changed colour - there is no");
+            Console.WriteLine("  colour readback to check that with.");
+
+
+            Console.WriteLine();
+            Console.WriteLine("  LOOK AT THE KEYBOARD NOW. What you should see, left to right:");
+            Console.WriteLine("    the first third RED, the middle third GREEN, the last third BLUE,");
+            Console.WriteLine("    except the first 16 lamps, which the multi-update turned WHITE.");
+            Console.WriteLine();
+            Console.WriteLine("    all three bands, in order  -> the write path works");
+            Console.WriteLine("    only some bands            -> partial; report which ones");
+            Console.WriteLine("    a rainbow, or flickering   -> the device's own effect is outrunning us,");
+            Console.WriteLine("                                  or Windows Dynamic Lighting owns the device");
+            Console.WriteLine("                                  (Settings > Personalisation > Dynamic");
+            Console.WriteLine("                                  Lighting). Both look the same from here.");
+            Console.WriteLine();
+            if (staticOnce)
+            {
+                Console.WriteLine("  --static: written once, no hold loop. Whatever is on the keyboard now is");
+                Console.WriteLine("  what a single write leaves behind. The device is NOT handed back to its");
+                Console.WriteLine("  own effect engine, so nothing here will repaint it.");
+                return 0;
+            }
+
+            Console.WriteLine($"  Holding {holdSeconds}s ...");
+
+            // Drive at the device's own update rate, not once a second.
+            //
+            // Measured on board 8D87: a 1 Hz hold produced a RAINBOW with a few keys flickering
+            // once a second - the device's own effect running at ~30 Hz, with each of our frames
+            // visible for one repaint before being painted over. The reports were landing; they
+            // were just being outrun.
+            //
+            // The HID LampArray spec lets a device resume autonomous effects when the host stops
+            // updating, and MinUpdateInterval is what "updating" means. At 33 ms this host looked
+            // idle between frames, so AutonomousMode was accepted and then effectively undone.
+            // So: re-send the control report periodically as well as the colours, and pace the
+            // loop off the device's own declared interval rather than a number picked by hand.
+            int frameMs = Math.Max(16, (int)keyboard.MinUpdateInterval.TotalMilliseconds);
+            int frames = holdSeconds * 1000 / frameMs;
+            int framesPerSecond = Math.Max(1, 1000 / frameMs);
+
+            for (int f = 0; f < frames; f++)
+            {
+                if (f % framesPerSecond == 0) keyboard.SetAutonomousMode(false);
+
+                keyboard.SetRange(0, third, 255, 0, 0);
+                keyboard.SetRange((ushort)(third + 1), twoThirds, 0, 255, 0);
+                keyboard.SetRange((ushort)(twoThirds + 1), last, 0, 0, 255);
+                keyboard.SetLamps(white);
+                Thread.Sleep(frameMs);
+            }
+
+            Console.WriteLine("\n  Handing the keyboard back to its own effects.");
+            keyboard.SetAutonomousMode(true);
+            return 0;
+        }
+        finally
+        {
+            keyboard.SetAutonomousMode(true);
+            foreach (var arr in arrays) arr.Dispose();
+        }
+    }
+
+    private static string Accepted(bool ok) => ok ? "accepted" : "REFUSED";
+}

--- a/tools/LightingProbe/SetKey.cs
+++ b/tools/LightingProbe/SetKey.cs
@@ -1,0 +1,280 @@
+// Light exactly ONE key, and blank every other one.
+//
+// This is the narrowest possible test of per-key control, and it is deliberately not the
+// three-band pattern --self-test draws. Bands prove reports are landing somewhere; one lit key on
+// an otherwise black keyboard proves the lamp INDEX is right, which is the thing a per-key feature
+// actually needs. A wrong index still produces a lit key - just the wrong one - and that is
+// readable at a glance in a way a band is not.
+//
+// Board 8D87 note: the lamp-attributes response ignores the requested id and free-runs, so the map
+// is built by keying on the id the DEVICE reports (same approach as --map). A caller that assumed
+// "ask for N, get N" would light the wrong key and have no way to tell.
+//
+// WRITES lamp colours. Gated behind --commit, like every other write in this investigation: the
+// dry run resolves the key, prints the lamp id it would drive, and sends nothing.
+//
+// Two things will fight you, and both look identical from here - a rainbow that ignores you:
+//   * Windows Dynamic Lighting owns LampArray devices when enabled and repaints continuously.
+//   * The device's own effect engine runs at ~30 Hz and resumes whenever the host looks idle.
+// Stop OGH's background process and turn Dynamic Lighting off before trusting a negative result.
+
+using OmenCore.Hardware;
+
+namespace OmenCore.Tools.LightingProbe;
+
+internal static class SetKey
+{
+    internal static int Run(string[] args)
+    {
+        string keyArg = Arg(args, "--key") ?? "F4";
+        string colorArg = Arg(args, "--color") ?? "FF0000";
+        bool commit = args.Contains("--commit");
+
+        // ONE WRITE IS THE DEFAULT, and that is a measured decision rather than an assumption.
+        //
+        // This mode originally always ran a 30 Hz repaint loop, inherited from --self-test, whose
+        // comment reasons that the device resumes its own effects whenever the host looks idle for
+        // longer than MinUpdateInterval. Measured 2026-08-06, after the keyboard was recovered: a
+        // single blank-around + single-lamp update, with the process then EXITING, left the key lit
+        // and steady. So AutonomousMode = 0 is honoured and persists with no host process at all.
+        //
+        // The earlier "the device outruns us" reading came from two things that were both true at
+        // the time and are not properties of the protocol: the keyboard was in the stuck state, and
+        // this file was painting the target black every frame (see BlankAround). Neither justifies a
+        // permanent repaint thread, which is what shipping this in OmenCore would have inherited.
+        //
+        // --hold <seconds> still runs the loop, because "does it decay after N seconds" is a
+        // different question from "does one write land" and only the loop can answer it.
+        bool holdRequested = Arg(args, "--hold") != null;
+        int holdSeconds = 10;
+        if (int.TryParse(Arg(args, "--hold"), out int parsedHold))
+            holdSeconds = Math.Clamp(parsedHold, 2, 120);
+
+        if (!TryParseColor(colorArg, out byte r, out byte g, out byte b))
+        {
+            Console.WriteLine($"Could not parse --color '{colorArg}'. Expected RRGGBB.");
+            return 1;
+        }
+
+        Console.WriteLine("=== Light a single key ===\n");
+
+        var arrays = HidLampArray.OpenAll();
+        var keyboard = arrays.FirstOrDefault(a => a.Kind == 1 && a.LampCount > 8);
+        if (keyboard == null)
+        {
+            Console.WriteLine("  No keyboard-kind LampArray found.");
+            foreach (var a in arrays) a.Dispose();
+            return 1;
+        }
+
+        try
+        {
+            Console.WriteLine($"  target : {keyboard.VendorId:X4}:{keyboard.ProductId:X4}, " +
+                              $"{keyboard.LampCount} lamps, min update " +
+                              $"{keyboard.MinUpdateInterval.TotalMilliseconds:F0} ms");
+
+            // Build the map the same way --map does: key on the reported id, walk an extra pass.
+            var byId = new SortedDictionary<ushort, HidLampArray.LampInfo>();
+            for (int i = 0; i < keyboard.LampCount * 2 && byId.Count < keyboard.LampCount; i++)
+            {
+                var info = keyboard.GetLampInfo((ushort)(i % keyboard.LampCount));
+                if (info != null) byId[info.Value.LampId] = info.Value;
+            }
+            if (byId.Count < keyboard.LampCount)
+                Console.WriteLine($"  WARNING: map incomplete, {byId.Count} of {keyboard.LampCount} lamps seen.");
+
+            // Resolve --key to a lamp id. A bare number is a lamp id; anything else is a key.
+            ushort lampId;
+            string label;
+            if (ushort.TryParse(keyArg, out ushort direct) && byId.ContainsKey(direct))
+            {
+                lampId = direct;
+                label = $"lamp {direct} (usage 0x{byId[direct].KeyUsage:X2})";
+            }
+            else
+            {
+                if (!TryParseUsage(keyArg, out byte usage))
+                {
+                    Console.WriteLine($"  Could not resolve --key '{keyArg}'. Try a key name (F4, Esc, A, Space),");
+                    Console.WriteLine("  a HID usage (0x3D), or a bare lamp id. Run --map for the full table.");
+                    return 1;
+                }
+                var hits = byId.Where(kv => kv.Value.KeyUsage == usage).Select(kv => kv.Key).ToList();
+                if (hits.Count == 0)
+                {
+                    Console.WriteLine($"  No lamp carries usage 0x{usage:X2}. Run --map to see what exists.");
+                    return 1;
+                }
+                if (hits.Count > 1)
+                    Console.WriteLine($"  note: usage 0x{usage:X2} maps to {hits.Count} lamps ({string.Join(", ", hits)}); using the first.");
+                lampId = hits[0];
+                label = $"'{keyArg}' -> usage 0x{usage:X2} -> lamp {lampId}";
+            }
+
+            var pos = byId[lampId];
+            Console.WriteLine($"  key    : {label}");
+            Console.WriteLine($"  at     : ({pos.XMicrometres / 1000.0:F0}, {pos.YMicrometres / 1000.0:F0}) mm");
+            Console.WriteLine($"  colour : #{r:X2}{g:X2}{b:X2}");
+            Console.WriteLine($"  plan   : blank every lamp EXCEPT {lampId}, then set lamp {lampId}");
+            Console.WriteLine($"  mode   : {(holdRequested ? $"repaint loop, {holdSeconds}s, then hand back" : "ONE write, then exit (nothing maintains it)")}");
+
+            if (!commit)
+            {
+                Console.WriteLine();
+                Console.WriteLine("  DRY RUN. Nothing was written. Re-run with --commit.");
+                return 0;
+            }
+
+            ushort last = (ushort)(keyboard.LampCount - 1);
+            var one = new List<HidLampArray.LampColor> { new(lampId, r, g, b) };
+
+            Console.WriteLine();
+            bool control = keyboard.SetAutonomousMode(false);
+            Console.WriteLine($"  host control  : {(control ? "accepted" : "REFUSED")}   (unverifiable - the control report is not readable on this device)");
+            Console.WriteLine($"  blank others  : {(BlankAround(keyboard, lampId, last) ? "accepted" : "REFUSED")}");
+            Console.WriteLine($"  set lamp {lampId,-4} : {(keyboard.SetLamps(one) ? "accepted" : "REFUSED")}");
+
+            Console.WriteLine();
+            Console.WriteLine("  \"accepted\" means the device took the report. There is no colour readback in");
+            Console.WriteLine("  the LampArray spec, so only looking can confirm it.");
+            Console.WriteLine();
+            Console.WriteLine($"  LOOK AT THE KEYBOARD. Expect: everything dark except ONE key lit #{r:X2}{g:X2}{b:X2}.");
+            Console.WriteLine($"  It should be the key at x={pos.XMicrometres / 1000.0:F0} mm, y={pos.YMicrometres / 1000.0:F0} mm.");
+            Console.WriteLine();
+            Console.WriteLine("    exactly that key      -> per-key control works, and the map is right");
+            Console.WriteLine("    a different key       -> control works, the lamp index is wrong");
+            Console.WriteLine("    all dark              -> the blank landed, the single-lamp update did not");
+            Console.WriteLine("    rainbow / flickering  -> something else owns the device (DL, OGH, or the");
+            Console.WriteLine("                             device's own effect engine outrunning us)");
+
+            if (!holdRequested)
+            {
+                Console.WriteLine();
+                Console.WriteLine("  Written ONCE. This process is about to exit and nothing will maintain it,");
+                Console.WriteLine("  so whatever is on the keyboard in a minute is what one report achieves.");
+                Console.WriteLine("  The device is NOT handed back to its own effects. To restore it:");
+                Console.WriteLine("    LightingProbe --autonomous on      (or launch OGH, or reboot)");
+                return 0;
+            }
+
+            // Pace off the device's declared interval and re-assert control, or its own effect
+            // engine resumes the moment the host looks idle. See the note in SelfTest.
+            int frameMs = Math.Max(16, (int)keyboard.MinUpdateInterval.TotalMilliseconds);
+            int frames = holdSeconds * 1000 / frameMs;
+            int framesPerSecond = Math.Max(1, 1000 / frameMs);
+            Console.WriteLine();
+            Console.WriteLine($"  Holding {holdSeconds}s at {frameMs} ms/frame ...");
+
+            for (int f = 0; f < frames; f++)
+            {
+                if (f % framesPerSecond == 0) keyboard.SetAutonomousMode(false);
+                BlankAround(keyboard, lampId, last);
+                keyboard.SetLamps(one);
+                Thread.Sleep(frameMs);
+            }
+
+            Console.WriteLine("  Handing the keyboard back to its own effects.");
+            return 0;
+        }
+        finally
+        {
+            // Only hand back when a hold was asked for. The default is a single write whose whole
+            // point is that it survives this process exiting, and restoring autonomous mode here
+            // would repaint it before anyone could look.
+            if (holdRequested) keyboard.SetAutonomousMode(true);
+            foreach (var a in arrays) a.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Blank every lamp EXCEPT the target, as two ranges either side of it.
+    ///
+    /// Measured 2026-08-06: blanking 0..last and then setting the target in a second report made
+    /// the target visibly STROBE at the frame rate. Of course it did - the target was painted black
+    /// and then red every frame, with a report boundary in between. The first read of that was
+    /// "flickering, so something is fighting us", which was wrong: the fight was with the previous
+    /// line of this method. Never paint the target black.
+    /// </summary>
+    private static bool BlankAround(HidLampArray kb, ushort target, ushort last)
+    {
+        bool ok = true;
+        if (target > 0) ok &= kb.SetRange(0, (ushort)(target - 1), 0, 0, 0);
+        if (target < last) ok &= kb.SetRange((ushort)(target + 1), last, 0, 0, 0);
+        return ok;
+    }
+
+    private static string? Arg(string[] args, string name)
+    {
+        int i = Array.IndexOf(args, name);
+        return i >= 0 && i + 1 < args.Length ? args[i + 1] : null;
+    }
+
+    private static bool TryParseColor(string s, out byte r, out byte g, out byte b)
+    {
+        r = g = b = 0;
+        string h = s.Trim().TrimStart('#');
+        if (h.Length != 6) return false;
+        try
+        {
+            r = Convert.ToByte(h[..2], 16);
+            g = Convert.ToByte(h[2..4], 16);
+            b = Convert.ToByte(h[4..], 16);
+            return true;
+        }
+        catch { return false; }
+    }
+
+    /// <summary>
+    /// Inverse of LampMap.KeyName for the names worth typing, plus raw usages. Deliberately small:
+    /// --map prints the authoritative table, so this only has to cover the convenient cases.
+    /// </summary>
+    private static bool TryParseUsage(string s, out byte usage)
+    {
+        usage = 0;
+        string k = s.Trim();
+
+        if (k.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            return byte.TryParse(k[2..], System.Globalization.NumberStyles.HexNumber, null, out usage);
+
+        if (k.Length == 1)
+        {
+            char c = char.ToUpperInvariant(k[0]);
+            if (c is >= 'A' and <= 'Z') { usage = (byte)(0x04 + (c - 'A')); return true; }
+            if (c is >= '1' and <= '9') { usage = (byte)(0x1E + (c - '1')); return true; }
+            if (c == '0') { usage = 0x27; return true; }
+        }
+
+        if ((k.StartsWith('F') || k.StartsWith('f')) && int.TryParse(k[1..], out int n) && n is >= 1 and <= 12)
+        {
+            usage = (byte)(0x39 + n);
+            return true;
+        }
+
+        usage = k.ToLowerInvariant() switch
+        {
+            "esc" or "escape" => 0x29,
+            "enter" or "return" => 0x28,
+            "backspace" => 0x2A,
+            "tab" => 0x2B,
+            "space" or "spacebar" => 0x2C,
+            "capslock" or "caps" => 0x39,
+            "insert" or "ins" => 0x49,
+            "home" => 0x4A,
+            "pgup" or "pageup" => 0x4B,
+            "delete" or "del" => 0x4C,
+            "end" => 0x4D,
+            "pgdn" or "pagedown" => 0x4E,
+            "right" => 0x4F,
+            "left" => 0x50,
+            "down" => 0x51,
+            "up" => 0x52,
+            "menu" => 0x65,
+            "lctrl" => 0xE0,
+            "lshift" => 0xE1,
+            "lalt" => 0xE2,
+            "lgui" or "win" => 0xE3,
+            _ => 0
+        };
+        return usage != 0;
+    }
+}

--- a/tools/LightingProbe/SetKey.cs
+++ b/tools/LightingProbe/SetKey.cs
@@ -228,7 +228,7 @@ internal static class SetKey
     /// Inverse of LampMap.KeyName for the names worth typing, plus raw usages. Deliberately small:
     /// --map prints the authoritative table, so this only has to cover the convenient cases.
     /// </summary>
-    private static bool TryParseUsage(string s, out byte usage)
+    internal static bool TryParseUsage(string s, out byte usage)
     {
         usage = 0;
         string k = s.Trim();

--- a/tools/LightingProbe/Wmi.cs
+++ b/tools/LightingProbe/Wmi.cs
@@ -1,0 +1,76 @@
+// Exercises OmenCore's own keyboard-lighting detection against the BIOS, so a mistake in the
+// shipping code shows up here rather than in a user's log.
+//
+// Three commands are involved and it is easy to conflate them:
+//
+//   Default  0x2B  lighting topology   -> NbKeyboardLightingType. HP's own gate.
+//   Keyboard 0x01  lighting supported  -> bit 0 of byte 0. NOT a keyboard-type getter,
+//                                         despite being widely described as one.
+//   Keyboard 0x06  LED animation       -> wants a 128-byte reply; a 4-byte request is
+//                                         refused with RTCD 5 (wrong buffer size).
+
+using OmenCore.Hardware;
+
+namespace OmenCore.Tools.LightingProbe;
+
+internal static class Wmi
+{
+    internal static int Run()
+    {
+        Console.WriteLine("=== BIOS keyboard lighting ===\n");
+
+        using var bios = new HpWmiBios();
+        if (!bios.IsAvailable)
+        {
+            Console.WriteLine("FAIL: HP WMI BIOS unavailable. Run elevated on an HP OMEN/Victus machine.");
+            return 1;
+        }
+
+        var topology = bios.GetKeyboardLightingType();
+        var supported = bios.IsKeyboardLightingSupported();
+        var kbdType = bios.GetKeyboardType();
+        bool backlight = bios.HasBacklight();
+
+        Console.WriteLine($"  Lighting topology (Default 0x2B) : {Describe(topology)}");
+        Console.WriteLine($"  Lighting supported (Kbd 0x01 b0) : {Describe(supported)}");
+        Console.WriteLine($"  Keyboard type (mapped)           : {Describe(kbdType)}");
+        Console.WriteLine($"  HasBacklight()                   : {backlight}");
+
+        Console.WriteLine();
+        switch (topology)
+        {
+            case HpWmiBios.KeyboardLightingType.RgbPerKey:
+                Console.WriteLine("  -> Per-key RGB. The four-zone command path does NOT apply to this board.");
+                Console.WriteLine("     Note the trap: the four-zone colour block (Keyboard 0x02) still reads back");
+                Console.WriteLine("     plausibly here, because HP's ZONE_NUM is computed as (type - 4) <= 1 and a");
+                Console.WriteLine("     per-key type falls through to 4. Reading that block alone would give a");
+                Console.WriteLine("     confident wrong answer. Gate on this topology probe first.");
+                break;
+            case HpWmiBios.KeyboardLightingType.FourZoneWithNumpad:
+            case HpWmiBios.KeyboardLightingType.FourZoneWithoutNumpad:
+                Console.WriteLine("  -> Four-zone. Colours at block offset 25 + 3*zone, RGB order, Keyboard 0x02/0x03.");
+                break;
+            case HpWmiBios.KeyboardLightingType.OneZoneWithNumpad:
+            case HpWmiBios.KeyboardLightingType.OneZoneWithoutNumpad:
+                Console.WriteLine("  -> Single zone.");
+                break;
+            case HpWmiBios.KeyboardLightingType.Normal:
+                Console.WriteLine("  -> Backlit but not addressable. No colour control.");
+                break;
+            case HpWmiBios.KeyboardLightingType.None:
+                Console.WriteLine("  -> No keyboard lighting.");
+                break;
+            default:
+                Console.WriteLine("  -> Topology probe gave no usable answer on this board.");
+                Console.WriteLine("     That is information, not a failure: it means this board does not");
+                Console.WriteLine("     implement Default 0x2B and its capability has to come from elsewhere.");
+                break;
+        }
+
+        Console.WriteLine();
+        return 0;
+    }
+
+    private static string Describe<T>(T? value) where T : struct =>
+        value.HasValue ? value.Value.ToString()! : "(no answer)";
+}


### PR DESCRIPTION
# Per-key RGB and light bar for OMEN MAX 16 (board 8D87)

Measured on one machine: OMEN MAX 16-ak0098nr, board `8D87`, BIOS F.07, EC 40.38. Everything below
was confirmed on hardware — by state readback where the device offers one, and by a person looking at
the keyboard where it does not.

## What this fixes

`HidPerKeyBackend` speaks the `0x0F`/`0x42`/`0x52` command set from the `0x03F0` OMEN family, inferred
from OpenRGB. This keyboard is **Darfon `0d62:54bf`** and does not speak it. The previously guessed
PID `0x054F` does not exist on the hardware.

That mismatch also explains a long-standing field report — *"the light bar responds but the keyboard
body does not."* On a per-key chassis the four-zone commands **succeed and land on the light bar**,
which is a separate device. They always looked like successful keyboard writes, so the failure
reported as "the keyboard is broken" when it was really "that is the wrong surface".

`ApplyPerKeyGridAsync` returned a hardcoded `false`, so the existing per-key grid editor had never
sent anything on any model. It now works.

**Pressing `Fn` erased the picture.** Applying per-key colour wrote the MCU's colour map and then took
host control of the LampArray — and host control is precisely what stops the MCU drawing that map. The
picture was suppressed the moment it was sent, so the keyboard stayed on the `Fn` overlay with nothing
to repaint from. Both paths that painted keys did it. They now release host control and write the full
176-byte map, and the MCU restores the picture itself on `Fn` release, with OmenCore closed or running.

**The editor drew a coarser keyboard than the hardware has.** It enumerated cells from the device's
HID LampArray, which is *not* a subset of the MCU's colour map — 120 lamps against 176 LEDs, agreeing
on only **46 of 99 keys**. Every dual-legend key is one lamp and two LEDs, so the whole F row and
number row had a second LED nothing could reach. `KeyNum0` is 2 lamps against 3 LEDs, and both lamps
resolved to the same LED list and overwrote each other, so half the key was inert. The Omen,
Calculator, Settings, Power, `Fn` and Copilot keys have **no lamp at all** yet own live LEDs, so they
were absent from the editor while every apply still lit them. The editor now draws from the layout
table instead: one cell per LED, inside its own key's cap.

`KeyboardLightingServiceV2`'s no-model-config fallback list omitted `KeyboardMethod.HidPerKey`, so a
per-key keyboard was invisible to detection — and because the four-zone paths "succeed" on the bar,
probing stopped at a backend that cannot touch the keyboard.

The three reactive lighting features — temperature-responsive, throttling indicator, performance-mode
synced — each carried their own copy of the same fan-out and **none of them touched the light bar**.
On a chassis with one, the most visible light in the room stayed put while every RGB peripheral in the
house changed colour. They now share one fan-out that includes the bar.

**And all three were inert regardless.** `MainViewModel` built `LightingViewModel` without
`hardwareMonitoringService` or `performanceModeService`, both optional parameters defaulting to null.
The view-model subscribes to `SampleUpdated` and `ModeApplied` in its constructor, so a null service
means the toggle enables a feature nothing ever publishes to. Nothing logged an error — nothing
failed. Two changes, because the first alone would still read as broken: the services are now passed,
and enabling a toggle **paints immediately** instead of waiting for a poll tick that is 2-10 s out and
rate-limited to 30 s when the temperature band has not changed. A feature whose first visible effect
is half a minute away gets reported as doing nothing. A null service now warns at the point the
feature is switched on rather than no-opping silently.

## What it looks like

![The measured per-key editor](https://raw.githubusercontent.com/tempestnano/omencore/assets/8d87-lighting-screenshots/per-key-editor.png)

Every LED the colour map can address, each inside its own key's cap, with the light bar's four zones
below them in the same selection space — one drag spans both. Painted red with the upper-left block
left green, which is what the hardware showed.

*(This capture predates the per-LED grid and shows the editor at one cell per key. The layout, the
selection model and the light bar row are unchanged; what it does not show is dual-legend keys
splitting in two.)*

![Keyboard effects and the light bar card](https://raw.githubusercontent.com/tempestnano/omencore/assets/8d87-lighting-screenshots/effects-and-light-bar.png)

The twelve device effects, rendered by the keyboard's own controller — they keep running with
OmenCore closed. *What's on it now?* reads the installed effect back off the device, which is the one
thing on this path that can be verified rather than assumed. Below it the light bar, with the colour,
brightness and animation controls that only exist elevated.

## Three devices

| surface | transport | does | admin? |
|---|---|---|---|
| keyboard `mi_03` | vendor HID | the twelve device animations, and the 176-LED static colour map | no |
| keyboard `mi_04` | HID LampArray | host-painted colour, 120 lamps, and per-lamp intensity | no |
| light bar | HP WMI `Keyboard/0x0B` | colour, brightness, nine animations | **yes** |
| light bar | HID LampArray `0461:0001` | colour only | no |

The keyboard's two interfaces are mutually exclusive states: installing a device effect hands the
lamps back to the firmware, and painting lamps takes them away. `DojoPerKeyBackend` owns that
handover, because a host-painted picture and a device-rendered animation cannot both own the keyboard.

**A static picture goes through `mi_03`, not `mi_04`, and that is not a preference.** The `Fn` overlay
is a device-side repaint: the MCU redraws its base layer from its own colour map when `Fn` is
released. A picture that lives only in host-painted lamps has nothing to be restored from, and the
LampArray offers no colour readback to rebuild it. So `mi_03` is the only surface on which a static
picture survives — which is also why taking host control while writing it is self-defeating.

## Reviewers: two board-scoped restrictions

Both come from a sample of **one machine**, and both are deliberate.

**1. The unelevated HID light bar path is gated to `8D87`** (`OmenBoard.SupportsHidLightBar`).

The bar is identified by *shape* — a 323 × 5 mm strip, 65:1, against the keyboard array's 2.7:1 on the
same machine — which is real detection and worth keeping on its own. The allowlist exists because one
machine cannot answer whether that virtual device exists on other OMENs, whether it *is* the bar
there, or whether Dynamic Lighting contends for it differently. It should shrink into a probe, not
grow. If you have a light bar on another board, `LightingProbe --lamps` and a report of the
Scene-kind array is exactly what would retire the gate.

**Scope is narrower than it sounds:** the HID path is consulted *only* when WMI is unavailable — i.e.
unelevated, where the light bar does nothing today. It never displaces WMI, so elevated behaviour is
unchanged, and forcing the gate to `false` restores current behaviour exactly.

**2. The per-LED editor appears only where a layout or a real lamp map is available.**
The existing 6 × 14 grid is untouched and still shown everywhere else. Two editors at once would be
two editors for one keyboard, disagreeing about what is on it. Where the board is in the layout
catalogue the editor is drawn from it, one cell per LED; where it is not but the device reports lamps,
the coarser lamp-derived grid is still offered, because a coarse editor beats none.

## The key → LED map, for every per-key OMEN keyboard

Colouring "the W key" is meaningless on this hardware without a grouping: the colour map is one byte
per **LED**, and a key owns between one and seven of them. HP ships that grouping as an embedded JSON
resource rather than as code, keyed by board and by keyboard language — which is why decompiling the
Gaming Hub does not reveal it and grepping the sources finds nothing.

Those resources are now extracted and shipped as `KeyboardLayouts.json`: **48 layouts across 92
boards**, each key with its name, its rectangle and its LED indices, generated by a script in the
notebook repo rather than written by hand. Detection needs nothing new — `Win32_BaseBoard.Product` is
the same four-character key HP's own `DeviceList.json` uses, and the per-SSID firmware cycle picks the
variant, which matters because a device ships on both sides of the `26C1` boundary and the two
firmwares blank different LED positions.

**Exactly one of the 48 has been seen on hardware.** `Dojo/Global`, on this board. The rest come from
the same tables by the same rule and nobody has watched one light up, so `KeyboardLayout.Verified`
carries that distinction and the UI says so rather than implying confidence it does not have. An
unknown board resolves to `null` and the editor falls back rather than guessing a near-miss — a
keyboard that lights the wrong key is worse than one that admits it does not know.

**What the tables do not contain is where an LED sits *within* a key.** Every element of a key repeats
the key's own rectangle, in all 33 layouts, so the data says which key an LED belongs to and never
which end of it. The editor divides a cap in colour-map order and every tooltip names the position it
writes, which is the only way to tie a cell back to a byte. Two LEDs always stack, because a two-LED
key is a dual-legend key and the legends are printed one above the other whatever the cap's aspect
says — `Esc` is 26 × 19, wider than tall, and its pair is vertical.

Also worth a look: **the four-zone editor is now hidden where the capability database says there is no
four-zone keyboard.** `HasFourZoneRgb = false` was already correct for `8D87`; the UI simply never read
it. This is only safe because the light bar now has controls of its own — before that, this editor was
the only way to reach the bar at all.

## Capability gaps, stated rather than papered over

- **Keyboard brightness has no lever.** MCU command `0x0C` is refused at every payload value (0, 1, 2,
  3, 50, 100) while five other commands are acknowledged through the same handle and frame builder.
  No effect consumes the effect record's brightness field either. So **a running device effect cannot
  be dimmed**; LampArray intensity only scales a host-painted picture.
- **Light bar brightness and animations need administrator.** Not an HP choice: the default ACL on
  `root\wmi` grants Execute Methods to Administrators only, and a restricted-token test fails *Access
  denied* before any HP code runs. Reaching them unprivileged needs a helper running as SYSTEM. Do
  **not** loosen that ACL — it is the namespace carrying fan control, power limits and GPU mode.
- **Colour never reads back**, on either interface. Methods that write colour report that the device
  *accepted* the report, which is a weaker claim than "it is visible", and the API says so.

## Two effects render black by design

Both look exactly like a bug from the user's chair, on **both** devices, for the same reasons:

- **Swipe** has no preset palette — with a theme selected it renders black. Needs custom colours.
- **Audio Pulse** *is* its two level bytes. At 0 it is black by definition; HP feeds them from an
  audio thread at ~5 Hz.

The UI warns before applying either.

## One trap worth knowing

**Do not ask the light bar for `#FFFFFF`.** The firmware substitutes exactly two values and only two:
`FF0000`→`FE0000`, which is cosmetically free, and `FFFFFF`→`FEA3DA`, which is **visibly purple-white**
beside a real white. `FF0001` and `FFFFFE` pass through byte-exact, so it is a two-entry lookup rather
than a gamma curve. The code routes `#FFFFFF` to `#FFFFFE`.

## Testing

- 28 unit tests over the selection maths and the division of a cap into its LEDs. Neither fails
  loudly: a wrong bounds check selects the *neighbouring* key, and a wrong division paints the
  neighbouring LED, on a device with no colour readback to catch either.
- Two tests over enabling temperature-responsive lighting — that it paints at once, and that it
  survives being enabled before the first sample arrives. Both were checked by inversion: with the
  immediate paint disabled the first fails with exactly the reported symptom, `LastEffect` null.
- The full suite passes: **1146 tests, 0 failures**. Each of the thirteen commits also builds
  independently, checked one at a time in a separate worktree, as do `LightingProbe` and `ViewProbe`,
  which are not in `OmenCore.sln` and so are compiled by nothing else.
- `LightingProbe` drives the shipping types against real hardware; `--read-effect` on `8D87` reports
  the installed effect and matches the device field for field. `--map-editor` runs the shipping
  view-model against the keyboard: 176 cells from the `Dojo/Global` layout, **zero overlaps**, and
  **every one of the 176 colour-map positions reachable from exactly one cell** — which is the
  invariant whose failure left half of `KeyNum0` inert — plus the four bar zones reading their live
  colours.
- Every UI observation was made by the machine's owner. Unelevated behaviour was verified with a
  restricted token (`runas /trustlevel:0x20000`).

## Credit

Key layout cross-checked against [arfelious/omen-rgb-linux](https://github.com/arfelious/omen-rgb-linux),
whose hand-built table for this chassis family independently establishes that one key spans several
LEDs (backspace 8, left shift 7, caps lock 5) — the insight that fixed a crushed modifier column, and
the first sign that a lamp-per-key editor was the wrong shape. Its 182-entry table was built by hand
for a different chassis; the map here is generated from OGH's own layout resources for this board, so
the two agree on the idea and share no offsets.

Protocol derived from OMEN Gaming Hub 1101.2607.3.0 (`McuSDK2.dll`) and confirmed byte-for-byte
against a USBPcap capture of OGH driving this board.

## Not done

- The keyboard→light-bar colour propagation is measured (every channel arrives one lower,
  `value × 254 / 255`) but the **mechanism is unestablished**: Dynamic Lighting mirroring and the HP
  driver doing it internally are indistinguishable from a readback.
- One effect-id readback of `1` (`STEADY`, which OGH never sends) is unexplained. Recorded as
  unexplained rather than written up as a finding.

## Stacking

Sits on `8d87/per-key-rgb`, which stacks on #162. Filed against `main`, so **the diff shown here
includes both of those** — review the thirteen commits from `Light one named key` forward, or wait for
the bases to merge and the diff will narrow on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

