### PR TITLE
Fix a shutdown race over the GPU engine performance counters

### DIFF
--- a/src/OmenCoreApp/Hardware/WmiBiosMonitor.cs
+++ b/src/OmenCoreApp/Hardware/WmiBiosMonitor.cs
@@ -232,6 +232,14 @@ namespace OmenCore.Hardware
 
         // Windows GPU engine counters fallback (self-reliant, no worker dependency)
         private readonly Dictionary<string, PerformanceCounter> _gpuEngineCounters = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Guards <see cref="_gpuEngineCounters"/>. Two threads reach it: the monitoring path, which
+        /// adds and removes counters as GPU engine instances come and go, and Dispose, which runs on
+        /// whatever thread tears the app down. Dispose does not hold <c>_updateGate</c> — it disposes
+        /// it — so the dictionary needs a lock of its own.
+        /// </summary>
+        private readonly object _gpuEngineCounterSync = new();
         private bool _gpuEngineCountersPrimed;
         private DateTime _lastGpuEngineCounterRefreshUtc = DateTime.MinValue;
         private static readonly TimeSpan GpuEngineCounterRefreshInterval = TimeSpan.FromSeconds(20);
@@ -1747,16 +1755,27 @@ namespace OmenCore.Hardware
             try
             {
                 RefreshGpuEngineCountersIfNeeded();
-                if (_gpuEngineCounters.Count == 0)
+
+                // Snapshot rather than enumerate. NextValue() below is a counter read that can take
+                // milliseconds per instance, and holding the lock across all of them would put Dispose
+                // behind a poll it is trying to stop. A counter disposed out from under the snapshot
+                // throws, which the existing catch already turns into a zero reading.
+                KeyValuePair<string, PerformanceCounter>[] counters;
+                lock (_gpuEngineCounterSync)
+                {
+                    counters = _gpuEngineCounters.ToArray();
+                }
+
+                if (counters.Length == 0)
                 {
                     return 0;
                 }
 
                 if (!_gpuEngineCountersPrimed)
                 {
-                    foreach (var counter in _gpuEngineCounters.Values)
+                    foreach (var counter in counters)
                     {
-                        _ = counter.NextValue();
+                        _ = counter.Value.NextValue();
                     }
 
                     _gpuEngineCountersPrimed = true;
@@ -1765,7 +1784,7 @@ namespace OmenCore.Hardware
 
                 double totalLoad = 0;
                 double preferredEnginePeak = 0;
-                foreach (var kvp in _gpuEngineCounters)
+                foreach (var kvp in counters)
                 {
                     var instanceName = kvp.Key;
                     var value = kvp.Value.NextValue();
@@ -1793,9 +1812,14 @@ namespace OmenCore.Hardware
 
         private void RefreshGpuEngineCountersIfNeeded()
         {
-            if (DateTime.UtcNow - _lastGpuEngineCounterRefreshUtc < GpuEngineCounterRefreshInterval && _gpuEngineCounters.Count > 0)
+            if (_disposed) return;
+
+            lock (_gpuEngineCounterSync)
             {
-                return;
+                if (DateTime.UtcNow - _lastGpuEngineCounterRefreshUtc < GpuEngineCounterRefreshInterval && _gpuEngineCounters.Count > 0)
+                {
+                    return;
+                }
             }
 
             var category = new PerformanceCounterCategory("GPU Engine");
@@ -1810,25 +1834,34 @@ namespace OmenCore.Hardware
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
-            var staleInstances = _gpuEngineCounters.Keys.Except(instanceNames, StringComparer.OrdinalIgnoreCase).ToList();
-            foreach (var stale in staleInstances)
+            // Enumerating the category is the slow part and needs no lock; only the mutation does.
+            lock (_gpuEngineCounterSync)
             {
-                _gpuEngineCounters[stale].Dispose();
-                _gpuEngineCounters.Remove(stale);
-            }
+                // Re-checked inside the lock: Dispose may have run while the category was being
+                // enumerated, and repopulating the dictionary afterwards would leak every counter
+                // created here, since nothing disposes it a second time.
+                if (_disposed) return;
 
-            foreach (var instanceName in instanceNames)
-            {
-                if (_gpuEngineCounters.ContainsKey(instanceName))
+                var staleInstances = _gpuEngineCounters.Keys.Except(instanceNames, StringComparer.OrdinalIgnoreCase).ToList();
+                foreach (var stale in staleInstances)
                 {
-                    continue;
+                    _gpuEngineCounters[stale].Dispose();
+                    _gpuEngineCounters.Remove(stale);
                 }
 
-                _gpuEngineCounters[instanceName] = new PerformanceCounter("GPU Engine", "Utilization Percentage", instanceName, true);
-                _gpuEngineCountersPrimed = false;
-            }
+                foreach (var instanceName in instanceNames)
+                {
+                    if (_gpuEngineCounters.ContainsKey(instanceName))
+                    {
+                        continue;
+                    }
 
-            _lastGpuEngineCounterRefreshUtc = DateTime.UtcNow;
+                    _gpuEngineCounters[instanceName] = new PerformanceCounter("GPU Engine", "Utilization Percentage", instanceName, true);
+                    _gpuEngineCountersPrimed = false;
+                }
+
+                _lastGpuEngineCounterRefreshUtc = DateTime.UtcNow;
+            }
         }
 
         private void TryApplyPowerFallback()
@@ -2542,11 +2575,22 @@ namespace OmenCore.Hardware
             _wmiBios.Dispose();
             _cpuPerfCounter?.Dispose();
             _tempFallbackMonitor?.Dispose();
-            foreach (var counter in _gpuEngineCounters.Values)
+
+            // Taken out of the dictionary under the lock, then disposed outside it. Enumerating the
+            // live collection is what threw: the monitoring path adds and removes counters as GPU
+            // engine instances appear, and it does not stop merely because Dispose has started.
+            PerformanceCounter[] counters;
+            lock (_gpuEngineCounterSync)
             {
-                counter.Dispose();
+                counters = _gpuEngineCounters.Values.ToArray();
+                _gpuEngineCounters.Clear();
             }
-            _gpuEngineCounters.Clear();
+
+            foreach (var counter in counters)
+            {
+                try { counter.Dispose(); }
+                catch (Exception) { /* One counter failing to close must not strand the rest. */ }
+            }
         }
     }
 }


### PR DESCRIPTION
﻿`WmiBiosMonitor.Dispose()` enumerates `_gpuEngineCounters.Values` while the monitoring path is still
adding to and removing from that dictionary:

```
System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at System.Collections.Generic.Dictionary`2.ValueCollection.Enumerator.MoveNext()
   at OmenCore.Hardware.WmiBiosMonitor.Dispose()
   at OmenCore.Services.HardwareMonitoringService.Dispose()
   at OmenCore.ViewModels.MainViewModel.Dispose()
```

`RefreshGpuEngineCountersIfNeeded` rebuilds the dictionary whenever GPU engine instances appear or
disappear, which on a hybrid laptop is every time the dGPU wakes or sleeps. `Dispose` does not hold
`_updateGate` — it disposes it — so nothing was serialising the two.

It shows up as an intermittent test failure when a view-model test disposes a monitor whose poll is
mid-refresh, and in the field as a noisy shutdown. Being a race, it passes in isolation and fails in
a full run, which is the shape that tends to get attributed to whichever change landed most
recently.

### The fix

The dictionary gets a lock of its own. The slow work stays outside it deliberately:

- enumerating `PerformanceCounterCategory` — a WMI-ish call that can take a while
- `NextValue()` on each counter — milliseconds per instance, in the poll path
- disposing the counters

Only the mutations and the snapshots are inside the lock, so `Dispose` is never queued behind a poll
it is trying to stop. `Dispose` takes the counters out under the lock and disposes them after
releasing it, and wraps each in its own try so one counter failing to close cannot strand the rest.

`RefreshGpuEngineCountersIfNeeded` re-checks `_disposed` **inside** the lock, because the category
enumeration happens outside it: without the second check, a refresh that started before `Dispose`
could repopulate the dictionary afterwards and leak every counter it created, since nothing disposes
them a second time.

### Testing

Full suite green. Found while running the suite repeatedly against unrelated work — it is not
reproducible on demand, so there is no regression test that would be honest about what it proves.
The change is a lock around a dictionary that two threads reach, and the argument for it is the
stack trace above.
