### PR TITLE
Don't wake a sleeping dGPU to poll it

### DIFF
--- a/src/OmenCore.HardwareWorker/OmenCore.HardwareWorker.csproj
+++ b/src/OmenCore.HardwareWorker/OmenCore.HardwareWorker.csproj
@@ -33,4 +33,12 @@
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Shared with the app rather than duplicated: either process polling a sleeping
+         dGPU is enough to keep it awake, so the check has to exist in both. The file is
+         deliberately dependency-free (cfgmgr32 P/Invoke only) so it links cleanly here. -->
+    <Compile Include="..\OmenCoreApp\Hardware\GpuPowerStateProbe.cs"
+             Link="Hardware\GpuPowerStateProbe.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/OmenCore.HardwareWorker/Program.cs
+++ b/src/OmenCore.HardwareWorker/Program.cs
@@ -28,6 +28,7 @@ class Program
     private const string MutexName = "Global\\OmenCore_HardwareWorker_Mutex";
     
     private static Computer? _computer;
+    private static OmenCore.Hardware.GpuPowerStateProbe? _gpuSleepProbe;
     private static readonly object _lock = new();
     private static HardwareSample _lastSample = new();
     private static bool _running = true;
@@ -594,6 +595,37 @@ class Program
         return UpdateIntervalMs;
     }
 
+    /// <summary>
+    /// True when this is the discrete NVIDIA GPU and it is parked in D3. Reading it is what
+    /// would wake it, so the state comes from the PnP manager instead.
+    /// </summary>
+    private static bool IsSleepingNvidiaGpu(IHardware hardware)
+    {
+        if (hardware.HardwareType != HardwareType.GpuNvidia) return false;
+
+        _gpuSleepProbe ??= new OmenCore.Hardware.GpuPowerStateProbe(
+            msg => LogToFile($"[{DateTime.Now:O}] {msg}\n"));
+        return _gpuSleepProbe.IsAsleep();
+    }
+
+    /// <summary>
+    /// A sleeping dGPU draws no meaningful power and has no die temperature to report. The
+    /// sample is seeded from the previous cycle, so without this the last values measured
+    /// before it slept would be served indefinitely as though they were current.
+    /// </summary>
+    private static void ZeroGpuTelemetry(HardwareSample sample)
+    {
+        sample.GpuTemperature = 0;
+        sample.GpuHotspot = 0;
+        sample.GpuLoad = 0;
+        sample.GpuPower = 0;
+        sample.GpuClock = 0;
+        sample.GpuMemoryClock = 0;
+        sample.GpuVoltage = 0;
+        sample.GpuCurrent = 0;
+        sample.VramUsage = 0;
+    }
+
     private static void UpdateHardwareReadings()
     {
         if (_computer == null) return;
@@ -645,6 +677,14 @@ class Program
                     if (_amdGpuTelemetryQuarantined && hardware.HardwareType == HardwareType.GpuAmd)
                     {
                         // Skip unstable AMD ADL-backed updates after quarantine is activated.
+                        continue;
+                    }
+
+                    if (IsSleepingNvidiaGpu(hardware))
+                    {
+                        // Leave a parked dGPU parked. LHM reaches it through NVML, which wakes
+                        // the device to answer, so this poll loop would hold it in D0 forever.
+                        ZeroGpuTelemetry(sample);
                         continue;
                     }
 

--- a/src/OmenCore.HardwareWorker/Program.cs
+++ b/src/OmenCore.HardwareWorker/Program.cs
@@ -499,6 +499,18 @@ class Program
                     continue;
                 }
 
+                // A diagnostic line is not worth waking a parked dGPU for. This runs from
+                // InitializeHardware, so once every time the worker starts - and the worker is
+                // started by the app, restarted after a resume, and respawned when it is orphaned.
+                // The update loop was taught to leave a D3 dGPU alone; this path was still pulling
+                // it back to D0 behind it.
+                if (IsSleepingNvidiaGpu(hw))
+                {
+                    LogToFile($"[{DateTime.Now:O}] [GPU Detected] NVIDIA: {hw.Name} — parked in D3, sensors not read\n");
+                    Console.WriteLine($"[GPU Detected] NVIDIA: {hw.Name} (parked in D3, sensors not read)");
+                    continue;
+                }
+
                 hw.Update();
                 var tempSensors = hw.Sensors.Where(s => s.SensorType == SensorType.Temperature).ToList();
                 var loadSensors = hw.Sensors.Where(s => s.SensorType == SensorType.Load).ToList();

--- a/src/OmenCoreApp.Tests/Hardware/GpuPowerStateProbeTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/GpuPowerStateProbeTests.cs
@@ -1,0 +1,113 @@
+using FluentAssertions;
+using OmenCore.Hardware;
+using System;
+using Xunit;
+
+namespace OmenCoreApp.Tests.Hardware
+{
+    public class GpuPowerStateProbeTests
+    {
+        /// <summary>
+        /// A CM_POWER_DATA blob: PD_Size, then PD_MostRecentPowerState, then fields this
+        /// code does not read.
+        /// </summary>
+        private static byte[] PowerData(uint mostRecentPowerState)
+        {
+            var buffer = new byte[56];
+            BitConverter.GetBytes(56u).CopyTo(buffer, 0);
+            BitConverter.GetBytes(mostRecentPowerState).CopyTo(buffer, 4);
+            return buffer;
+        }
+
+        [Theory]
+        [InlineData(1u, GpuPowerState.D0)]
+        [InlineData(2u, GpuPowerState.D1)]
+        [InlineData(3u, GpuPowerState.D2)]
+        [InlineData(4u, GpuPowerState.D3)]
+        public void ParseMostRecentPowerState_DecodesEachDeviceState(uint raw, GpuPowerState expected)
+        {
+            var buffer = PowerData(raw);
+
+            GpuPowerStateProbe.ParseMostRecentPowerState(buffer, buffer.Length)
+                .Should().Be(expected);
+        }
+
+        [Fact]
+        public void ParseMostRecentPowerState_ReadsOffsetFour_NotOffsetZero()
+        {
+            // PD_Size sits at offset 0 and is 56 on a real blob. Reading the wrong DWORD
+            // would decode that as a device state, and 56 is not one -- but a probe that
+            // read offset 0 would also report Unknown for every awake GPU, which fails
+            // open and looks like it works. Pin the offset explicitly.
+            var buffer = PowerData(4);
+            BitConverter.GetBytes(1u).CopyTo(buffer, 0);
+
+            GpuPowerStateProbe.ParseMostRecentPowerState(buffer, buffer.Length)
+                .Should().Be(GpuPowerState.D3, "the state is the second DWORD, not the first");
+        }
+
+        [Theory]
+        [InlineData(0u)]
+        [InlineData(5u)]
+        [InlineData(uint.MaxValue)]
+        public void ParseMostRecentPowerState_RejectsValuesOutsideTheEnum(uint raw)
+        {
+            var buffer = PowerData(raw);
+
+            GpuPowerStateProbe.ParseMostRecentPowerState(buffer, buffer.Length)
+                .Should().Be(GpuPowerState.Unknown);
+        }
+
+        [Fact]
+        public void ParseMostRecentPowerState_ReturnsUnknown_ForShortBuffer()
+        {
+            // A truncated reply must not be decoded as D3: that would suspend GPU telemetry
+            // on a GPU that is wide awake.
+            GpuPowerStateProbe.ParseMostRecentPowerState(new byte[4], 4)
+                .Should().Be(GpuPowerState.Unknown);
+        }
+
+        [Fact]
+        public void ParseMostRecentPowerState_HonoursLength_NotBufferSize()
+        {
+            // The buffer is oversized by design; only the returned length is meaningful.
+            GpuPowerStateProbe.ParseMostRecentPowerState(PowerData(4), 4)
+                .Should().Be(GpuPowerState.Unknown);
+        }
+
+        [Fact]
+        public void ParseMostRecentPowerState_ReturnsUnknown_ForNullBuffer()
+        {
+            GpuPowerStateProbe.ParseMostRecentPowerState(null!, 56)
+                .Should().Be(GpuPowerState.Unknown);
+        }
+
+        [Fact]
+        public void Read_FailsOpen_WhenNoMatchingAdapterExists()
+        {
+            // Fail-open is the whole safety property: an unreadable probe must report
+            // Unknown so callers keep polling, not D3 so they stop.
+            var probe = new GpuPowerStateProbe(instanceIdPrefix: @"PCI\VEN_NOSUCHVENDOR");
+
+            probe.Read().Should().Be(GpuPowerState.Unknown);
+            probe.IsAsleep().Should().BeFalse();
+        }
+
+        [Fact]
+        public void Read_DoesNotThrow_OnAnyMachine()
+        {
+            // Runs on CI without an NVIDIA adapter and on hardware with one.
+            var probe = new GpuPowerStateProbe();
+
+            var act = () => probe.Read();
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void GpuMonitoringSample_IsNotAsleepByDefault()
+        {
+            new GpuMonitoringSample().GpuAsleep.Should().BeFalse();
+        }
+    }
+}

--- a/src/OmenCoreApp/Hardware/GpuPowerStateProbe.cs
+++ b/src/OmenCoreApp/Hardware/GpuPowerStateProbe.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace OmenCore.Hardware
+{
+    /// <summary>
+    /// Device power state, as reported by CM_POWER_DATA.PD_MostRecentPowerState.
+    /// </summary>
+    public enum GpuPowerState
+    {
+        Unknown = 0,
+        D0 = 1,
+        D1 = 2,
+        D2 = 3,
+        D3 = 4
+    }
+
+    /// <summary>
+    /// Reads a discrete GPU's current power state <b>without waking it</b>.
+    ///
+    /// On an Optimus/RTD3 laptop the dGPU parks in D3 whenever nothing is rendering, and
+    /// any NVAPI query pulls it back to D0 for the driver's inactivity timeout. A monitoring
+    /// loop polling faster than that timeout therefore prevents the state it is trying to
+    /// report: the GPU never idles, and the telemetry saying so is the reason why.
+    ///
+    /// DEVPKEY_Device_PowerData is answered from the PnP manager's own bookkeeping and does
+    /// not touch the device, so it can be called at any cadence. It is the only reading of
+    /// dGPU power state that is safe to take in a poll loop — nvidia-smi and NVAPI both wake
+    /// the device to answer, then report the P-state and wattage of a GPU that was asleep
+    /// until they asked.
+    ///
+    /// Every failure path returns <see cref="GpuPowerState.Unknown"/> so callers fall back to
+    /// polling normally. Suspending telemetry because a probe broke would be a worse bug than
+    /// the one this fixes.
+    ///
+    /// Deliberately dependency-free — only cfgmgr32 P/Invoke — so it can be linked into the
+    /// hardware worker, which does not reference the app assembly.
+    /// </summary>
+    public sealed class GpuPowerStateProbe
+    {
+        // DEVPKEY_Device_PowerData and DEVPKEY_Device_ClassGuid share the DEVPKEY_Device fmtid.
+        private static readonly Guid DevpkeyDeviceFmtid =
+            new("a45c254e-df1c-4efd-8020-67d146a850e0");
+        private const uint PidClassGuid = 10;
+        private const uint PidPowerData = 32;
+
+        private static readonly Guid GuidDevclassDisplay =
+            new("4d36e968-e325-11ce-bfc1-08002be10318");
+
+        private const int CrSuccess = 0;
+        private const uint CmLocateDevnodeNormal = 0;
+        private const uint CmGetidlistFilterEnumerator = 0x00000001;
+        private const uint CmGetidlistFilterPresent = 0x00000100;
+
+        // CM_POWER_DATA: PD_Size is the first DWORD, PD_MostRecentPowerState the second.
+        private const int MostRecentPowerStateOffset = 4;
+        private const int MinimumPowerDataLength = MostRecentPowerStateOffset + sizeof(uint);
+
+        private readonly Action<string>? _log;
+        private readonly string _instanceIdPrefix;
+        private readonly object _sync = new();
+
+        private string? _cachedInstanceId;
+        private bool _noSuchAdapter;
+        private GpuPowerState _lastLoggedState = GpuPowerState.Unknown;
+
+        /// <param name="log">Called only on state transitions, not per poll.</param>
+        /// <param name="instanceIdPrefix">
+        /// PnP instance-id prefix of the adapter to watch. Defaults to NVIDIA's PCI vendor id;
+        /// the class itself is vendor-agnostic.
+        /// </param>
+        public GpuPowerStateProbe(Action<string>? log = null,
+                                  string instanceIdPrefix = @"PCI\VEN_10DE")
+        {
+            _log = log;
+            _instanceIdPrefix = instanceIdPrefix;
+        }
+
+        /// <summary>
+        /// True when the adapter is known to be in D3. False when it is awake <i>or</i> when
+        /// the state could not be determined — see the class remarks on failing open.
+        /// </summary>
+        public bool IsAsleep() => Read() == GpuPowerState.D3;
+
+        /// <summary>
+        /// Current power state, or <see cref="GpuPowerState.Unknown"/> if it cannot be read.
+        /// </summary>
+        public GpuPowerState Read()
+        {
+            if (!OperatingSystem.IsWindows()) return GpuPowerState.Unknown;
+
+            try
+            {
+                var instanceId = ResolveInstanceId();
+                if (instanceId == null) return GpuPowerState.Unknown;
+
+                var state = ReadPowerState(instanceId);
+
+                // The devnode can go stale across a driver restart or a GPU mode switch.
+                // One re-resolve, then give up for this call.
+                if (state == GpuPowerState.Unknown)
+                {
+                    lock (_sync) { _cachedInstanceId = null; }
+                    instanceId = ResolveInstanceId();
+                    if (instanceId != null) state = ReadPowerState(instanceId);
+                }
+
+                LogTransition(state);
+                return state;
+            }
+            catch (Exception ex)
+            {
+                _log?.Invoke($"GpuPowerStateProbe: read failed: {ex.Message}");
+                return GpuPowerState.Unknown;
+            }
+        }
+
+        private void LogTransition(GpuPowerState state)
+        {
+            lock (_sync)
+            {
+                if (state == _lastLoggedState) return;
+                _lastLoggedState = state;
+            }
+
+            _log?.Invoke(state == GpuPowerState.D3
+                ? "dGPU entered D3 — suspending GPU telemetry polling so it can stay there"
+                : $"dGPU power state now {state} — GPU telemetry polling active");
+        }
+
+        private string? ResolveInstanceId()
+        {
+            lock (_sync)
+            {
+                if (_cachedInstanceId != null) return _cachedInstanceId;
+                if (_noSuchAdapter) return null;
+            }
+
+            string? found = null;
+            try
+            {
+                foreach (var id in EnumeratePciDeviceIds())
+                {
+                    if (!id.StartsWith(_instanceIdPrefix, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    // The vendor id alone is not enough: NVIDIA's HDMI audio function is a
+                    // separate PCI device under the same vendor. Match the display class.
+                    if (!IsDisplayClass(id)) continue;
+
+                    found = id;
+                    break;
+                }
+            }
+            catch (Exception ex)
+            {
+                _log?.Invoke($"GpuPowerStateProbe: device discovery failed: {ex.Message}");
+                return null;
+            }
+
+            lock (_sync)
+            {
+                _cachedInstanceId = found;
+                // Latch only a clean "no such adapter". A discovery that threw returns above
+                // without latching, so a transient failure does not disable the probe for the
+                // lifetime of the process.
+                if (found == null) _noSuchAdapter = true;
+                return found;
+            }
+        }
+
+        private static IEnumerable<string> EnumeratePciDeviceIds()
+        {
+            const uint flags = CmGetidlistFilterEnumerator | CmGetidlistFilterPresent;
+
+            if (CM_Get_Device_ID_List_SizeW(out var length, "PCI", flags) != CrSuccess || length == 0)
+                yield break;
+
+            var buffer = new char[length];
+            if (CM_Get_Device_ID_ListW("PCI", buffer, length, flags) != CrSuccess)
+                yield break;
+
+            // REG_MULTI_SZ: NUL-separated, double-NUL terminated.
+            var start = 0;
+            for (var i = 0; i < buffer.Length; i++)
+            {
+                if (buffer[i] != '\0') continue;
+                if (i > start) yield return new string(buffer, start, i - start);
+                start = i + 1;
+            }
+        }
+
+        private static bool IsDisplayClass(string instanceId)
+        {
+            if (CM_Locate_DevNodeW(out var devInst, instanceId, CmLocateDevnodeNormal) != CrSuccess)
+                return false;
+
+            var key = new DEVPROPKEY { fmtid = DevpkeyDeviceFmtid, pid = PidClassGuid };
+            var buffer = new byte[16];
+            var size = (uint)buffer.Length;
+
+            if (CM_Get_DevNode_PropertyW(devInst, ref key, out _, buffer, ref size, 0) != CrSuccess)
+                return false;
+            if (size < 16) return false;
+
+            return new Guid(buffer) == GuidDevclassDisplay;
+        }
+
+        private static GpuPowerState ReadPowerState(string instanceId)
+        {
+            if (CM_Locate_DevNodeW(out var devInst, instanceId, CmLocateDevnodeNormal) != CrSuccess)
+                return GpuPowerState.Unknown;
+
+            var key = new DEVPROPKEY { fmtid = DevpkeyDeviceFmtid, pid = PidPowerData };
+            var buffer = new byte[128];
+            var size = (uint)buffer.Length;
+
+            if (CM_Get_DevNode_PropertyW(devInst, ref key, out _, buffer, ref size, 0) != CrSuccess)
+                return GpuPowerState.Unknown;
+
+            return ParseMostRecentPowerState(buffer, (int)size);
+        }
+
+        /// <summary>
+        /// Pulls PD_MostRecentPowerState out of a CM_POWER_DATA blob. Split out so the
+        /// decoding is testable without an NVIDIA adapter present.
+        /// </summary>
+        internal static GpuPowerState ParseMostRecentPowerState(byte[] buffer, int length)
+        {
+            if (buffer == null || length < MinimumPowerDataLength) return GpuPowerState.Unknown;
+
+            var raw = BitConverter.ToUInt32(buffer, MostRecentPowerStateOffset);
+
+            return raw switch
+            {
+                1 => GpuPowerState.D0,
+                2 => GpuPowerState.D1,
+                3 => GpuPowerState.D2,
+                4 => GpuPowerState.D3,
+                _ => GpuPowerState.Unknown
+            };
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct DEVPROPKEY
+        {
+            public Guid fmtid;
+            public uint pid;
+        }
+
+        [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode)]
+        private static extern int CM_Locate_DevNodeW(out uint pdnDevInst, string pDeviceID, uint ulFlags);
+
+        [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode)]
+        private static extern int CM_Get_DevNode_PropertyW(
+            uint dnDevInst,
+            ref DEVPROPKEY propertyKey,
+            out ulong propertyType,
+            byte[] propertyBuffer,
+            ref uint propertyBufferSize,
+            uint ulFlags);
+
+        [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode)]
+        private static extern int CM_Get_Device_ID_List_SizeW(out uint pulLen, string pszFilter, uint ulFlags);
+
+        [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode)]
+        private static extern int CM_Get_Device_ID_ListW(string pszFilter, char[] buffer, uint bufferLen, uint ulFlags);
+    }
+}

--- a/src/OmenCoreApp/Hardware/LibreHardwareMonitorImpl.cs
+++ b/src/OmenCoreApp/Hardware/LibreHardwareMonitorImpl.cs
@@ -343,6 +343,17 @@ namespace OmenCore.Hardware
                     hw.HardwareType == HardwareType.GpuAmd ||
                     hw.HardwareType == HardwareType.GpuIntel)
                 {
+                    // A diagnostic line is not worth waking a parked dGPU for, and this runs on every
+                    // InitializeComputer() - so once at startup and again on every Reinitialize(),
+                    // which is what TryRestartAsync does after a resume. Reading sensors here goes
+                    // through NVML, which wakes the device to answer: the poll loops were taught to
+                    // leave it alone and this path was still pulling it back to D0 behind them.
+                    if (IsSleepingNvidiaGpu(hw))
+                    {
+                        _logger?.Invoke($"[GPU Detected] NVIDIA: {hw.Name} — parked in D3, sensors not read");
+                        continue;
+                    }
+
                     hw.Update();
                     var tempSensors = hw.Sensors.Where(s => s.SensorType == SensorType.Temperature).ToList();
                     var loadSensors = hw.Sensors.Where(s => s.SensorType == SensorType.Load).ToList();

--- a/src/OmenCoreApp/Hardware/LibreHardwareMonitorImpl.cs
+++ b/src/OmenCoreApp/Hardware/LibreHardwareMonitorImpl.cs
@@ -92,6 +92,7 @@ namespace OmenCore.Hardware
         private static readonly TimeSpan _lowOverheadCacheLifetime = TimeSpan.FromMilliseconds(3000); // 3 seconds in low overhead
 
         private readonly Action<string>? _logger;
+        private GpuPowerStateProbe? _gpuSleepProbe;
         private PerformanceCounter? _cpuLoadCounter;
         private bool _cpuLoadCounterPrimed;
         private readonly Dictionary<string, PerformanceCounter> _gpuEngineCounters = new(StringComparer.OrdinalIgnoreCase);
@@ -747,6 +748,19 @@ namespace OmenCore.Hardware
         private const int NvmlRetryCooldownSeconds = 60;       // v2.8.6: Retry NVML after 60s cooldown
 
         /// <summary>
+        /// True when this is the discrete NVIDIA GPU and it is parked in D3. LHM reaches that
+        /// GPU through NVML, which wakes the device to answer — so polling it is what stops it
+        /// ever being idle. See <see cref="GpuPowerStateProbe"/>.
+        /// </summary>
+        private bool IsSleepingNvidiaGpu(IHardware hardware)
+        {
+            if (hardware.HardwareType != HardwareType.GpuNvidia) return false;
+
+            _gpuSleepProbe ??= new GpuPowerStateProbe(_logger);
+            return _gpuSleepProbe.IsAsleep();
+        }
+
+        /// <summary>
         /// Safely updates GPU hardware with timeout protection.
         /// NVML can hang or throw exceptions during high GPU load (e.g., benchmarks).
         /// </summary>
@@ -761,6 +775,9 @@ namespace OmenCore.Hardware
         /// </remarks>
         private bool TryUpdateGpuHardware(IHardware hardware)
         {
+            // Nothing below is measurable on a parked GPU, and measuring is what un-parks it.
+            if (IsSleepingNvidiaGpu(hardware)) return false;
+
             if (_nvmlDisabled)
             {
                 // v2.8.6: NVML disabled due to repeated failures—check if cooldown expired
@@ -821,7 +838,7 @@ namespace OmenCore.Hardware
                 _cachedAmdGpuTelemetryQuarantined = false;
                 _cachedAmdGpuTelemetryQuarantineReason = string.Empty;
                 
-                _computer?.Accept(new UpdateVisitor());
+                _computer?.Accept(new UpdateVisitor(IsSleepingNvidiaGpu));
 
                 foreach (var hardware in _computer?.Hardware ?? Array.Empty<IHardware>())
                 {
@@ -1813,7 +1830,7 @@ namespace OmenCore.Hardware
                 try
                 {
                     // Update hardware readings to get fresh fan data
-                    _computer?.Accept(new UpdateVisitor());
+                    _computer?.Accept(new UpdateVisitor(IsSleepingNvidiaGpu));
 
                     foreach (var hardware in _computer?.Hardware ?? Array.Empty<IHardware>())
                     {
@@ -2319,6 +2336,14 @@ namespace OmenCore.Hardware
     /// </summary>
     internal class UpdateVisitor : IVisitor
     {
+        private readonly Func<IHardware, bool>? _skip;
+
+        /// <param name="skip">
+        /// Returns true for hardware that must not be updated this pass. Used to leave a
+        /// sleeping dGPU alone — updating it is what wakes it.
+        /// </param>
+        public UpdateVisitor(Func<IHardware, bool>? skip = null) => _skip = skip;
+
         public void VisitComputer(IComputer computer)
         {
             computer.Traverse(this);
@@ -2326,6 +2351,8 @@ namespace OmenCore.Hardware
 
         public void VisitHardware(IHardware hardware)
         {
+            if (_skip?.Invoke(hardware) == true) return;
+
             hardware.Update();
             foreach (var subHardware in hardware.SubHardware)
                 subHardware.Accept(this);

--- a/src/OmenCoreApp/Hardware/NvapiService.cs
+++ b/src/OmenCoreApp/Hardware/NvapiService.cs
@@ -17,6 +17,7 @@ namespace OmenCore.Hardware
     public class NvapiService : IDisposable
     {
         private readonly Services.LoggingService _logging;
+        private readonly GpuPowerStateProbe _powerStateProbe;
         private bool _initialized;
         private bool _disposed;
         private NvPhysicalGpuHandle[] _gpuHandles = new NvPhysicalGpuHandle[NVAPI_MAX_PHYSICAL_GPUS];
@@ -293,6 +294,7 @@ namespace OmenCore.Hardware
         public NvapiService(Services.LoggingService logging)
         {
             _logging = logging;
+            _powerStateProbe = new GpuPowerStateProbe(msg => logging.Info($"[NVAPI] {msg}"));
         }
 
         /// <summary>
@@ -1249,6 +1251,9 @@ namespace OmenCore.Hardware
         {
             if (!_initialized || _primaryGpu == null) return 0;
 
+            // Reading a thermal sensor wakes the die. See GpuPowerStateProbe.
+            if (_powerStateProbe.IsAsleep()) return 0;
+
             try
             {
                 var sensors = _primaryGpu.ThermalInformation.ThermalSensors;
@@ -1303,6 +1308,10 @@ namespace OmenCore.Hardware
         {
             if (!_initialized || _primaryGpu == null) return 0;
 
+            // Reading power topology wakes the GPU, so the figure it returns describes a
+            // device that was asleep until it was asked. See GpuPowerStateProbe.
+            if (_powerStateProbe.IsAsleep()) return 0;
+
             try
             {
                 var entries = _primaryGpu.PowerTopologyInformation.PowerTopologyEntries;
@@ -1328,6 +1337,13 @@ namespace OmenCore.Hardware
             var sample = new GpuMonitoringSample { GpuName = GpuName };
 
             if (!_initialized || _primaryGpu == null) return sample;
+
+            // Every read below wakes a sleeping dGPU. See GpuPowerStateProbe.
+            if (_powerStateProbe.IsAsleep())
+            {
+                sample.GpuAsleep = true;
+                return sample;
+            }
 
             try
             {
@@ -1393,6 +1409,13 @@ namespace OmenCore.Hardware
             var sample = new GpuMonitoringSample { GpuName = GpuName };
 
             if (!_initialized || _primaryGpu == null) return sample;
+
+            // Every read below wakes a sleeping dGPU. See GpuPowerStateProbe.
+            if (_powerStateProbe.IsAsleep())
+            {
+                sample.GpuAsleep = true;
+                return sample;
+            }
 
             try
             {
@@ -1704,5 +1727,12 @@ namespace OmenCore.Hardware
         public double MemoryClockMhz { get; set; }
         public double VramUsedMb { get; set; }
         public double VramTotalMb { get; set; }
+
+        /// <summary>
+        /// The dGPU was in D3 and was deliberately not woken, so every figure above is
+        /// unset rather than measured. Distinguishes "asleep" from "idle at 0 W" -- which
+        /// matters, because reading the difference is what destroys it.
+        /// </summary>
+        public bool GpuAsleep { get; set; }
     }
 }

--- a/src/OmenCoreApp/Hardware/WmiBiosMonitor.cs
+++ b/src/OmenCoreApp/Hardware/WmiBiosMonitor.cs
@@ -205,6 +205,8 @@ namespace OmenCore.Hardware
         private DateTime _lastGpuFreezeWarnAt = DateTime.MinValue;
         private int _consecutiveGpuInactiveReads;
         private bool _gpuInactive;
+        // Set from the dGPU's actual PnP power state rather than inferred from telemetry.
+        private bool _gpuAsleepFromProbe;
         private int _updateReadingsCount;
         
         // GPU metrics from NVAPI
@@ -765,6 +767,7 @@ namespace OmenCore.Hardware
                                 try
                                 {
                                     var lightSample = _nvapi.GetLoadAndVramOnly();
+                                    _gpuAsleepFromProbe = lightSample.GpuAsleep;
                                     double nvapiLoad = -1;
 
                                     if (lightSample.GpuTemperatureC > 0)
@@ -864,27 +867,15 @@ namespace OmenCore.Hardware
                     try
                     {
                         var gpuSample = _nvapi.GetMonitoringSample();
-                        
-                        _cachedGpuLoad = gpuSample.GpuLoadPercent;
-                        _gpuLoadSource = "NVAPI";
-                        _cachedGpuPowerWatts = StabilizePowerReading(
-                            NormalizeGpuPowerWatts(gpuSample.GpuPowerWatts, gpuSample.GpuLoadPercent, "NVAPI"),
-                            ref _lastValidGpuPowerWatts,
-                            ref _consecutiveZeroGpuPowerReads,
-                            gpuSample.GpuLoadPercent,
-                            gpuSample.GpuTemperatureC > 0 ? gpuSample.GpuTemperatureC : _cachedGpuTemp);
-                        _cachedGpuClockMhz = gpuSample.CoreClockMhz;
-                        _cachedGpuMemClockMhz = gpuSample.MemoryClockMhz;
-                        _cachedGpuVramUsedMb = gpuSample.VramUsedMb;
-                        _cachedGpuVramTotalMb = gpuSample.VramTotalMb;
-                        
-                        // If NVAPI returns a GPU temp, prefer it over WMI BIOS
-                        // (NVAPI reads directly from the GPU die sensor, higher precision)
-                        if (gpuSample.GpuTemperatureC > 0)
-                        {
-                            _cachedGpuTemp = gpuSample.GpuTemperatureC;
-                        }
-                        
+                        _gpuAsleepFromProbe = gpuSample.GpuAsleep;
+
+                        // A parked dGPU has nothing to report, and reporting it is what
+                        // un-parks it. Leave the caches as they were rather than writing
+                        // zeroes over them — VRAM capacity in particular is static, and
+                        // zeroing it would read as a 0 GB card. SanitizeGpuTelemetry turns
+                        // the probe result into TelemetryDataState.Inactive.
+                        if (!gpuSample.GpuAsleep) ApplyGpuSample(gpuSample);
+
                         _nvapiConsecutiveFailures = 0; // Reset on success
                     }
                     catch (Exception ex)
@@ -1893,8 +1884,55 @@ namespace OmenCore.Hardware
             }
         }
 
+        /// <summary>
+        /// Copies an NVAPI snapshot into the telemetry caches. Only called for a sample that
+        /// was actually measured — see the D3 guard at the call site.
+        /// </summary>
+        private void ApplyGpuSample(GpuMonitoringSample gpuSample)
+        {
+            _cachedGpuLoad = gpuSample.GpuLoadPercent;
+            _gpuLoadSource = "NVAPI";
+            _cachedGpuPowerWatts = StabilizePowerReading(
+                NormalizeGpuPowerWatts(gpuSample.GpuPowerWatts, gpuSample.GpuLoadPercent, "NVAPI"),
+                ref _lastValidGpuPowerWatts,
+                ref _consecutiveZeroGpuPowerReads,
+                gpuSample.GpuLoadPercent,
+                gpuSample.GpuTemperatureC > 0 ? gpuSample.GpuTemperatureC : _cachedGpuTemp);
+            _cachedGpuClockMhz = gpuSample.CoreClockMhz;
+            _cachedGpuMemClockMhz = gpuSample.MemoryClockMhz;
+            _cachedGpuVramUsedMb = gpuSample.VramUsedMb;
+            _cachedGpuVramTotalMb = gpuSample.VramTotalMb;
+
+            // If NVAPI returns a GPU temp, prefer it over WMI BIOS
+            // (NVAPI reads directly from the GPU die sensor, higher precision)
+            if (gpuSample.GpuTemperatureC > 0)
+            {
+                _cachedGpuTemp = gpuSample.GpuTemperatureC;
+            }
+        }
+
         private void SanitizeGpuTelemetry()
         {
+            // The PnP power state is authoritative and costs nothing to read, so when it says
+            // D3 there is no need to infer inactivity from telemetry — nor any way to, since
+            // the readings that would carry the evidence are the ones being skipped.
+            //
+            // Conditioned on NVAPI still being live: the flag is only refreshed by the paths
+            // that poll it, so if NVAPI drops out while the GPU is asleep it would otherwise
+            // latch the GPU as inactive for the rest of the session.
+            if (_gpuAsleepFromProbe && _nvapi?.IsAvailable == true && !_nvapiMonitoringDisabled)
+            {
+                _consecutiveGpuInactiveReads = 0;
+                _gpuInactive = true;
+                _cachedGpuTemp = 0;
+                _cachedGpuLoad = 0;
+                _cachedGpuPowerWatts = 0;
+                _cachedGpuClockMhz = 0;
+                _cachedGpuMemClockMhz = 0;
+                _cachedGpuVramUsedMb = 0;
+                return;
+            }
+
             // Hybrid iGPU+dGPU systems can surface a small non-zero GPU power value even when
             // the discrete GPU is effectively inactive (Optimus power-saving path). Treat dGPU
             // as active only when we see stronger discrete-activity signals.


### PR DESCRIPTION
## The problem

On an Optimus/RTD3 laptop the discrete GPU parks in D3 whenever nothing is rendering. OmenCore polls
it on a timer through NVAPI and NVML, and **both wake the device to answer** — so the GPU never gets
to idle, and it draws 20–25 W doing nothing.

Reported by a user as "nothing is using my dGPU but it's reporting 20–25 W". It was not a misread of
a sleeping GPU. It never slept.

This is not board-specific. It costs idle power and battery life on any laptop with an NVIDIA dGPU
and working RTD3.

## Measured

`nvidia-smi` cannot be used to check this — the query wakes the GPU and then reports the P-state of a
GPU it just woke, which is why the symptom is self-confirming. `DEVPKEY_Device_PowerData` is answered
from the PnP manager's own bookkeeping and does not touch the device.

Board: OMEN MAX 16 (8D87), RTX 5080 Laptop, BIOS F.07.

| Condition | `PD_MostRecentPowerState` |
|---|---|
| Before — app running | **D0**, 6/6 samples over 60 s |
| Before — app stopped | **D3** within 9 s, then 14/14 over 210 s |
| Before — app restarted | **D0**, 4/5 |
| **After — patched app running** | **D3, 16/16 over 160 s** |
| After — worker alone, unpatched | D0 4/9 |
| After — worker alone, patched | D0 1/9 — one wake at process start |

D3 re-entry on this board is under ten seconds, which is why a 2 s poll loop is enough to prevent it
entirely.

## What changed

`GpuPowerStateProbe` reads the PnP power state, and each poll path skips the dGPU while it reads D3.
Three loops needed it, and each was only found by fixing the previous one and re-measuring:

1. **`NvapiService`** — `GetMonitoringSample`, `GetLoadAndVramOnly`, `GetGpuPowerWatts`,
   `GetGpuTemperature`.
2. **`LibreHardwareMonitorImpl`** — the blanket `Computer.Accept(new UpdateVisitor())` runs *before*
   the selective per-hardware loop, so guarding `TryUpdateGpuHardware` alone changes nothing.
   `UpdateVisitor` now takes an optional skip predicate.
3. **`OmenCore.HardwareWorker`** — a second process running LHM with `IsGpuEnabled = true` at
   500 ms–3 s. The probe is linked in as shared source rather than duplicated; it is deliberately
   dependency-free (cfgmgr32 P/Invoke only) so it compiles there without pulling in the app assembly.

`SanitizeGpuTelemetry` already tried to infer dGPU inactivity from load, clocks and power, but that
inference is circular: those readings are taken by waking the device, and a woken GPU reports `P0` at
20–25 W, which reads as *active*. The probe is authoritative when it fires — conditioned on NVAPI
still being live, so a dropout cannot latch the GPU as inactive for the session.

A sleeping GPU now reports the existing `TelemetryDataState.Inactive` rather than a measured zero, and
the caches are left alone rather than overwritten — VRAM capacity is static, and zeroing it renders as
a 0 GB card.

## Failing open

Every error path in the probe returns `Unknown`, and callers then poll exactly as they do today.
Suspending telemetry because a probe broke would be a worse bug than the one this fixes. There is a
test for it, and one pinning the `CM_POWER_DATA` offset: reading the first `DWORD` instead of the
second returns `PD_Size`, which decodes to no valid device state — so that mistake also fails open and
looks like a working probe.

## Not fixed

One wake remains at process start, within ~12 s of launch. It is not isolated between LHM's
`Computer.Open()` enumeration and the diagnostic sensor dump in `LogDetectedHardware`. A single wake
decays in about ten seconds here, so it is a different order of problem from a poll loop — but it is
not nothing, and it is not addressed here.

`LowOverheadMode` is not a mitigation for any of this: it shortens the LHM sensor cache to 3 s and
keeps polling.

## Related

Same root cause as the GPU-mode detection issue where a dGPU in D3 was reported as "Integrated GPU
Only" — in both cases the app asks a question that changes the answer.

## Testing

Full suite green. New tests cover the `CM_POWER_DATA` decode, the offset, the enum bounds, short and
null buffers, and the fail-open path. The behavioural claim above is verified on hardware by power
state, not by return code.
