### PR TITLE
Stop the hardware worker when OmenCore exits

### DIFF
--- a/src/OmenCore.HardwareWorker/Program.cs
+++ b/src/OmenCore.HardwareWorker/Program.cs
@@ -1436,6 +1436,11 @@ class Program
                 {
                     response = "OK";
                     _running = false;
+                    // Logged because the log is the only way to tell a requested exit from a
+                    // parent that simply died — and those two get very different treatment
+                    // (see MonitorParentProcess).
+                    Console.WriteLine("SHUTDOWN received. Worker exiting.");
+                    LogToFile($"[{DateTime.Now:O}] SHUTDOWN received from client. Worker exiting.\n");
                 }
                 else if (request == "DISABLE_BATTERY")
                 {

--- a/src/OmenCoreApp.Tests/Hardware/HardwareWorkerClientPipeTests.cs
+++ b/src/OmenCoreApp.Tests/Hardware/HardwareWorkerClientPipeTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO.Pipes;
 using System.Linq;
 using System.Reflection;
@@ -108,6 +110,92 @@ namespace OmenCoreApp.Tests.Hardware
             {
                 results[i].Should().Be($"ECHO:REQ{i}", "each caller must receive the response to its own request, never another caller's");
             }
+        }
+
+        /// <summary>
+        /// Dispose() used to wrap StopAsync in an un-awaited Task.Run. App.OnExit returns
+        /// straight into process teardown, so that task never got far enough to put SHUTDOWN
+        /// on the pipe: the worker saw its parent vanish, could not tell a deliberate exit
+        /// from a crash, and stayed up polling hardware for the whole orphan timeout.
+        ///
+        /// The assertion is deliberately made with no waiting or polling after Dispose returns —
+        /// that is the whole property under test.
+        /// </summary>
+        [Fact]
+        public async Task Dispose_DeliversShutdown_BeforeReturning()
+        {
+            var (server, clientStream) = await CreateConnectedTestPipeAsync();
+            using var serverDisposable = server;
+
+            var (client, pipeField, _) = CreateClientWithReflectionAccess();
+            pipeField.SetValue(client, clientStream);
+
+            string? received = null;
+            var serverTask = Task.Run(async () =>
+            {
+                var buffer = new byte[256];
+                var bytesRead = await server.ReadAsync(buffer, 0, buffer.Length);
+                received = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+
+                var reply = Encoding.UTF8.GetBytes("OK");
+                await server.WriteAsync(reply, 0, reply.Length);
+                await server.FlushAsync();
+            });
+
+            await Task.Run(() => client.Dispose());
+
+            received.Should().Be("SHUTDOWN",
+                "Dispose must have delivered the shutdown request before returning — a caller that exits the process immediately afterwards gives a fire-and-forget task no chance to run");
+
+            await serverTask;
+        }
+
+        /// <summary>
+        /// The blocking shutdown must stay bounded: a wedged worker that never answers the pipe
+        /// cannot be allowed to hang the app's exit. Failing to stop it is recoverable (the
+        /// worker's own orphan watchdog still applies); an app that will not close is not.
+        /// </summary>
+        [Fact]
+        public async Task Dispose_ReturnsWithinTheBound_WhenTheWorkerNeverAnswers()
+        {
+            var (server, clientStream) = await CreateConnectedTestPipeAsync();
+            using var serverDisposable = server;
+
+            var (client, pipeField, _) = CreateClientWithReflectionAccess();
+            pipeField.SetValue(client, clientStream);
+
+            // Server never reads or replies — the request times out inside SendRequestAsync.
+            var stopwatch = Stopwatch.StartNew();
+            await Task.Run(() => client.Dispose());
+            stopwatch.Stop();
+
+            stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(15),
+                "the stop sequence is bounded by BlockingStopTimeoutMs and must not wait on an unresponsive worker indefinitely");
+        }
+
+        /// <summary>
+        /// StopAsync resolves the worker by process name because the client usually did not
+        /// launch it — but only if it ever attached to one. A client that never connected must
+        /// not reach out and terminate whatever OmenCore.HardwareWorker happens to be running,
+        /// which on a developer machine is a live worker belonging to the installed app.
+        /// </summary>
+        [Fact]
+        public async Task StopAsync_DoesNotTouchAnyProcess_WhenTheClientNeverAttached()
+        {
+            var log = new List<string>();
+            var client = new HardwareWorkerClient(log.Add);
+
+            var attached = typeof(HardwareWorkerClient)
+                .GetField("_attachedToWorker", BindingFlags.Instance | BindingFlags.NonPublic);
+            attached.Should().NotBeNull();
+            attached!.GetValue(client).Should().Be(false, "a freshly constructed client has not started or attached to a worker");
+
+            await client.StopAsync();
+
+            log.Should().NotContain(line => line.Contains("terminating", StringComparison.OrdinalIgnoreCase),
+                "an unattached client must never terminate a worker process it does not own");
+            log.Should().NotContain(line => line.Contains("Worker PID", StringComparison.Ordinal),
+                "an unattached client must not even resolve a worker process");
         }
     }
 }

--- a/src/OmenCoreApp/App.xaml.cs
+++ b/src/OmenCoreApp/App.xaml.cs
@@ -1071,7 +1071,25 @@ namespace OmenCore
             {
                 Logging.Warn($"[App] OnExit: MainViewModel.Dispose() failed: {ex.Message}");
             }
-            
+
+            // Backstop. The dispose chain above reaches HardwareWorkerClient only through
+            // WmiBiosMonitor's temp-fallback monitor, but the app also starts a worker itself in
+            // TryStartHardwareWorkerBootstrap — so a worker can outlive a chain that was never
+            // built or that threw partway. A worker still alive here has no parent left to
+            // reconnect to; it would keep polling hardware for the whole orphan timeout after the
+            // user quit. The worker only survives a *crash* on purpose, and OnExit is not one.
+            try
+            {
+                if (!HardwareWorkerClient.StopWorkerProcessBlocking(msg => Logging.Info($"[App] OnExit: {msg}")))
+                {
+                    Logging.Warn("[App] OnExit: hardware worker may still be running");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.Warn($"[App] OnExit: hardware worker shutdown failed: {ex.Message}");
+            }
+
             // Release single instance mutex
             if (_singleInstanceMutex != null)
             {

--- a/src/OmenCoreApp/Hardware/HardwareWorkerClient.cs
+++ b/src/OmenCoreApp/Hardware/HardwareWorkerClient.cs
@@ -25,8 +25,15 @@ namespace OmenCore.Hardware
     {
         private const string PipeName = "OmenCore_HardwareWorker";
         private const string WorkerExeName = "OmenCore.HardwareWorker.exe";
+        private const string WorkerProcessName = "OmenCore.HardwareWorker";
         private const int ConnectionTimeoutMs = 5000;  // Increased for slow boot
         private const int RequestTimeoutMs = 2000;
+        // How long the worker gets to unwind its poll loop and release the LHM driver
+        // handles after acknowledging SHUTDOWN, before it is terminated instead.
+        private const int ShutdownGraceMs = 1500;
+        private const int KillWaitMs = 1000;
+        // Outer bound on the whole stop sequence for callers that cannot await it.
+        private const int BlockingStopTimeoutMs = 5000;
         private const int MaxRestartAttempts = 5;
         private const int RestartCooldownMs = 5000;
         private const int WorkerStartupDelayMs = 2000;  // Increased for hardware scan time
@@ -46,7 +53,11 @@ namespace OmenCore.Hardware
         private readonly bool _orphanTimeoutEnabled;
         private readonly int _orphanTimeoutMinutes;
         private bool _ownsWorkerProcess;
-        
+        // Whether this client ever launched or attached to a worker. Gates the by-name lookup
+        // in StopAsync: a client that never connected has no claim on whatever worker happens
+        // to be running.
+        private bool _attachedToWorker;
+
         private HardwareSample _cachedSample = new();
         private DateTime _lastSuccessfulRead = DateTime.MinValue;
         private int _restartAttempts = 0;
@@ -195,7 +206,8 @@ namespace OmenCore.Hardware
                 }
 
                 _ownsWorkerProcess = true;
-                
+                _attachedToWorker = true;
+
                 LogWorker($"Worker started with PID {_workerProcess.Id}", startupCorrelationId);
                 
                 // Wait for worker to initialize pipe server (longer delay for boot scenarios)
@@ -263,7 +275,8 @@ namespace OmenCore.Hardware
                 await RegisterAsParentAsync(correlationId);
 
                 ReleaseOwnedWorkerProcessHandle();
-                
+                _attachedToWorker = true;
+
                 _restartAttempts = 0;
                 return true;
             }
@@ -629,6 +642,147 @@ namespace OmenCore.Hardware
         }
         
         /// <summary>
+        /// Locate the running worker, whether or not this client launched it.
+        ///
+        /// This client usually does *not* own the process: App's startup bootstrap and
+        /// WmiBiosMonitor.TryPrelaunchHardwareWorker both start the worker before any client
+        /// exists, so StartAsync takes the attach-over-the-pipe path and
+        /// TryConnectToExistingWorkerAsync deliberately drops the handle. Without this lookup
+        /// StopAsync can ask the worker to exit but has no way to confirm or enforce it.
+        ///
+        /// Scoped to the current logon session so another signed-in user's worker is never touched.
+        /// </summary>
+        private static Process? FindRunningWorker(Action<string>? logger)
+        {
+            Process[] candidates;
+            int sessionId;
+            try
+            {
+                candidates = Process.GetProcessesByName(WorkerProcessName);
+                using var self = Process.GetCurrentProcess();
+                sessionId = self.SessionId;
+            }
+            catch (Exception ex)
+            {
+                logger?.Invoke($"[Worker] Could not enumerate worker processes: {ex.Message}");
+                return null;
+            }
+
+            Process? match = null;
+            foreach (var candidate in candidates)
+            {
+                var isOurs = false;
+                try
+                {
+                    isOurs = match == null && candidate.SessionId == sessionId;
+                }
+                catch (Exception ex)
+                {
+                    // SessionId is unreadable for processes we cannot open — treat as not ours.
+                    logger?.Invoke($"[Worker] Skipping worker candidate: {ex.Message}");
+                }
+
+                if (isOurs)
+                {
+                    match = candidate;
+                }
+                else
+                {
+                    candidate.Dispose();
+                }
+            }
+
+            return match;
+        }
+
+        /// <summary>
+        /// Confirm the worker is gone, and make it so if it is not.
+        ///
+        /// A SHUTDOWN reply of "OK" only means the request was parsed — the worker still has to
+        /// unwind its poll loop and release the LibreHardwareMonitor driver handles — so the exit
+        /// is verified rather than assumed. Pass <paramref name="owned"/> when the caller holds a
+        /// handle it will dispose itself; otherwise the worker is resolved by name.
+        ///
+        /// Returns true when no worker process remains.
+        /// </summary>
+        private static async Task<bool> StopWorkerProcessAsync(Process? owned, Action<string>? logger)
+        {
+            var worker = owned ?? FindRunningWorker(logger);
+            if (worker == null) return true;
+
+            try
+            {
+                if (!HasExited(worker, logger))
+                {
+                    var pid = worker.Id;
+                    using var cts = new CancellationTokenSource(ShutdownGraceMs);
+                    try
+                    {
+                        await worker.WaitForExitAsync(cts.Token);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        logger?.Invoke($"[Worker] Worker PID {pid} still running {ShutdownGraceMs} ms after SHUTDOWN; terminating");
+                        worker.Kill();
+                        worker.WaitForExit(KillWaitMs);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.Invoke($"[Worker] Error while stopping worker process: {ex.Message}");
+            }
+
+            // Report what is true of the process, not whether the calls above threw. A worker
+            // that exited underneath us and a Kill() that quietly failed both surface as
+            // exceptions, and only one of those is success — so ask the process, not the
+            // control flow. Read before Dispose closes the handle.
+            var stopped = HasExited(worker, logger);
+            if (stopped)
+            {
+                logger?.Invoke("[Worker] Worker process stopped");
+            }
+
+            if (owned == null) worker.Dispose();
+            return stopped;
+        }
+
+        /// <summary>
+        /// Whether the process is actually gone, treating an unanswerable question as "still
+        /// running" so a caller never reports a stop it could not observe.
+        /// </summary>
+        private static bool HasExited(Process process, Action<string>? logger)
+        {
+            try
+            {
+                return process.HasExited;
+            }
+            catch (Exception ex)
+            {
+                logger?.Invoke($"[Worker] Could not read worker process state: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Bounded, blocking stop for shutdown paths that cannot await — notably App.OnExit,
+        /// which runs on the dispatcher thread after the message loop has stopped. Task.Run
+        /// keeps the wait off that SynchronizationContext so it cannot deadlock, and the
+        /// timeout keeps a wedged worker from hanging the app's exit.
+        /// </summary>
+        public static bool StopWorkerProcessBlocking(Action<string>? logger)
+        {
+            var task = Task.Run(() => StopWorkerProcessAsync(null, logger));
+            if (!task.Wait(BlockingStopTimeoutMs))
+            {
+                logger?.Invoke($"[Worker] Worker shutdown did not finish within {BlockingStopTimeoutMs} ms");
+                return false;
+            }
+
+            return task.Result;
+        }
+
+        /// <summary>
         /// Stop the worker process gracefully
         /// </summary>
         public async Task StopAsync()
@@ -637,55 +791,62 @@ namespace OmenCore.Hardware
             {
                 if (_pipeClient?.IsConnected == true)
                 {
-                    await SendRequestAsync("SHUTDOWN");
-                    await Task.Delay(500);
+                    var response = await SendRequestAsync("SHUTDOWN");
+                    _logger?.Invoke($"[Worker] SHUTDOWN sent; worker replied '{response}'");
+                }
+                else
+                {
+                    _logger?.Invoke("[Worker] No pipe connection at shutdown; stopping the worker process directly");
                 }
             }
             catch (Exception ex)
             {
                 _logger?.Invoke($"[Worker] Error sending shutdown command: {ex.Message}");
             }
-            
-            try
-            {
-                if (_workerProcess != null && !_workerProcess.HasExited)
-                {
-                    _workerProcess.Kill();
-                    _workerProcess.WaitForExit(1000);
-                }
 
-                ReleaseOwnedWorkerProcessHandle();
-            }
-            catch (Exception ex)
+            // Only hunt for a worker by name if this client actually attached to one. A client
+            // that never connected has no claim on whatever worker happens to be running.
+            var owned = _ownsWorkerProcess ? _workerProcess : null;
+            if (owned != null || _attachedToWorker)
             {
-                _logger?.Invoke($"[Worker] Error killing worker process: {ex.Message}");
+                await StopWorkerProcessAsync(owned, _logger);
             }
+
+            ReleaseOwnedWorkerProcessHandle();
         }
-        
+
         public void Dispose()
         {
             if (_disposed) return;
             _disposed = true;
-            
+
             try
             {
-                // Fire and forget shutdown with exception handling
-                _ = Task.Run(async () =>
+                // Blocking and bounded, deliberately. This runs from App.OnExit, which returns
+                // straight into process teardown, so the previous fire-and-forget Task.Run never
+                // got far enough to deliver SHUTDOWN: the worker saw its parent vanish, read that
+                // as a crash, and stayed up for the full orphan timeout. Task.Run keeps the wait
+                // off the UI SynchronizationContext so it cannot deadlock.
+                if (!Task.Run(StopAsync).Wait(BlockingStopTimeoutMs))
                 {
-                    try
-                    {
-                        await StopAsync();
-                    }
-                    finally
-                    {
-                        _pipeClient?.Dispose();
-                        _workerProcess?.Dispose();
-                    }
-                });
+                    _logger?.Invoke($"[Worker] Shutdown did not finish within {BlockingStopTimeoutMs} ms; abandoning worker");
+                }
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"[Worker] Dispose error: {ex.Message}");
+                _logger?.Invoke($"[Worker] Dispose error: {ex.Message}");
+            }
+            finally
+            {
+                try
+                {
+                    _pipeClient?.Dispose();
+                    _workerProcess?.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    _logger?.Invoke($"[Worker] Dispose cleanup error: {ex.Message}");
+                }
             }
         }
     }


### PR DESCRIPTION
## What happens now

Quitting OmenCore leaves `OmenCore.HardwareWorker` running for the full five-minute orphan timeout,
still polling hardware every 500 ms – 3 s and still holding the LibreHardwareMonitor driver handles.

Two logs, one graceful exit:

```
app     09:34:40.025  OmenCore shutdown complete
worker  09:34:41.179  Parent process 19396 exited. Worker staying alive for reconnection.
```

## Why — the survival is deliberate, the inability to distinguish it is not

`MonitorParentProcess` deliberately keeps the worker alive when its parent dies, so a restarted app
reconnects without a gap in temperatures, with `OrphanWatchdog` cleaning up if nothing reconnects.
That is the right behaviour for a crash.

The worker separates a crash from a deliberate exit by whether it received `SHUTDOWN`. `SHUTDOWN`
never arrived, so every exit looked like a crash. Two independent reasons, either sufficient:

1. **`HardwareWorkerClient.Dispose` fired and forgot.** It wrapped `StopAsync` in an un-awaited
   `Task.Run`. `App.OnExit` returns straight into process teardown, so that task never got far
   enough to write to the pipe.

2. **`StopAsync` had no fallback.** If the pipe was gone its only other lever was killing
   `_workerProcess` — and that handle is normally **null**. Both
   `App.TryStartHardwareWorkerBootstrap` and `WmiBiosMonitor.TryPrelaunchHardwareWorker` start the
   worker before any client exists, so `StartAsync` takes the attach-over-the-pipe path and
   `TryConnectToExistingWorkerAsync` drops the handle by design. Three launchers, one of which can
   stop what it started, and it usually is not the one that started it.

## The change

- `Dispose` waits on the stop sequence, bounded, and on the thread pool so it cannot deadlock
  against the dispatcher's `SynchronizationContext`.
- `StopAsync` resolves the worker by name when it does not own the handle, and reports whether the
  process is **actually gone** rather than whether the calls threw — a `Kill` that quietly failed
  and a worker that exited underneath us both surface as exceptions, and only one is success.
- The by-name lookup is scoped to the current logon session and gated on this client having attached
  to a worker, so it cannot reach another user's worker or adopt one it has no claim on. Graceful
  `SHUTDOWN` first; termination only after a 1.5 s grace, so the worker still releases its driver
  handles on the normal path.
- `App.OnExit` carries a backstop, because the dispose chain reaches `HardwareWorkerClient` by
  exactly one route (`MainViewModel` → `HardwareMonitoringService` → `WmiBiosMonitor` → its
  temp-fallback monitor) while the app also starts a worker directly.
- The worker logs `SHUTDOWN` receipt. Without it, a requested exit and a vanished parent are
  indistinguishable in the only durable record of either.

## Verified

Measured through the real exit path — `MinimizeToTrayOnClose` false via an isolated
`OMENCORE_CONFIG_DIR`, window closed, both processes polled:

| Build | App gone | Worker gone |
|---|---|---|
| Before | < 5 s | **still alive at 65 s** |
| After  | 4 s   | **2 s — before the app** |

and the handshake that is now visible:

```
worker  10:01:03.036  SHUTDOWN received from client. Worker exiting.
```

The forced-kill fallback only fires against a worker that ignores `SHUTDOWN`, which the real worker
never does, so it was exercised against a decoy process instead: found, grace period, terminated,
exit confirmed.

Three regression tests, using the pipe-injection seam the existing tests in that file already use.
The one that matters asserts the request has **already** been delivered when `Dispose` returns, with
no waiting or polling after the fact — that is the property that was missing.

Full suite: **1005 passed, 0 failed**.

## Noticed, not fixed

`App.OnExit` logs `MainViewModel.Dispose() failed: The CancellationTokenSource has been disposed` on
every graceful exit, before and after this change — services are disposed once on window close and
again in `OnExit`. Harmless today only because the worker stop happens to run before the throw. It is
part of why this PR carries the `OnExit` backstop rather than trusting the dispose chain, but the
double-dispose itself is left alone.

Found on an OMEN MAX 16-ak0xxx (8D87, BIOS F.07, EC 40.38); the mechanism is not board-specific.
Off `main`, independent of #166, lands in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
